### PR TITLE
bugfix for `interpolate()` - duplication of values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,4 @@
 
 # Next Release
+
+- (#66)[https://github.com/IAMconsortium/pyam/pull/66] Fixes a bug in the `interpolate()` function ( duplication of data points if already defined)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -215,12 +215,15 @@ class IamDataFrame(object):
         """
         df = self.pivot_table(index=IAMC_IDX, columns=['year'],
                               values='value', aggfunc=np.sum)
+        # drop year-rows where values are already defined
+        if year in df.columns:
+            df = df[np.isnan(df[year])]
         fill_values = df.apply(fill_series,
                                raw=False, axis=1, year=year)
         fill_values = fill_values.dropna().reset_index()
         fill_values = fill_values.rename(columns={0: "value"})
         fill_values['year'] = year
-        self.data = self.data.append(fill_values)
+        self.data = self.data.append(fill_values, ignore_index=True)
 
     def as_pandas(self, with_metadata=False):
         """Return this as a pd.DataFrame

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -318,8 +318,13 @@ def test_interpolate(test_df):
            'years': [2005, 2007, 2010], 'value': [1, 3, 6]}
     exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
                                         columns=['years'], values='value')
-    obs = test_df.filter(variable='Primary Energy').timeseries()
+    variable = {'variable': 'Primary Energy'}
+    obs = test_df.filter(**variable).timeseries()
     npt.assert_array_equal(obs, exp)
+
+    # redo the inpolation and check that no duplicates are added
+    test_df.interpolate(2007)
+    assert not test_df.filter(**variable).data.duplicated().any()
 
 
 def test_set_meta_as_named_series(meta_df):


### PR DESCRIPTION
This PR fixes a bug in the ` interpolate` function, where values are duplicated if they are already defined. The fix only interpolates (and adds to the `IamDataFrame.data` only years that are missing.