### PR TITLE
Allow `rename()` for model and scenarios

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#87)[https://github.com/IAMconsortium/pyam/pull/87] Extending `rename()` to work with model and scenario names
 - (#85)[https://github.com/IAMconsortium/pyam/pull/85] Improved functionality for importing metadata and bugfix for filtering for strings if `nan` values exist in metadata
 - (#83)[https://github.com/IAMconsortium/pyam/pull/83] Extending `filter_by_meta()` to work with non-matching indices between `df` and `data
 - (#81)[https://github.com/IAMconsortium/pyam/pull/81] Bug-fix when using `set_meta()` with unnamed pd.Series and no `name` kwarg

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -449,12 +449,12 @@ class IamDataFrame(object):
         ret = copy.deepcopy(self) if not inplace else self
         for col, _mapping in mapping.items():
             if col in ['model', 'scenario']:
-                index = pd.DataFrame(index=self.meta.index).reset_index()
+                index = pd.DataFrame(index=ret.meta.index).reset_index()
                 index.loc[:, col] = index.loc[:, col].replace(_mapping)
                 if index.duplicated().any():
                     raise ValueError('Renaming to non-unique {} index!'
                                      .format(col))
-                ret.meta.index = index.set_index(META_IDX)
+                ret.meta.index = index.set_index(META_IDX).index
             elif col not in ['region', 'variable', 'unit']:
                 raise ValueError('Renaming by {} not supported!'.format(col))
             ret.data.loc[:, col] = ret.data.loc[:, col].replace(_mapping)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -432,7 +432,9 @@ class IamDataFrame(object):
             return df
 
     def rename(self, mapping, inplace=False):
-        """Rename and aggregate column entries using groupby.sum()
+        """Rename and aggregate column entries using `groupby.sum()` on values.
+        When renaming models or scenarios, the uniqueness of the index must be
+        maintained, and the function will raise an error otherwise.
 
         Parameters
         ----------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -590,7 +590,6 @@ def test_rename_index(meta_df):
     ], columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
     ).set_index(IAMC_IDX).sort_index()
     exp.columns = exp.columns.map(int)
-
     pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
 
     # test meta changes
@@ -599,10 +598,6 @@ def test_rename_index(meta_df):
         ['b_model', 'a_scenario2', False],
     ], columns=['model', 'scenario', 'exclude']
     ).set_index(META_IDX)
-
-    print(obs.meta)
-    print(exp)
-
     pd.testing.assert_frame_equal(obs.meta, exp)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ import pandas as pd
 from numpy import testing as npt
 
 from pyam import IamDataFrame, plotting, validate, categorize, \
-    require_variable, check_aggregate, filter_by_meta, META_IDX
+    require_variable, check_aggregate, filter_by_meta, META_IDX, IAMC_IDX
 from pyam.core import _meta_idx
 
 from conftest import TEST_DATA_DIR
@@ -549,7 +549,7 @@ def test_48b():
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 
 
-def test_rename():
+def test_rename_variable():
     df = IamDataFrame(pd.DataFrame([
         ['model', 'scen', 'SST', 'test_1', 'unit', 1, 5],
         ['model', 'scen', 'SDN', 'test_2', 'unit', 2, 6],
@@ -568,6 +568,27 @@ def test_rename():
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
     )).data.sort_values(by='region').reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
+
+
+def test_rename_index_fail(meta_df):
+    mapping = {'scenario': {'a_scenario': 'a_scenario2'}}
+    pytest.raises(ValueError, meta_df.rename, mapping)
+
+
+def test_rename_index(meta_df):
+    mapping = {'model': {'a_model': 'b_model'},
+               'scenario': {'a_scenario': 'b_scen'}}
+    obs = meta_df.rename(mapping).timeseries().sort_index()
+
+    exp = pd.DataFrame([
+        ['b_model', 'b_scen', 'World', 'Primary Energy', 'EJ/y', 1., 6.],
+        ['b_model', 'b_scen', 'World', 'Primary Energy|Coal', 'EJ/y', .5, 3.],
+        ['b_model', 'a_scenario2', 'World', 'Primary Energy', 'EJ/y', 2., 7.],
+    ], columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
+    ).set_index(IAMC_IDX).sort_index()
+    exp.columns = exp.columns.map(int)
 
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -580,8 +580,9 @@ def test_rename_index_fail(meta_df):
 def test_rename_index(meta_df):
     mapping = {'model': {'a_model': 'b_model'},
                'scenario': {'a_scenario': 'b_scen'}}
-    obs = meta_df.rename(mapping).timeseries().sort_index()
+    obs = meta_df.rename(mapping)
 
+    # test data changes
     exp = pd.DataFrame([
         ['b_model', 'b_scen', 'World', 'Primary Energy', 'EJ/y', 1., 6.],
         ['b_model', 'b_scen', 'World', 'Primary Energy|Coal', 'EJ/y', .5, 3.],
@@ -590,7 +591,19 @@ def test_rename_index(meta_df):
     ).set_index(IAMC_IDX).sort_index()
     exp.columns = exp.columns.map(int)
 
-    pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
+    pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
+
+    # test meta changes
+    exp = pd.DataFrame([
+        ['b_model', 'b_scen', False],
+        ['b_model', 'a_scenario2', False],
+    ], columns=['model', 'scenario', 'exclude']
+    ).set_index(META_IDX)
+
+    print(obs.meta)
+    print(exp)
+
+    pd.testing.assert_frame_equal(obs.meta, exp)
 
 
 def test_convert_unit():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description

This PR extends the `rename()` function to also work for the `model` and `scenario` names. In contrast to renaming of `variable` or `region`, renaming by `model` and `scenario` enforces a unique `meta.index` and will raise an error if renaming leads to duplicates of model-scenario combination.

