### PR TITLE
fix bug when timeseries columns are formatted as float

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#104)[https://github.com/IAMconsortium/pyam/pull/104] fixes a bug with timeseries utils functions, ensures that years are cast as integers
 - (#101)[https://github.com/IAMconsortium/pyam/pull/101] add function `cross_threshold()` to determine years where a timeseries crosses a given threshold
 - (#94)[https://github.com/IAMconsortium/pyam/pull/94] `set_meta()` can take pd.DataFrame (with columns `['model', 'scenario']`) as `index` arg
 - (#93)[https://github.com/IAMconsortium/pyam/pull/93] IamDataFrame can be initilialzed from pd.DataFrame with index

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -28,6 +28,7 @@ from pyam.utils import (
     years_match,
     isstr,
     islistable,
+    cast_years_to_int,
     META_IDX,
     YEAR_IDX,
     IAMC_IDX,
@@ -66,6 +67,10 @@ class IamDataFrame(object):
             self.data = read_ix(data, **kwargs)
         else:
             self.data = read_files(data, **kwargs)
+
+        # cast year column to `int` if necessary
+        if not self.data.year.dtype == 'int64':
+            self.data.year = cast_years_to_int(self.data.year)
 
         # define a dataframe for categorization and other metadata indicators
         self.meta = self.data[META_IDX].drop_duplicates().set_index(META_IDX)

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -59,6 +59,8 @@ def cumulative(x, first_year, last_year):
                          .format(x.name or x, last_year))
         return np.nan
 
+    format_cols_to_int(x)
+
     x[first_year] = fill_series(x, first_year)
     x[last_year] = fill_series(x, last_year)
 
@@ -118,3 +120,13 @@ def cross_threshold(x, threshold=0, direction=['from above', 'from below']):
                 years.append(cross_yr)
         prev_yr, prev_val = yr, val
     return years
+
+
+def format_cols_to_int(x):
+    """formatting timeseries columns to int and checking validity of columns"""
+    cols = list(map(int, x.index))
+    error = x.index[cols != x.index]
+    if not error.empty:
+        raise ValueError('invalid timeseries columns `{}`'.format(error))
+    x.index = cols
+    return x

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from pyam.logger import logger
-from pyam.utils import isstr
+from pyam.utils import isstr, cast_years_to_int
 
 # %%
 
@@ -59,7 +59,9 @@ def cumulative(x, first_year, last_year):
                          .format(x.name or x, last_year))
         return np.nan
 
-    format_cols_to_int(x)
+    # cast tiemseries colums to `int` if necessary
+    if not x.index.dtype == 'int64':
+        cast_years_to_int(x, index=True)
 
     x[first_year] = fill_series(x, first_year)
     x[last_year] = fill_series(x, last_year)
@@ -120,13 +122,3 @@ def cross_threshold(x, threshold=0, direction=['from above', 'from below']):
                 years.append(cross_yr)
         prev_yr, prev_val = yr, val
     return years
-
-
-def format_cols_to_int(x):
-    """formatting timeseries columns to int and checking validity of columns"""
-    cols = list(map(int, x.index))
-    error = x.index[cols != x.index]
-    if not error.empty:
-        raise ValueError('invalid timeseries columns `{}`'.format(error))
-    x.index = cols
-    return x

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import warnings
+from pyam.logger import logger
 
 from pyam.utils import (
     isstr
 )
 
 # %%
+
 
 def fill_series(x, year):
     """Returns the value of a timeseries (indexed over years) for a year
@@ -50,17 +51,15 @@ def cumulative(x, first_year, last_year):
     last_year: int
         last year of the sum (inclusive)
     """
-
+    # if the timeseries does not cover the range `[first_year, last_year]`,
+    # return nan to avoid erroneous aggregation
     if min(x.index) > first_year:
-        # if the timeseries does not cover the range `[first_year, last_year]`,
-        # replace by nan to avoid erroneous aggregation
-        warnings.warn('timeseries {} does not start by {}'.format(x.name,
-                      first_year))
+        logger().warning('the timeseries `{}` does not start by {}'.format(
+            x.name or x, first_year))
         return np.nan
-
     if max(x.index) < last_year:
-        warnings.warn('the timeseries {} does not extend until {}'
-                      .format(x.name, last_year))
+        logger().warning('the timeseries `{}` does not extend until {}'
+                         .format(x.name or x, last_year))
         return np.nan
 
     x[first_year] = fill_series(x, first_year)

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -2,10 +2,7 @@
 
 import numpy as np
 from pyam.logger import logger
-
-from pyam.utils import (
-    isstr
-)
+from pyam.utils import isstr
 
 # %%
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -262,3 +262,17 @@ def years_match(data, years):
     """
     years = [years] if isinstance(years, int) else years
     return data.isin(years)
+
+
+def cast_years_to_int(x, index=False):
+    """formatting series or timeseries columns to int and checking validity"""
+    _x = x.index if index else x
+    cols = list(map(int, _x))
+    error = _x[cols != _x]
+    if not error.empty:
+        raise ValueError('invalid values `{}`'.format(list(error)))
+    if index:
+        x.index = cols
+        return x
+    else:
+        return _x

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -265,7 +265,10 @@ def years_match(data, years):
 
 
 def cast_years_to_int(x, index=False):
-    """formatting series or timeseries columns to int and checking validity"""
+    """Formatting series or timeseries columns to int and checking validity.
+    If `index=False`, the function works on the `pd.Series x`; else,
+    the function casts the index of `x` to int and returns x with a new index.
+    """
     _x = x.index if index else x
     cols = list(map(int, _x))
     error = _x[cols != _x]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,6 +33,17 @@ def test_init_df_with_index(test_pd_df):
     pd.testing.assert_frame_equal(df.timeseries().reset_index(), test_pd_df)
 
 
+def test_init_df_with_float_cols_raises(test_pd_df):
+    _test_df = test_pd_df.rename(columns={2005: 2005.5, 2010: 2010.})
+    pytest.raises(ValueError, IamDataFrame, data=_test_df)
+
+
+def test_init_df_with_float_cols(test_pd_df):
+    _test_df = test_pd_df.rename(columns={2005: 2005., 2010: 2010.})
+    obs = IamDataFrame(_test_df).timeseries().reset_index()
+    pd.testing.assert_series_equal(obs[2005], test_pd_df[2005])
+
+
 def test_init_df_from_timeseries(test_df):
     df = IamDataFrame(test_df.timeseries())
     pd.testing.assert_frame_equal(df.timeseries(), test_df.timeseries())

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pandas as pd
 from pyam.logger import logger
-from pyam import fill_series, cumulative, cross_threshold, format_cols_to_int
+from pyam import fill_series, cumulative, cross_threshold, cast_years_to_int
 import pytest
 
 
@@ -21,7 +21,7 @@ def test_fill_series_out_of_range():
 
 def test_cols_to_int():
     y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002., 2007.5, 2003., 2013.])
-    pytest.raises(ValueError, format_cols_to_int, x=y)
+    pytest.raises(ValueError, cast_years_to_int, x=y)
 
 
 def test_cumulative():

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -3,8 +3,40 @@
 
 import numpy as np
 import pandas as pd
-from pyam import cross_threshold
+from pyam.logger import logger
+from pyam import fill_series, cumulative, cross_threshold, format_cols_to_int
 import pytest
+
+
+def test_fill_series():
+    # note that the series is not order and the index is defined as float
+    y = pd.Series(data=[np.nan, 1, 4, 1], index=[2002., 2008., 2005., 2013.])
+    assert fill_series(y, 2006) == 3.
+
+
+def test_fill_series_out_of_range():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002., 2005., 2007., 2013.])
+    assert fill_series(y, 2001) is np.nan
+
+
+def test_cols_to_int():
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002., 2007.5, 2003., 2013.])
+    pytest.raises(ValueError, format_cols_to_int, x=y)
+
+
+def test_cumulative():
+    # note that the series is not order and the index is defined as float
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002., 2007., 2003., 2013.])
+    assert cumulative(y, 2008, 2013) == 6
+
+
+def test_cumulative_out_of_range():
+    # set logger level to exclude warnings in unit test output
+    logger().setLevel('ERROR')
+    # note that the series is not order and the index is defined as float
+    y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002., 2005., 2007., 2013.])
+    assert cumulative(y, 2008, 2015) is np.nan
+    logger().setLevel('NOTSET')
 
 
 def test_cross_treshold():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR fixes a bug with the timeseries functions `fill_series()` and `cumulative()` when the columns (years) are defined as floats instead of integers. An auxiliary function is introduced to cast columns to `int` and raise an error if non-meaningful years are present (like `2020.5`).

It also casts the `year` column in new instances of an `IamDataFrame` as `int`, closes #104.