### PR TITLE
escape brackets and dot in `pattern_match()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#80)[https://github.com/IAMconsortium/pyam/pull/80] Extend the pseudo-regexp syntax for filtering in `pattern_match()`
 - (#73)[https://github.com/IAMconsortium/pyam/pull/73] Adds ability to remove labels for markers, colors, or linestyles
 - (#71)[https://github.com/IAMconsortium/pyam/pull/71] Line plots `legend` keyword can now be a dictionary of legend arguments
 - (#70)[https://github.com/IAMconsortium/pyam/pull/70] Support reading of both SSP and RCP data files downloaded from the IIASA database.

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -231,8 +231,11 @@ def pattern_match(data, values, level=None):
         if isstr(s):
             regexp = (str(s)
                       .replace('|', '\\|')
+                      .replace('.', '\.')  # `.` has to be replaced before `*`
                       .replace('*', '.*')
                       .replace('+', '\+')
+                      .replace('(', '\(')
+                      .replace(')', '\)')
                       ) + "$"
             pattern = re.compile(regexp)
             subset = filter(pattern.match, data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,3 +51,24 @@ def test_pattern_match_plus():
     exp = [False, True, True, True]
 
     assert (obs == exp).all()
+
+
+def test_pattern_match_dot():
+    data = pd.Series(['foo', 'fo.'])
+    values = ['fo.']
+
+    obs = utils.pattern_match(data, values)
+    exp = [False, True]
+
+    assert (obs == exp).all()
+
+
+def test_pattern_match_brackets():
+    data = pd.Series(['foo (bar)', 'foo bar'])
+    values = ['foo (bar)']
+
+    obs = utils.pattern_match(data, values)
+    exp = [True, False]
+
+    print(obs)
+    assert (obs == exp).all()


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added - in line with current documentation
- [x] Description in RELEASE_NOTES.md Added

# Description

This PR extends the pseudo-syntax to escape regexp-reserved characters `.` and brackets when filtering an `IamDataFrame`.

See #79 for a nice-to-have feature to deactivate the pseudo-syntax.