### PR TITLE
fix bug to not show legend by default for more than 13 handles

### DIFF
--- a/pyam/plotting.py
+++ b/pyam/plotting.py
@@ -581,8 +581,9 @@ def _add_legend(ax, handles, labels, legend):
     if legend is None and len(labels) >= MAX_LEGEND_LABELS:
         logger().info('>={} labels, not applying legend'.format(
             MAX_LEGEND_LABELS))
-    legend = {} if legend in [True, None] else legend
-    ax.legend(handles, labels, **legend)
+    else:
+        legend = {} if legend in [True, None] else legend
+        ax.legend(handles, labels, **legend)
 
 
 def set_panel_label(label, ax=None, x=0.05, y=0.9):


### PR DESCRIPTION
# Description of PR

This PR fixes a bug that messed up the plotting library (expected) default behaviour of not showing legends for more than 13 handles.

Closes #84