### PR TITLE
cast value column to float when initalizing an IamDataFrame from file

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -658,6 +658,9 @@ class IamDataFrame(object):
         if path.endswith('csv'):
             df = pd.read_csv(path, *args, **kwargs)
         else:
+            xl = pd.ExcelFile(path)
+            if len(xl.sheet_names) > 1 and 'sheet_name' not in kwargs:
+                kwargs['sheet_name'] = 'meta'
             df = pd.read_excel(path, *args, **kwargs)
 
         req_cols = ['model', 'scenario', 'exclude']

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -130,6 +130,9 @@ def read_pandas(fname, *args, **kwargs):
     if fname.endswith('csv'):
         df = pd.read_csv(fname, *args, **kwargs)
     else:
+        xl = pd.ExcelFile(fname)
+        if len(xl.sheet_names) > 1 and 'sheet_name' not in kwargs:
+            kwargs['sheet_name'] = 'data'
         df = pd.read_excel(fname, *args, **kwargs)
     return df
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -183,7 +183,10 @@ def format_data(df):
         numcols = sorted(set(df.columns) - set(IAMC_IDX))
         df = pd.melt(df, id_vars=IAMC_IDX, var_name='year',
                      value_vars=numcols, value_name='value')
+
+    # cast year and value columns to numeric
     df['year'] = pd.to_numeric(df['year'])
+    df['value'] = df['value'].astype('float64')
 
     # drop NaN's
     df.dropna(inplace=True)


### PR DESCRIPTION
# Description of PR

This PR fixes a bug that the `value` column was read as `object` rather than `float` when initialising an `IamDataFrame` from an Excel table.