### PR TITLE
change default behaviour of legend-display in `line_plot()`

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -336,7 +336,7 @@ class IamDataFrame(object):
             logger().info("No scenarios satisfy the criteria")
         else:
             self.meta.loc[idx, name] = value
-            msg = "{} scenario{} categorized as {}: '{}'"
+            msg = '{} scenario{} categorized as `{}: {}`'
             logger().info(msg.format(len(idx), '' if len(idx) == 1 else 's',
                                      name, value))
 
@@ -369,13 +369,14 @@ class IamDataFrame(object):
                           .format(variable))
             return
 
-        msg = '{} scenario{} to not include required variable {}'
+        msg = '{} scenario does not include required variable `{}`' if n == 1 \
+            else '{} scenarios do not include required variable `{}`'
 
         if exclude:
             self.meta.loc[idx, 'exclude'] = True
-            msg += ', marked as `exclude=True` in metadata'
+            msg += ', marked as `exclude: True` in metadata'
 
-        logger().info(msg.format(n, '' if n == 1 else 's', variable))
+        logger().info(msg.format(n, variable))
         return pd.DataFrame(index=idx).reset_index()
 
     def validate(self, criteria={}, exclude=False):
@@ -400,8 +401,8 @@ class IamDataFrame(object):
             logger().info(msg.format(len(df), len(self.data)))
 
             if exclude and len(idx) > 0:
-                logger().info('{} non-valid scenarios will be excluded'
-                              .format(len(idx)))
+                logger().info('{} non-valid scenario{} will be excluded'
+                              .format(len(idx), '' if len(idx) == 1 else 's'))
 
             return df
 

--- a/pyam/plotting.py
+++ b/pyam/plotting.py
@@ -453,7 +453,7 @@ def bar_plot(df, x='year', y='value', bars='variable',
     return ax
 
 
-def line_plot(df, x='year', y='value', ax=None, legend=True, title=True,
+def line_plot(df, x='year', y='value', ax=None, legend=None, title=True,
               color=None, marker=None, linestyle=None, cmap=None,
               **kwargs):
     """Plot data as lines with or without markers.
@@ -470,8 +470,8 @@ def line_plot(df, x='year', y='value', ax=None, legend=True, title=True,
         default: value
     ax : matplotlib.Axes, optional
     legend : bool, optional
-        Include a legend
-        default: False
+        Include a legend (`None` displays legend only if less than 13 entries)
+        default: None
     title : bool or string, optional
         Display a default or custom title.
     color : string, optional
@@ -543,7 +543,7 @@ def line_plot(df, x='year', y='value', ax=None, legend=True, title=True,
         labels = sorted(list(set(tuple(legend_data))))
         idxs = [legend_data.index(d) for d in labels]
         handles = [handles[i] for i in idxs]
-    if legend:
+    if legend is None and len(labels) < 13 or legend is True:
         ax.legend(handles, labels)
 
     # add default labels if possible


### PR DESCRIPTION
This PR changes the default behaviour of the `line_plot()` legend display - currently, the default is to show the legend even with hundreds of lines, which makes the plot small and hard to read.

Suggestion for new `legend` args options:
 - `None` (default), which displays the legend if less than 13 legend entries are shown
 - `boolean` with behaviour as currently implemented