### PR TITLE
Extend PR template with description section

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,14 @@
 - [ ] Documentation Added
 - [ ] Description in RELEASE_NOTES.md Added
 
-# Adding to RELEASE_NOTES.md
+## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)
 
 Please add a single line in the release notes similar to the following:
 
 ```
 - (#XX)[http://link-to-pr.com] Added feature which does something
 ```
+
+# Description of PR
+
+Please describe the changes introduced by this PR.


### PR DESCRIPTION
Suggestion to extend the PR template to make it clear that a description section should be added and that one can remove the release-notes template.