### PR TITLE
WIP - do not merge - add an `append` kwarg to the `rename()` function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#82)[https://github.com/IAMconsortium/pyam/pull/82] Adding the option to append (instead of replace) in `rename()`
 - (#81)[https://github.com/IAMconsortium/pyam/pull/81] Bug-fix when using `set_meta()` with unnamed pd.Series and no `name` kwarg
 - (#80)[https://github.com/IAMconsortium/pyam/pull/80] Extend the pseudo-regexp syntax for filtering in `pattern_match()`
 - (#73)[https://github.com/IAMconsortium/pyam/pull/73] Adds ability to remove labels for markers, colors, or linestyles

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -452,6 +452,12 @@ class IamDataFrame(object):
         for col, dct in mapping.items():
             if col not in ['region', 'variable', 'unit']:
                 raise ValueError('renaming by {} not supported!'.format(col))
+
+            # remove dict entries where `key == value` to avoid double-counting
+            if append:
+                dct = dict([(key, value) for key, value in dct.items()
+                            if not key == value])
+
             data.loc[:, col] = data.loc[:, col].replace(dct)
             data = data[data[col].isin(dct.values())] if append else data
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -432,7 +432,7 @@ class IamDataFrame(object):
             return df
 
     def rename(self, mapping, append=False, inplace=False):
-        """Rename and aggregate column entries using groupby.sum()
+        """Rename and aggregate using `groupby.sum()`
 
         Parameters
         ----------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,7 +17,9 @@ df_rename_tests = pd.DataFrame([
     ['model', 'scen', 'region_a', 'test_1', 'unit', 1, 5],
     ['model', 'scen', 'region_b', 'test_2', 'unit', 2, 6],
     ['model', 'scen', 'region_a', 'test_3', 'unit', 3, 7],
-    ], columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+],
+    columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
+)
 
 
 def test_get_item(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -569,7 +569,8 @@ def test_rename():
 def test_rename_append():
     df = IamDataFrame(df_rename_tests)
 
-    mapping = {'variable': {'test_1': 'test', 'test_3': 'test'}}
+    mapping = {'variable': {'test_1': 'test', 'test_3': 'test',
+                            'test_2': 'test_2'}}
     obs = df.rename(mapping, append=True).data.reset_index(drop=True)
 
     exp = IamDataFrame(df_rename_tests.append(pd.DataFrame([

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -583,9 +583,9 @@ def test_rename_append():
 
 def test_convert_unit():
     df = IamDataFrame(pd.DataFrame([
-        ['model', 'scen', 'SST', 'test_1', 'A', 1, 5],
-        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
-        ['model', 'scen', 'SST', 'test_3', 'C', 3, 7],
+        ['model', 'scen', 'region_a', 'test_1', 'A', 1, 5],
+        ['model', 'scen', 'region_a', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'region_a', 'test_3', 'C', 3, 7],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
     ))
@@ -595,9 +595,9 @@ def test_convert_unit():
     obs = df.convert_unit(unit_conv).data.reset_index(drop=True)
 
     exp = IamDataFrame(pd.DataFrame([
-        ['model', 'scen', 'SST', 'test_1', 'B', 5, 25],
-        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
-        ['model', 'scen', 'SST', 'test_3', 'D', 9, 21],
+        ['model', 'scen', 'region_a', 'test_1', 'B', 5, 25],
+        ['model', 'scen', 'region_a', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'region_a', 'test_3', 'D', 9, 21],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
     )).data.reset_index(drop=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,15 @@ from pyam.core import _meta_idx
 from conftest import TEST_DATA_DIR
 
 
+df_rename_tests = pd.DataFrame([
+        ['model', 'scen', 'region_a', 'test_1', 'unit', 1, 5],
+        ['model', 'scen', 'region_b', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'region_a', 'test_3', 'unit', 3, 7],
+    ], columns=['model', 'scenario', 'region',
+                'variable', 'unit', 2005, 2010],
+    )
+
+
 def test_get_item(test_df):
     assert test_df['model'].unique() == ['a_model']
 
@@ -542,21 +551,14 @@ def test_48b():
 
 
 def test_rename():
-    df = IamDataFrame(pd.DataFrame([
-        ['model', 'scen', 'SST', 'test_1', 'unit', 1, 5],
-        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
-        ['model', 'scen', 'SST', 'test_3', 'unit', 3, 7],
-    ], columns=['model', 'scenario', 'region',
-                'variable', 'unit', 2005, 2010],
-    ))
+    df = IamDataFrame(df_rename_tests)
 
     mapping = {'variable': {'test_1': 'test', 'test_3': 'test'}}
-
     obs = df.rename(mapping).data.reset_index(drop=True)
 
     exp = IamDataFrame(pd.DataFrame([
-        ['model', 'scen', 'SST', 'test', 'unit', 4, 12],
-        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'region_a', 'test', 'unit', 4, 12],
+        ['model', 'scen', 'region_b', 'test_2', 'unit', 2, 6],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
     )).data.sort_values(by='region').reset_index(drop=True)
@@ -565,26 +567,16 @@ def test_rename():
 
 
 def test_rename_append():
-    df = IamDataFrame(pd.DataFrame([
-        ['model', 'scen', 'SST', 'test_1', 'unit', 1, 5],
-        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
-        ['model', 'scen', 'SST', 'test_3', 'unit', 3, 7],
-    ], columns=['model', 'scenario', 'region',
-                'variable', 'unit', 2005, 2010],
-    ))
+    df = IamDataFrame(df_rename_tests)
 
     mapping = {'variable': {'test_1': 'test', 'test_3': 'test'}}
-
     obs = df.rename(mapping, append=True).data.reset_index(drop=True)
 
-    exp = IamDataFrame(pd.DataFrame([
-        ['model', 'scen', 'SST', 'test_1', 'unit', 1, 5],
-        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
-        ['model', 'scen', 'SST', 'test_3', 'unit', 3, 7],
-        ['model', 'scen', 'SST', 'test', 'unit', 4, 12],
+    exp = IamDataFrame(df_rename_tests.append(pd.DataFrame([
+        ['model', 'scen', 'region_a', 'test', 'unit', 4, 12],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
-    )).data.sort_values(by='region').reset_index(drop=True)
+    ))).data.sort_values(by='region').reset_index(drop=True)
 
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -564,6 +564,31 @@ def test_rename():
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 
 
+def test_rename_append():
+    df = IamDataFrame(pd.DataFrame([
+        ['model', 'scen', 'SST', 'test_1', 'unit', 1, 5],
+        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'SST', 'test_3', 'unit', 3, 7],
+    ], columns=['model', 'scenario', 'region',
+                'variable', 'unit', 2005, 2010],
+    ))
+
+    mapping = {'variable': {'test_1': 'test', 'test_3': 'test'}}
+
+    obs = df.rename(mapping, append=True).data.reset_index(drop=True)
+
+    exp = IamDataFrame(pd.DataFrame([
+        ['model', 'scen', 'SST', 'test_1', 'unit', 1, 5],
+        ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'SST', 'test_3', 'unit', 3, 7],
+        ['model', 'scen', 'SST', 'test', 'unit', 4, 12],
+    ], columns=['model', 'scenario', 'region',
+                'variable', 'unit', 2005, 2010],
+    )).data.sort_values(by='region').reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
+
+
 def test_convert_unit():
     df = IamDataFrame(pd.DataFrame([
         ['model', 'scen', 'SST', 'test_1', 'A', 1, 5],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,12 +14,10 @@ from conftest import TEST_DATA_DIR
 
 
 df_rename_tests = pd.DataFrame([
-        ['model', 'scen', 'region_a', 'test_1', 'unit', 1, 5],
-        ['model', 'scen', 'region_b', 'test_2', 'unit', 2, 6],
-        ['model', 'scen', 'region_a', 'test_3', 'unit', 3, 7],
-    ], columns=['model', 'scenario', 'region',
-                'variable', 'unit', 2005, 2010],
-    )
+    ['model', 'scen', 'region_a', 'test_1', 'unit', 1, 5],
+    ['model', 'scen', 'region_b', 'test_2', 'unit', 2, 6],
+    ['model', 'scen', 'region_a', 'test_3', 'unit', 3, 7],
+    ], columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
 
 
 def test_get_item(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# WIP - do not merge

Needs more careful checks whether this new feature doesn't duplicate entries

# Description

This PR adds the option to "rename and append" using the `rename()` function, instead of only replacing values.

For example, having timeseries for `Primary Energy|Coal` and `Primary Energy|Gas`, the `rename()` function can now add the timeseries `Primary Energy` using

```
df.rename({'variable':
    {'Primary Energy|Coal': 'Primary Energy'
     'Primary Energy|Gas': 'Primary Energy'}},
    append=True)
```

This function also works for aggregating across regions.