### PR TITLE
initialise IamDataFrame with index

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#93)[https://github.com/IAMconsortium/pyam/pull/93] IamDataFrame can be initilialzed from pd.DataFrame with index
 - (#92)[https://github.com/IAMconsortium/pyam/pull/92] Adding `$` to the pseudo-regexp syntax in `pattern_match()`, adds override option
 - (#90)[https://github.com/IAMconsortium/pyam/pull/90] Adding a function to `set_panel_label()` as part of the plotting library
 - (#87)[https://github.com/IAMconsortium/pyam/pull/87] Extending `rename()` to work with model and scenario names

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -52,6 +52,7 @@ class IamDataFrame(object):
         data: ixmp.TimeSeries, ixmp.Scenario, pd.DataFrame or data file
             an instance of an TimeSeries or Scenario (requires `ixmp`),
             or pd.DataFrame or data file with IAMC-format data columns.
+            A pd.DataFrame can have the required data as columns or index.
 
             Special support is provided for data files downloaded directly from
             IIASA SSP and RCP databases. If you run into any problems loading

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -169,6 +169,10 @@ def format_data(df):
             df['scenario'] = scen.apply(
                 lambda s: '-'.join(s.split('-')[1:]).strip())
 
+    # reset the index if meaningful entries are included there
+    if not list(df.index.names) == [None]:
+        df.reset_index(inplace=True)
+
     # format columns to lower-case and check that all required columns exist
     if not set(IAMC_IDX).issubset(set(df.columns)):
         missing = list(set(IAMC_IDX) - set(df.columns))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,11 @@ def test_df():
 
 
 @pytest.fixture(scope="function")
+def test_pd_df():
+    yield TEST_DF
+
+
+@pytest.fixture(scope="function")
 def meta_df():
     df = IamDataFrame(data=TEST_DF)
     yield df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ TEST_DATA_DIR = os.path.join(here, 'data')
 
 
 TEST_DF = pd.DataFrame([
-    ['a_model', 'a_scenario', 'World', 'Primary Energy', 'EJ/y', 1, 6],
+    ['a_model', 'a_scenario', 'World', 'Primary Energy', 'EJ/y', 1, 6.],
     ['a_model', 'a_scenario', 'World', 'Primary Energy|Coal', 'EJ/y', 0.5, 3],
     ['a_model', 'a_scenario2', 'World', 'Primary Energy', 'EJ/y', 2, 7],
 ],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,8 +30,12 @@ df_filter_by_meta_nonmatching_idx = pd.DataFrame([
 
 def test_init_df_with_index(test_pd_df):
     df = IamDataFrame(test_pd_df.set_index(META_IDX))
-    pd.testing.assert_series_equal(df.models(),
-                                   pd.Series(data=['a_model'], name='model'))
+    pd.testing.assert_frame_equal(df.timeseries().reset_index(), test_pd_df)
+
+
+def test_init_df_from_timeseries(test_df):
+    df = IamDataFrame(test_df.timeseries())
+    pd.testing.assert_frame_equal(df.timeseries(), test_df.timeseries())
 
 
 def test_get_item(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,6 +28,12 @@ df_filter_by_meta_nonmatching_idx = pd.DataFrame([
 ).set_index(['model', 'region'])
 
 
+def test_init_df_with_index(test_pd_df):
+    df = IamDataFrame(test_pd_df.set_index(META_IDX))
+    pd.testing.assert_series_equal(df.models(),
+                                   pd.Series(data=['a_model'], name='model'))
+
+
 def test_get_item(test_df):
     assert test_df['model'].unique() == ['a_model']
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR extends the IamDataFrame constructor to take a pd.DataFrame with a meaningful index, for example the dataframe returned by `IamDataFrame.timeseries()`. Closes #77 