### PR TITLE
set meta by pd.DataFrame

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#94)[https://github.com/IAMconsortium/pyam/pull/94] `set_meta()` can take pd.DataFrame (with columns `['model', 'scenario']`) as `index` arg
 - (#93)[https://github.com/IAMconsortium/pyam/pull/93] IamDataFrame can be initilialzed from pd.DataFrame with index
 - (#92)[https://github.com/IAMconsortium/pyam/pull/92] Adding `$` to the pseudo-regexp syntax in `pattern_match()`, adds override option
 - (#90)[https://github.com/IAMconsortium/pyam/pull/90] Adding a function to `set_panel_label()` as part of the plotting library

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -297,6 +297,10 @@ class IamDataFrame(object):
         if not isinstance(index, pd.MultiIndex):
             raise ValueError('index cannot be coerced to pd.MultiIndex')
 
+        # raise error if index is not unique
+        if index.duplicated().any():
+            raise ValueError("non-unique ['model', 'scenario'] index!")
+
         # create pd.Series from meta, index and name if provided
         meta = pd.Series(data=meta, index=index, name=name)
         meta.name = name = name or meta.name
@@ -308,10 +312,6 @@ class IamDataFrame(object):
             .reindex(columns=META_IDX + [name])
             .set_index(META_IDX)
         )
-
-        # raise error if index is not unique
-        if meta.index.duplicated().any():
-            raise ValueError("non-unique ['model', 'scenario'] index!")
 
         # check if trying to add model-scenario index not existing in self
         diff = meta.index.difference(self.meta.index)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -412,7 +412,6 @@ def test_set_meta_non_existing_index_fail(meta_df):
 def test_set_meta_by_df(meta_df):
     df = pd.DataFrame([
         ['a_model', 'a_scenario', 'a_region1', 1],
-        ['a_model', 'a_scenario', 'a_region2', 2],
     ], columns=['model', 'scenario', 'region', 'col'])
 
     meta_df.set_meta(meta=0.3, name='meta_values', index=df)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -409,6 +409,23 @@ def test_set_meta_non_existing_index_fail(meta_df):
     pytest.raises(ValueError, meta_df.set_meta, s)
 
 
+def test_set_meta_by_df(meta_df):
+    df = pd.DataFrame([
+        ['a_model', 'a_scenario', 'a_region1', 1],
+        ['a_model', 'a_scenario', 'a_region2', 2],
+    ], columns=['model', 'scenario', 'region', 'col'])
+
+    meta_df.set_meta(meta=0.3, name='meta_values', index=df)
+
+    idx = pd.MultiIndex(levels=[['a_model'], ['a_scenario', 'a_scenario2']],
+                        labels=[[0, 0], [0, 1]], names=['model', 'scenario'])
+    exp = pd.Series(data=[0.3, np.nan], index=idx)
+    exp.name = 'meta_values'
+
+    obs = meta_df['meta_values']
+    pd.testing.assert_series_equal(obs, exp)
+
+
 def test_set_meta_as_series(meta_df):
     s = pd.Series([0.3, 0.4])
     meta_df.set_meta(s, 'meta_series')


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

In the existing implementation of `set_meta()`, passing over a non-valid index (e.g., a pd.DataFrame) was simply ignored without warning or error. This PR is a clean-up in the sense that if there is an `index` arg, it will be used and an error raised if it cannot be coerced in a meaningful way.

In addition, the function now also takes a `pd.DataFrame` with columns `['model', 'scenario']` as valid `index` arg.