### PR TITLE
fixing `validate()` function if both upper and lower check are given

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -637,12 +637,11 @@ def _check_rows(rows, check, in_range=True, return_test='any'):
     for (bd, op) in [('up', up_op), ('lo', lo_op)]:
         if bd in check:
             check_idx.append(set(rows.index[op(check[bd])]))
-    check_idx = set.intersection(*check_idx)
 
     if return_test is 'any':
-        ret = where_idx & check_idx
+        ret = where_idx & set.union(*check_idx)
     elif return_test == 'all':
-        ret = where_idx if where_idx == check_idx else set()
+        ret = where_idx if where_idx == set.intersection(*check_idx) else set()
     else:
         raise ValueError('Unknown return test: {}'.format(return_test))
     return ret

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,7 +149,7 @@ def test_validate_both(meta_df):
     obs = meta_df.validate({'Primary Energy': {'lo': 2.0, 'up': 6.5}},
                            exclude=False)
     assert len(obs) == 2
-    assert obs['year'].values[0] == 2010
+    assert list(obs['year'].values) == [2005, 2010]
 
 
 def test_validate_year(meta_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -145,6 +145,13 @@ def test_validate_lo(meta_df):
     assert obs['year'].values[0] == 2005
 
 
+def test_validate_both(meta_df):
+    obs = meta_df.validate({'Primary Energy': {'lo': 2.0, 'up': 6.5}},
+                           exclude=False)
+    assert len(obs) == 2
+    assert obs['year'].values[0] == 2010
+
+
 def test_validate_year(meta_df):
     obs = meta_df.validate({'Primary Energy': {'up': 5.0, 'year': 2005}},
                            exclude=False)


### PR DESCRIPTION
This PR fixes an issue with the `validate()` function that does not correctly fail when checking both upper and lower bounds. Unit test to illustrate the failing test added.