### PR TITLE
fixes for `pandas.combine_first()`, empty filtered IamDataFrames, general index for `metadata()`

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -419,6 +419,9 @@ class IamDataFrame(object):
             pd.unique(list(zip(ret.data['model'], ret.data['scenario']))),
             names=('model', 'scenario')
         )
+        if len(idx) == 0:
+            logger().warning('Filtered IamDataFrame is empty!')
+
         ret.meta = ret.meta.loc[idx]
         if not inplace:
             return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -263,7 +263,14 @@ class IamDataFrame(object):
             category column name (if not given by data series name)
         """
         if isinstance(meta, pd.Series) and \
-                meta.index.names == ['model', 'scenario']:
+                meta.index.names[0:2] == ['model', 'scenario']:
+            # reduce index dimentsions to model-scenario if necessary
+            if len(meta.index.names) > 2:
+                drop = list(range(2, len(meta.index.names)))
+                meta.index = meta.index.droplevel(drop)
+                if meta.index.duplicated():
+                    raise ValueError("non-unique ['model', 'scenario'] index!")
+            # check if trying to add model-scenario index not existing in self
             diff = meta.index.difference(self.meta.index)
             if not diff.empty:
                 error = "adding metadata for non-existing scenarios '{}'!"

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -268,7 +268,7 @@ class IamDataFrame(object):
             if len(meta.index.names) > 2:
                 drop = list(range(2, len(meta.index.names)))
                 meta.index = meta.index.droplevel(drop)
-                if meta.index.duplicated():
+                if meta.index.duplicated().any():
                     raise ValueError("non-unique ['model', 'scenario'] index!")
             # check if trying to add model-scenario index not existing in self
             diff = meta.index.difference(self.meta.index)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -264,7 +264,7 @@ class IamDataFrame(object):
         """
         if isinstance(meta, pd.Series) and \
                 set(['model', 'scenario']).issubset(meta.index.names):
-            meta.name = meta.name or name
+            meta.name = name or meta.name
             # reduce index dimentsions to model-scenario only
             meta = (meta
                     .reset_index()

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -265,7 +265,7 @@ class IamDataFrame(object):
         if isinstance(meta, pd.Series) and \
                 set(['model', 'scenario']).issubset(meta.index.names):
             meta.name = name or meta.name
-            # reduce index dimentsions to model-scenario only
+            # reduce index dimensions to model-scenario only
             meta = (meta
                     .reset_index()
                     .loc[:, ['model', 'scenario', meta.name]]

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -729,9 +729,10 @@ def validate(df, *args, **kwargs):
     """
     filters = kwargs.pop('filters', {})
     fdf = df.filter(filters)
-    vdf = fdf.validate(*args, **kwargs)
-    df.meta['exclude'] |= fdf.meta['exclude']  # update if any excluded
-    return vdf
+    if len(fdf.data) > 0:
+        vdf = fdf.validate(*args, **kwargs)
+        df.meta['exclude'] |= fdf.meta['exclude']  # update if any excluded
+        return vdf
 
 
 def require_variable(df, *args, **kwargs):
@@ -744,12 +745,12 @@ def require_variable(df, *args, **kwargs):
     filters: dict, optional
         filter by data & metadata columns, see function 'filter()' for details
     """
-
     filters = kwargs.pop('filters', {})
     fdf = df.filter(filters)
-    vdf = fdf.require_variable(*args, **kwargs)
-    df.meta['exclude'] |= fdf.meta['exclude']  # update if any excluded
-    return vdf
+    if len(fdf.data) > 0:
+        vdf = fdf.require_variable(*args, **kwargs)
+        df.meta['exclude'] |= fdf.meta['exclude']  # update if any excluded
+        return vdf
 
 
 def categorize(df, *args, **kwargs):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -365,7 +365,7 @@ class IamDataFrame(object):
             self.meta.loc[idx, 'exclude'] = True
             msg += ', marked as `exclude=True` in metadata'
 
-        logger().info(msg.format(variable, i, '' if i == 1 else 's'))
+        logger().info(msg.format(i, '' if i == 1 else 's', variable))
         return pd.DataFrame(index=idx).reset_index()
 
     def validate(self, criteria={}, exclude=False):
@@ -628,7 +628,7 @@ class IamDataFrame(object):
 
 
 def _meta_idx(data):
-    return data[META_IDX].set_index(META_IDX).index
+    return data[META_IDX].drop_duplicates().set_index(META_IDX).index
 
 
 def _apply_filters(data, meta, filters):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -360,8 +360,8 @@ class IamDataFrame(object):
         keep = _apply_filters(self.data, self.meta, criteria)
         idx = self.meta.index.difference(_meta_idx(self.data[keep]))
 
-        i = len(idx)
-        if i == 0:
+        n = len(idx)
+        if n == 0:
             logger().info('All scenarios have the required variable `{}`'
                           .format(variable))
             return
@@ -372,7 +372,7 @@ class IamDataFrame(object):
             self.meta.loc[idx, 'exclude'] = True
             msg += ', marked as `exclude=True` in metadata'
 
-        logger().info(msg.format(i, '' if i == 1 else 's', variable))
+        logger().info(msg.format(n, '' if n == 1 else 's', variable))
         return pd.DataFrame(index=idx).reset_index()
 
     def validate(self, criteria={}, exclude=False):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -353,17 +353,19 @@ class IamDataFrame(object):
         keep = _apply_filters(self.data, self.meta, criteria)
         idx = self.meta.index.difference(_meta_idx(self.data[keep]))
 
-        if len(idx) == 0:
-            logger().info('All scenarios have the required variable')
+        i = len(idx)
+        if i == 0:
+            logger().info('All scenarios have the required variable `{}`'
+                          .format(variable))
             return
 
-        msg = '{} scenario{} to not include required variables'
+        msg = '{} scenario{} to not include required variable {}'
 
         if exclude:
             self.meta.loc[idx, 'exclude'] = True
             msg += ', marked as `exclude=True` in metadata'
 
-        logger().info(msg.format(len(idx), '' if len(idx) == 1 else 's'))
+        logger().info(msg.format(variable, i, '' if i == 1 else 's'))
         return pd.DataFrame(index=idx).reset_index()
 
     def validate(self, criteria={}, exclude=False):
@@ -388,7 +390,8 @@ class IamDataFrame(object):
             logger().info(msg.format(len(df), len(self.data)))
 
             if exclude and len(idx) > 0:
-                logger().info('Non-valid scenarios will be excluded')
+                logger().info('{} non-valid scenarios will be excluded'
+                              .format(len(idx)))
 
             return df
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -270,6 +270,8 @@ class IamDataFrame(object):
                 raise ValueError(error.format(diff))
             meta = meta.to_frame(name or meta.name)
             self.meta = meta.combine_first(self.meta)
+            #  quickfix for pandas.combine_first(), issue #7509
+            self.meta['exclude'] = self.meta['exclude'].astype('bool')
             return  # EXIT FUNCTION
 
         if isinstance(meta, pd.Series):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -338,6 +338,12 @@ def test_add_metadata_as_int(meta_df):
     pd.testing.assert_series_equal(obs, exp)
 
 
+def test_filter_by_metadata_str(meta_df):
+    meta_df.metadata(['testing', 'testing2'], name='category')
+    obs = meta_df.filter({'category': 'testing'})
+    assert obs['scenario'].unique() == 'a_scenario'
+    
+
 def test_filter_by_metadata_bool(meta_df):
     meta_df.metadata([True, False], name='exclude')
     obs = meta_df.filter({'exclude': True})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -276,9 +276,9 @@ def test_interpolate(test_df):
 
 
 def test_add_metadata_as_named_series(meta_df):
-    idx = pd.MultiIndex(levels=[['a_model'], ['a_scenario'], ['a_region']],
+    idx = pd.MultiIndex(levels=[['a_scenario'], ['a_model'], ['a_region']],
                         labels=[[0], [0], [0]],
-                        names=['model', 'scenario', 'region'])
+                        names=['scenario', 'model', 'region'])
 
     s = pd.Series(data=[0.3], index=idx)
     s.name = 'meta_values'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -277,8 +277,7 @@ def test_add_metadata_as_named_series(meta_df):
     s.name = 'meta_values'
     meta_df.metadata(s)
 
-    idx = pd.MultiIndex(levels=[['a_model'],
-                                ['a_scenario', 'a_scenario2']],
+    idx = pd.MultiIndex(levels=[['a_model'], ['a_scenario', 'a_scenario2']],
                         labels=[[0, 0], [0, 1]], names=['model', 'scenario'])
     exp = pd.Series(data=[0.3, np.nan], index=idx)
     exp.name = 'meta_values'
@@ -287,7 +286,15 @@ def test_add_metadata_as_named_series(meta_df):
     pd.testing.assert_series_equal(obs, exp)
 
 
-def test_add_metadata_index_fail(meta_df):
+def test_add_metadata_non_unique_index_fail(meta_df):
+    idx = pd.MultiIndex(levels=[['a_model'], ['a_scenario'], ['a', 'b']],
+                        labels=[[0, 0], [0, 0], [0, 1]],
+                        names=['model', 'scenario', 'region'])
+    s = pd.Series([0.4, 0.5], idx)
+    pytest.raises(ValueError, meta_df.metadata, s)
+
+
+def test_add_metadata_non_existing_index_fail(meta_df):
     idx = pd.MultiIndex(levels=[['a_model', 'fail_model'],
                                 ['a_scenario', 'fail_scenario']],
                         labels=[[0, 1], [0, 1]], names=['model', 'scenario'])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,8 +269,9 @@ def test_interpolate(test_df):
 
 
 def test_add_metadata_as_named_series(meta_df):
-    idx = pd.MultiIndex(levels=[['a_model'], ['a_scenario']],
-                        labels=[[0], [0]], names=['model', 'scenario'])
+    idx = pd.MultiIndex(levels=[['a_model'], ['a_scenario'], ['a_region']],
+                        labels=[[0], [0], [0]],
+                        names=['model', 'scenario', 'region'])
 
     s = pd.Series(data=[0.3], index=idx)
     s.name = 'meta_values'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,8 @@ from numpy import testing as npt
 
 from pyam import IamDataFrame, plotting, validate, categorize, \
     require_variable
+from pyam.core import _meta_idx
+
 
 from testing_utils import here, meta_df, test_df, reg_df, TEST_DATA_DIR
 
@@ -110,6 +112,11 @@ def test_timeseries(test_df):
 def test_read_pandas():
     ia = IamDataFrame(os.path.join(TEST_DATA_DIR, 'testing_data_2.csv'))
     assert list(ia['variable'].unique()) == ['Primary Energy']
+
+
+def test_meta_idx(meta_df):
+    # assert that the `drop_duplicates()` in `_meta_idx()` returns right length
+    assert len(_meta_idx(meta_df.data)) == 2
 
 
 def test_require_variable(meta_df):


### PR DESCRIPTION
this PR brings in fixes for a few minor but annoying issues:
 - `pd.combine_first()` drops the dtype setting of the `meta['exlcude']` column, causing `|=` to fail
 - `filter()` shows a warning, if an empty IamDataFrame is returned
 - the  top-level functions `validate()` and `require_variable()` show the empty-IamDataFrame warning instead of performing a meaningless comparison
 - `metadata()` now accepts series with MultiIndex `['model', 'scenario', ...]` - this means that the output of the `timeseries()` function can be directly used as input for `metadata()` or with `apply()`. A unit test was adapted to illustrate/check the new behaviour. A ValueError is raised if the reduced MultiIndex has duplicates.
 - drop duplicates in `_meta_idx()` to yield correct counts in error messages

Some logger messages have also been updated and harmonized...