### PR TITLE
add a function to retrieve years in which a series crosses a threshold

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#101)[https://github.com/IAMconsortium/pyam/pull/101] add function `cross_threshold()` to determine years where a timeseries crosses a given threshold
 - (#94)[https://github.com/IAMconsortium/pyam/pull/94] `set_meta()` can take pd.DataFrame (with columns `['model', 'scenario']`) as `index` arg
 - (#93)[https://github.com/IAMconsortium/pyam/pull/93] IamDataFrame can be initilialzed from pd.DataFrame with index
 - (#92)[https://github.com/IAMconsortium/pyam/pull/92] Adding `$` to the pseudo-regexp syntax in `pattern_match()`, adds override option

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -114,8 +114,11 @@ def cross_threshold(x, threshold=0, direction=['from above', 'from below']):
             prev_yr, prev_val = yr, val
             continue
         if not np.sign(prev_val - threshold) == np.sign(val - threshold):
-            change = (val - prev_val) / (yr - prev_yr)
-            # add one because int() rounds down
-            years.append(prev_yr + int((threshold - prev_val) / change) + 1)
+            if ('from above' in direction and prev_val > val) \
+                    or ('from below' in direction and prev_val < val):
+                change = (val - prev_val) / (yr - prev_yr)
+                # add one because int() rounds down
+                cross_yr = prev_yr + int((threshold - prev_val) / change) + 1
+                years.append(cross_yr)
         prev_yr, prev_val = yr, val
     return years

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -3,6 +3,9 @@
 import numpy as np
 import warnings
 
+from pyam.utils import (
+    isstr
+)
 
 # %%
 
@@ -84,7 +87,7 @@ def cumulative(x, first_year, last_year):
         return value
 
 
-def cross_threshold(x, threshold=0):
+def cross_threshold(x, threshold=0, direction=['from above', 'from below']):
     """Returns a list of the years in which a timeseries (indexed over years)
     crosses a given threshold
 
@@ -92,9 +95,17 @@ def cross_threshold(x, threshold=0):
     ----------
     x: pandas.Series
         a timeseries indexed over years
+    threshold: float, default 0
+        the threshold that the timeseries is checked against
+    direction: str, optional, default `['from above', 'from below']`
+        whether to return all years where the threshold is crossed
+        or only where threshold is crossed in a specific direction
     """
     prev_yr, prev_val = None, None
     years = []
+    direction = [direction] if isstr(direction) else list(direction)
+    if not set(direction).issubset(set(['from above', 'from below'])):
+        raise ValueError('invalid direction `{}`'.format(direction))
 
     for yr, val in zip(x.index, x.values):
         if np.isnan(val):  # ignore nans in the timeseries

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -82,3 +82,29 @@ def cumulative(x, first_year, last_year):
         value += x[last_year]
 
         return value
+
+
+def cross_threshold(x, threshold=0):
+    """Returns a list of the years in which a timeseries (indexed over years)
+    crosses a given threshold
+
+    Parameters
+    ----------
+    x: pandas.Series
+        a timeseries indexed over years
+    """
+    prev_yr, prev_val = None, None
+    years = []
+
+    for yr, val in zip(x.index, x.values):
+        if np.isnan(val):  # ignore nans in the timeseries
+            continue
+        if prev_val is None:
+            prev_yr, prev_val = yr, val
+            continue
+        if not np.sign(prev_val - threshold) == np.sign(val - threshold):
+            change = (val - prev_val) / (yr - prev_yr)
+            # add one because int() rounds down
+            years.append(prev_yr + int((threshold - prev_val) / change) + 1)
+        prev_yr, prev_val = yr, val
+    return years

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -33,5 +33,5 @@ def test_cross_treshold_from_above():
 
 def test_cross_treshold_direction_error():
     y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
-    pytest.raises(ValueError, cross_threshold, x = y, threshold=2,
+    pytest.raises(ValueError, cross_threshold, x=y, threshold=2,
                   direction='up')

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pandas as pd
+import pyam
+
+
+def test_cross_treshold():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
+    obs = pyam.cross_threshold(y, 2)
+    assert obs == [2007, 2011]

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -3,16 +3,35 @@
 
 import numpy as np
 import pandas as pd
-import pyam
+from pyam import cross_threshold
+import pytest
 
 
 def test_cross_treshold():
     y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
-    obs = pyam.cross_threshold(y, 2)
+    obs = cross_threshold(y, 2)
     assert obs == [2007, 2011]
 
 
 def test_cross_treshold_empty():
     y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
-    obs = pyam.cross_threshold(y, 4)
+    obs = cross_threshold(y, 4)
     assert obs == []
+
+
+def test_cross_treshold_from_below():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
+    obs = cross_threshold(y, 2, direction='from below')
+    assert obs == [2007]
+
+
+def test_cross_treshold_from_above():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
+    obs = cross_threshold(y, 2, direction='from above')
+    assert obs == [2011]
+
+
+def test_cross_treshold_direction_error():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
+    pytest.raises(ValueError, cross_threshold, x = y, threshold=2,
+                  direction='up')

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -10,3 +10,9 @@ def test_cross_treshold():
     y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
     obs = pyam.cross_threshold(y, 2)
     assert obs == [2007, 2011]
+
+
+def test_cross_treshold_empty():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002, 2005, 2007, 2013])
+    obs = pyam.cross_threshold(y, 4)
+    assert obs == []


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR adds a `pyam.cross_threshold()` function to retrieve a list of years in which a `pd.Series` (e.g., a timeseries row) crosses a given threshold.