### PR TITLE
add a `filter_by_meta() ` function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 
 # Next Release
 
-- (#66)[https://github.com/IAMconsortium/pyam/pull/66] Fixes a bug in the `interpolate()` function ( duplication of data points if already defined)
+- (#66)[https://github.com/IAMconsortium/pyam/pull/66] Fixes a bug in the `interpolate()` function (duplication of data points if already defined)
+- (#65)[https://github.com/IAMconsortium/pyam/pull/65] Add a `filter_by_meta()` function to filter/join a pd.DataFrame with an IamDataFrame.meta table

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -977,8 +977,6 @@ def filter_by_meta(data, df, join_meta=False, **kwargs):
         by the given arguments (using `utils.pattern_match()`) and `col=None`
         joins the column without filtering
     """
-    print(data.columns)
-    print(META_IDX in list(data.columns))
     if not set(META_IDX).issubset(data.index.names + list(data.columns)):
         raise ValueError('missing required index dimensions or columns!')
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -977,8 +977,9 @@ def filter_by_meta(data, df, join_meta=False, **kwargs):
         by the given arguments (using `utils.pattern_match()`) and `col=None`
         joins the column without filtering
     """
-    if not set(META_IDX).issubset(data.index.names) \
-            and META_IDX not in data.columns:
+    print(data.columns)
+    print(META_IDX in list(data.columns))
+    if not set(META_IDX).issubset(data.index.names + list(data.columns)):
         raise ValueError('missing required index dimensions or columns!')
 
     meta = df.meta[list(kwargs)].copy()

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -975,7 +975,11 @@ def filter_by_meta(data, df, **kwargs):
         by the given arguments (using `utils.pattern_match()`) and `col=None`
         joins the column without filtering
     """
-    data = data.copy().join(df.meta[list(kwargs.keys())])
+    data = data.copy()
+    idx = data.index.copy()
+    data.index = data.index.droplevel(list(set(idx.names) - set(META_IDX)))
+    data = data.join(df.meta[list(kwargs.keys())])
+    data.index = idx
 
     # filter by joined columns
     keep = np.array([True] * len(data))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -958,3 +958,29 @@ def check_aggregate(df, variable, components=None, units=None,
                                   multiplier=multiplier)
         df.meta['exclude'] |= fdf.meta['exclude']  # update if any excluded
         return vdf
+
+
+def filter_by_meta(data, df, **kwargs):
+    """Add columns from IamDataFrame.meta table to a pd.DataFrame and apply
+    filters (optional)
+
+    Parameters
+    ----------
+    data: pd.DataFrame instance, index must include `['model', 'scenario']`
+        the DataFrame to which meta columns are to be joined
+    df: IamDataFrame instance
+        the IamDataFrame from which meta columns are joined
+    kwargs:
+        meta columns to be joined, where `col=...` applies filters
+        by the given arguments (using `utils.pattern_match()`) and `col=None`
+        joins the column without filtering
+    """
+    data = data.copy().join(df.meta[list(kwargs.keys())])
+
+    # filter by joined columns
+    keep = np.array([True] * len(data))
+    for col, values in kwargs.items():
+        if values is not None:
+            keep_col = pattern_match(data[col], values)
+            keep &= keep_col
+    return data[keep]

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -977,6 +977,10 @@ def filter_by_meta(data, df, join_meta=False, **kwargs):
         by the given arguments (using `utils.pattern_match()`) and `col=None`
         joins the column without filtering
     """
+    if not set(META_IDX).issubset(data.index.names) \
+            and META_IDX not in data.columns:
+        raise ValueError('missing required index dimensions or columns!')
+
     meta = df.meta[list(kwargs)].copy()
 
     # filter meta by columns

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -583,3 +583,27 @@ def test_pd_filter_by_meta_with_index(meta_df):
     exp['integer'] = 0
 
     pd.testing.assert_frame_equal(obs, exp)
+
+
+def test_pd_filter_by_meta_index_as_cols(meta_df):
+    data = pd.DataFrame([
+        ['a_model', 'a_scenario', 'a_region1', 1],
+        ['a_model', 'a_scenario', 'a_region2', 2],
+        ['a_model', 'a_scenario2', 'a_region3', 3],
+    ], columns=['model', 'scenario', 'region', 'col'])
+
+    meta_df.set_meta([True, False], 'boolean')
+    meta_df.set_meta(0, 'integer')
+
+    obs = filter_by_meta(data, meta_df, join_meta=True,
+                         boolean=True, integer=None)
+    obs = obs.reindex(columns=META_IDX + ['region','col', 'boolean', 'integer'])
+
+    exp = data.iloc[0:2].copy()
+    exp['boolean'] = True
+    exp['integer'] = 0
+
+    print(obs)
+    print(exp)
+
+    pd.testing.assert_frame_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -563,7 +563,7 @@ def test_convert_unit():
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 
 
-def test_pd_filter_by_meta(meta_df):
+def test_pd_filter_by_meta_with_index(meta_df):
     data = pd.DataFrame([
         ['a_model', 'a_scenario', 'a_region1', 1],
         ['a_model', 'a_scenario', 'a_region2', 2],
@@ -574,7 +574,8 @@ def test_pd_filter_by_meta(meta_df):
     meta_df.set_meta([True, False], 'boolean')
     meta_df.set_meta(0, 'integer')
 
-    obs = filter_by_meta(data, meta_df, boolean=True, integer=None)
+    obs = filter_by_meta(data, meta_df, join_meta=True,
+                         boolean=True, integer=None)
     obs = obs.reindex(columns=['col', 'boolean', 'integer'])
 
     exp = data.iloc[0:2].copy()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ import pandas as pd
 from numpy import testing as npt
 
 from pyam import IamDataFrame, plotting, validate, categorize, \
-    require_variable, check_aggregate
+    require_variable, check_aggregate, filter_by_meta, META_IDX
 from pyam.core import _meta_idx
 
 from conftest import TEST_DATA_DIR
@@ -561,3 +561,22 @@ def test_convert_unit():
     )).data.reset_index(drop=True)
 
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
+
+
+def test_pd_filter_by_meta(meta_df):
+    data = pd.DataFrame([
+        ['a_model', 'a_scenario', 1],
+        ['a_model', 'a_scenario', 2],
+        ['a_model', 'a_scenario2', 3],
+    ], columns=['model', 'scenario', 'col']).set_index(META_IDX)
+
+    meta_df.set_meta([True, False], 'boolean')
+    meta_df.set_meta(0, 'integer')
+
+    obs = filter_by_meta(data, meta_df, boolean=True, integer=None)
+
+    exp = data.loc[('a_model', 'a_scenario')]
+    exp['boolean'] = True
+    exp['integer'] = 0
+
+    npt.assert_array_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -565,19 +565,20 @@ def test_convert_unit():
 
 def test_pd_filter_by_meta(meta_df):
     data = pd.DataFrame([
-        ['a_model', 'a_scenario', 1],
-        ['a_model', 'a_scenario', 2],
-        ['a_model', 'a_scenario2', 3],
-    ], columns=['model', 'scenario', 'col']).set_index(META_IDX)
+        ['a_model', 'a_scenario', 'a_region1', 1],
+        ['a_model', 'a_scenario', 'a_region2', 2],
+        ['a_model', 'a_scenario2', 'a_region3', 3],
+    ], columns=['model', 'scenario', 'region', 'col']
+        ).set_index(META_IDX + ['region'])
 
     meta_df.set_meta([True, False], 'boolean')
     meta_df.set_meta(0, 'integer')
 
     obs = filter_by_meta(data, meta_df, boolean=True, integer=None)
+    obs = obs.reindex(columns=['col', 'boolean', 'integer'])
 
-    exp = data.loc[('a_model', 'a_scenario')]
+    exp = data.iloc[0:2].copy()
     exp['boolean'] = True
     exp['integer'] = 0
 
-    obs = obs.reindex(columns=['col', 'boolean', 'integer'])
     pd.testing.assert_frame_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -563,44 +563,23 @@ def test_convert_unit():
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 
 
-def test_pd_filter_by_meta_with_index(meta_df):
+def test_pd_filter_by_meta(meta_df):
     data = pd.DataFrame([
         ['a_model', 'a_scenario', 'a_region1', 1],
         ['a_model', 'a_scenario', 'a_region2', 2],
         ['a_model', 'a_scenario2', 'a_region3', 3],
     ], columns=['model', 'scenario', 'region', 'col']
-    ).set_index(META_IDX + ['region'])
+    ).set_index(['model', 'region'])
 
     meta_df.set_meta([True, False], 'boolean')
     meta_df.set_meta(0, 'integer')
 
     obs = filter_by_meta(data, meta_df, join_meta=True,
                          boolean=True, integer=None)
-    obs = obs.reindex(columns=['col', 'boolean', 'integer'])
+    obs = obs.reindex(columns=['scenario', 'col', 'boolean', 'integer'])
 
     exp = data.iloc[0:2].copy()
     exp['boolean'] = True
     exp['integer'] = 0
-
-    pd.testing.assert_frame_equal(obs, exp)
-
-
-def test_pd_filter_by_meta_index_as_cols(meta_df):
-    data = pd.DataFrame([
-        ['a_model', 'a_scenario', 'a_region1', 1],
-        ['a_model', 'a_scenario', 'a_region2', 2],
-        ['a_model', 'a_scenario2', 'a_region3', 3],
-    ], columns=['model', 'scenario', 'region', 'col'])
-
-    meta_df.set_meta([True, False], 'boolean')
-    meta_df.set_meta(0, 'int')
-
-    obs = filter_by_meta(data, meta_df, join_meta=True,
-                         boolean=True, int=None)
-    obs = obs.reindex(columns=META_IDX + ['region', 'col', 'boolean', 'int'])
-
-    exp = data.iloc[0:2].copy()
-    exp['boolean'] = True
-    exp['int'] = 0
 
     pd.testing.assert_frame_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -579,4 +579,5 @@ def test_pd_filter_by_meta(meta_df):
     exp['boolean'] = True
     exp['integer'] = 0
 
+    obs = obs.reindex(columns=['col', 'boolean', 'integer'])
     pd.testing.assert_frame_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -604,4 +604,3 @@ def test_pd_filter_by_meta_no_index(meta_df):
     exp['int'] = 0
 
     pd.testing.assert_frame_equal(obs, exp)
-    

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -565,10 +565,10 @@ def test_convert_unit():
 
 def test_pd_filter_by_meta_with_index(meta_df):
     data = pd.DataFrame([
-        ['a_model', 'a_scenario', 'a_region1', 1],
-        ['a_model', 'a_scenario', 'a_region2', 2],
-        ['a_model', 'a_scenario2', 'a_region3', 3],
-    ], columns=['model', 'scenario', 'region', 'col']
+                ['a_model', 'a_scenario', 'a_region1', 1],
+                ['a_model', 'a_scenario', 'a_region2', 2],
+                ['a_model', 'a_scenario2', 'a_region3', 3],
+            ], columns=['model', 'scenario', 'region', 'col']
         ).set_index(META_IDX + ['region'])
 
     meta_df.set_meta([True, False], 'boolean')
@@ -593,17 +593,14 @@ def test_pd_filter_by_meta_index_as_cols(meta_df):
     ], columns=['model', 'scenario', 'region', 'col'])
 
     meta_df.set_meta([True, False], 'boolean')
-    meta_df.set_meta(0, 'integer')
+    meta_df.set_meta(0, 'int')
 
     obs = filter_by_meta(data, meta_df, join_meta=True,
-                         boolean=True, integer=None)
-    obs = obs.reindex(columns=META_IDX + ['region','col', 'boolean', 'integer'])
+                         boolean=True, int=None)
+    obs = obs.reindex(columns=META_IDX + ['region', 'col', 'boolean', 'int'])
 
     exp = data.iloc[0:2].copy()
     exp['boolean'] = True
-    exp['integer'] = 0
-
-    print(obs)
-    print(exp)
+    exp['int'] = 0
 
     pd.testing.assert_frame_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -565,11 +565,11 @@ def test_convert_unit():
 
 def test_pd_filter_by_meta_with_index(meta_df):
     data = pd.DataFrame([
-                ['a_model', 'a_scenario', 'a_region1', 1],
-                ['a_model', 'a_scenario', 'a_region2', 2],
-                ['a_model', 'a_scenario2', 'a_region3', 3],
-            ], columns=['model', 'scenario', 'region', 'col']
-        ).set_index(META_IDX + ['region'])
+        ['a_model', 'a_scenario', 'a_region1', 1],
+        ['a_model', 'a_scenario', 'a_region2', 2],
+        ['a_model', 'a_scenario2', 'a_region3', 3],
+    ], columns=['model', 'scenario', 'region', 'col']
+    ).set_index(META_IDX + ['region'])
 
     meta_df.set_meta([True, False], 'boolean')
     meta_df.set_meta(0, 'integer')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -579,4 +579,4 @@ def test_pd_filter_by_meta(meta_df):
     exp['boolean'] = True
     exp['integer'] = 0
 
-    npt.assert_array_equal(obs, exp)
+    pd.testing.assert_frame_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -583,3 +583,25 @@ def test_pd_filter_by_meta(meta_df):
     exp['integer'] = 0
 
     pd.testing.assert_frame_equal(obs, exp)
+
+
+def test_pd_filter_by_meta_no_index(meta_df):
+    data = pd.DataFrame([
+        ['a_model', 'a_scenario', 'a_region1', 1],
+        ['a_model', 'a_scenario', 'a_region2', 2],
+        ['a_model', 'a_scenario2', 'a_region3', 3],
+    ], columns=['model', 'scenario', 'region', 'col'])
+
+    meta_df.set_meta([True, False], 'boolean')
+    meta_df.set_meta(0, 'int')
+
+    obs = filter_by_meta(data, meta_df, join_meta=True,
+                         boolean=True, int=None)
+    obs = obs.reindex(columns=META_IDX + ['region', 'col', 'boolean', 'int'])
+
+    exp = data.iloc[0:2].copy()
+    exp['boolean'] = True
+    exp['int'] = 0
+
+    pd.testing.assert_frame_equal(obs, exp)
+    


### PR DESCRIPTION
This PR implements a function to join a generic pd.DataFrame (indexed on `['model', 'scenario']`) with specific metadata columns from an IamDataFrame and apply filters on each column.

This is useful in the following workflow:
1. retrieve a pd.DataFrame from an IamDataFrame using `timeseries()`
2. do some computation on the df
3. add relevant metadata like categories from the original IamDataFrame
4. continue working on the df, eg using `groupby()`on the categories

This is sort-of possible with `as_pandas()` and `filter()`, but quite cumbersome, because `as_pandas()` returns value-columns (years)  and metadata columns (Step 1 above). So one would have to make some bypass for step 2 to just operate on the year-columns. I found the workflow described above more flexible and also easier to read (because less bypassing required).

The use of `col=None` for only joining a column without filter is modelled on `slice(None)` of `pd.MultiIndex`