### PR TITLE
check aggregate

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -475,7 +475,7 @@ class IamDataFrame(object):
             return ret
 
     def check_aggregate(self, var_total, var_sector=None, units=None,
-                        exclude=True, threshold=0.1, multiplier=1):
+                        exclude=False, threshold=0.1, multiplier=1):
         """Check whether the timeseries values match the aggregation
         of sub-categories
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -425,8 +425,7 @@ class IamDataFrame(object):
             logger().info(msg.format(len(df), len(self.data)))
 
             if exclude_on_fail and len(idx) > 0:
-                logger().info('{} non-valid scenario{} will be excluded'
-                              .format(len(idx), '' if len(idx) == 1 else 's'))
+                self._exclude(df)
 
             return df
 
@@ -508,13 +507,16 @@ class IamDataFrame(object):
             logger().info(msg.format(len(diff), n))
 
             if exclude:
-                idx = _meta_idx(diff.reset_index())
-                self.meta.loc[idx, 'exclude'] = True
-
-                logger().info('{} non-valid scenario{} will be excluded'
-                              .format(len(idx), '' if len(idx) == 1 else 's'))
+                self._exclude(diff.reset_index())
 
             return diff.unstack().rename_axis(None, axis=1)
+
+    def _exclude(self, df):
+        idx = _meta_idx(df)
+        self.meta.loc[idx, 'exclude'] = True
+
+        logger().info('{} non-valid scenario{} will be excluded'
+                      .format(len(idx), '' if len(idx) == 1 else 's'))
 
     def filter(self, filters=None, keep=True, inplace=False, **kwargs):
         """Return a filtered IamDataFrame (i.e., a subset of current data)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -417,16 +417,12 @@ class IamDataFrame(object):
         """
         df = _apply_criteria(self.data, criteria, in_range=False)
 
-        if exclude_on_fail:
-            idx = _meta_idx(df)
-            self.meta.loc[idx, 'exclude'] = True
-
         if not df.empty:
             msg = '{} of {} data points to not satisfy the criteria'
             logger().info(msg.format(len(df), len(self.data)))
 
-            if exclude_on_fail and len(idx) > 0:
-                self._exclude(df)
+            if exclude_on_fail and len(df) > 0:
+                self._exclude_on_fail(df)
 
             return df
 
@@ -512,9 +508,9 @@ class IamDataFrame(object):
 
             return diff.unstack().rename_axis(None, axis=1)
 
-    def _exclude(self, df):
+    def _exclude_on_fail(self, df):
         """Assign a selection of scenarios as `exclude: True` in meta"""
-        idx = _meta_idx(df)
+        idx = df if isinstance(df, pd.MultiIndex) else _meta_idx(df)
         self.meta.loc[idx, 'exclude'] = True
         logger().info('{} non-valid scenario{} will be excluded'
                       .format(len(idx), '' if len(idx) == 1 else 's'))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -29,6 +29,7 @@ from pyam.utils import (
     isstr,
     islistable,
     META_IDX,
+    YEAR_IDX,
     IAMC_IDX,
     SORT_IDX,
     LONG_IDX,
@@ -512,9 +513,9 @@ class IamDataFrame(object):
             return diff.unstack().rename_axis(None, axis=1)
 
     def _exclude(self, df):
+        """Assign a selection of scenarios as `exclude: True` in meta"""
         idx = _meta_idx(df)
         self.meta.loc[idx, 'exclude'] = True
-
         logger().info('{} non-valid scenario{} will be excluded'
                       .format(len(idx), '' if len(idx) == 1 else 's'))
 
@@ -788,7 +789,7 @@ def _aggregate_by_variables(df, variables, units=None):
         units = [units] if isstr(units) else units
         df = df[df.unit.isin(units)]
 
-    return df.groupby(['model', 'scenario', 'region', 'year']).sum()['value']
+    return df.groupby(YEAR_IDX).sum()['value']
 
 
 def _apply_filters(data, meta, filters):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -886,7 +886,8 @@ def validate(df, criteria={}, exclude_on_fail=False, **kwargs):
     Parameters
     ----------
     df: IamDataFrame instance
-    args and kwargs: see IamDataFrame.validate() and .filter() for details
+    args: see `IamDataFrame.validate()` for details
+    kwargs: passed to `df.filter()`
     """
     fdf = df.filter(**kwargs)
     if len(fdf.data) > 0:
@@ -902,7 +903,8 @@ def require_variable(df, variable, unit=None, year=None, exclude_on_fail=False,
     Parameters
     ----------
     df: IamDataFrame instance
-    args and kwargs: see IamDataFrame.validate() and .filter() for details
+    args: see `IamDataFrame.require_variable()` for details
+    kwargs: passed to `df.filter()`
     """
     fdf = df.filter(**kwargs)
     if len(fdf.data) > 0:
@@ -920,7 +922,8 @@ def categorize(df, name, value, criteria,
     Parameters
     ----------
     df: IamDataFrame instance
-    args and kwargs: see IamDataFrame.categorize()  and .filter() for details
+    args: see `IamDataFrame.categorize()` for details
+    kwargs: passed to `df.filter()`
     """
     fdf = df.filter(**kwargs)
     fdf.categorize(name=name, value=value, criteria=criteria, color=color,
@@ -933,21 +936,21 @@ def categorize(df, name, value, criteria,
         df.meta[name] = fdf.meta[name]
 
 
-def check_aggregate(df, *args, **kwargs):
+def check_aggregate(df, variable, components=None, units=None,
+                    exclude_on_fail=False, multiplier=1, **kwargs):
     """Check whether the timeseries values match the aggregation
     of sub-categories
 
     Parameters
     ----------
     df: IamDataFrame instance
-    args and kwargs: see IamDataFrame.check_aggregate() for details
-    filters: dict, optional
-        filter by data & metadata columns, see function 'filter()' for details,
-        filtering by 'variable'/'year' is replaced by arguments of 'criteria'
+    args: see IamDataFrame.check_aggregate() for details
+    kwargs: passed to `df.filter()`
     """
-    filters = kwargs.pop('filters', {})
-    fdf = df.filter(filters)
+    fdf = df.filter(**kwargs)
     if len(fdf.data) > 0:
-        vdf = fdf.check_aggregate(*args, **kwargs)
+        vdf = fdf.check_aggregate(variable=variable, components=components,
+                                  units=units, exclude_on_fail=exclude_on_fail,
+                                  multiplier=multiplier)
         df.meta['exclude'] |= fdf.meta['exclude']  # update if any excluded
         return vdf

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -28,6 +28,7 @@ from pyam.logger import logger
 
 # common indicies
 META_IDX = ['model', 'scenario']
+YEAR_IDX = ['model', 'scenario', 'region', 'year']
 IAMC_IDX = ['model', 'scenario', 'region', 'variable', 'unit']
 SORT_IDX = ['model', 'scenario', 'variable', 'year', 'region']
 LONG_IDX = IAMC_IDX + ['year']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -226,8 +226,7 @@ def test_validate_top_level(meta_df):
 
 
 def test_check_aggregate_fail(meta_df):
-    obs = meta_df.check_aggregate('Primary Energy', exclude=True)
-    print(obs)
+    obs = meta_df.check_aggregate('Primary Energy', exclude_on_fail=True)
     assert len(obs.columns) == 2
     assert obs.index.get_values()[0] == ('a_model', 'a_scenario', 'World')
 
@@ -238,16 +237,15 @@ def test_check_aggregate_pass(meta_df):
                        'region': 'World', 'variable': 'Primary Energy|Gas',
                        'unit': 'EJ/y', 'year': [2005, 2010], 'value': [.5, 3]})
     meta_df.data = meta_df.data.append(df, ignore_index=True)
-    obs = meta_df.check_aggregate('Primary Energy')
+    obs = meta_df.filter(scenario='a_scenario').check_aggregate('Primary Energy')
     assert obs is None
 
 
 def test_check_aggregate_top_level(meta_df):
-    obs = check_aggregate(meta_df, filters={'year': 2005},
-                          var_total='Primary Energy', threshold=0.1)
+    obs = check_aggregate(meta_df, variable='Primary Energy', year=2005)
     assert len(obs.columns) == 1
     assert obs.index.get_values()[0] == ('a_model', 'a_scenario', 'World')
-    
+
 
 def test_category_none(meta_df):
     meta_df.categorize('category', 'Testing', {'Primary Energy': {'up': 0.8}})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -226,7 +226,7 @@ def test_validate_top_level(meta_df):
 
 
 def test_check_aggregate_fail(meta_df):
-    obs = meta_df.check_aggregate('Primary Energy')
+    obs = meta_df.check_aggregate('Primary Energy', exclude=True)
     print(obs)
     assert len(obs.columns) == 2
     assert obs.index.get_values()[0] == ('a_model', 'a_scenario', 'World')


### PR DESCRIPTION
This PR adds a function to check whether the sub-categories of a timeseries (e.g., `foo|bar1`, `foo|bar2`) match the values of the variable of the level above (e.g., `foo`). This helps to identify reporting errors and missing entries.