### PR TITLE
extend `append()` function to allow adding data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- (#114)[https://github.com/IAMconsortium/pyam/pull/114] extends `append()` such that data can be added to existing scenarios
 - (#111)[https://github.com/IAMconsortium/pyam/pull/111] extends `set_meta()` such that it requires a name (not None)
 - (#109)[https://github.com/IAMconsortium/pyam/pull/109] add ability to fill between and add data ranges in `line_plot()`
 - (#104)[https://github.com/IAMconsortium/pyam/pull/104] fixes a bug with timeseries utils functions, ensures that years are cast as integers

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -179,8 +179,16 @@ class IamDataFrame(object):
             # if not ignored, check that overlapping meta dataframes are equal
             if not ignore_meta_conflict:
                 cols = [i for i in other.meta.columns if i in ret.meta.columns]
-                pd.testing.assert_frame_equal(ret.meta.loc[intersect, cols],
-                                              other.meta.loc[intersect, cols])
+                if not ret.meta.loc[intersect, cols].equals(
+                        other.meta.loc[intersect, cols]):
+                    conflict_idx = (
+                        pd.concat([ret.meta.loc[intersect, cols],
+                                   other.meta.loc[intersect, cols]]
+                                  ).drop_duplicates().index.drop_duplicates()
+                        )
+                    msg = 'conflict in `meta` for scenarios {}'.format(
+                        [i for i in pd.DataFrame(index=conflict_idx).index])
+                    raise ValueError(msg)
 
             cols = [i for i in other.meta.columns if i not in ret.meta.columns]
             _meta = other.meta.loc[intersect, cols]

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -184,8 +184,9 @@ class IamDataFrame(object):
                     conflict_idx = (
                         pd.concat([ret.meta.loc[intersect, cols],
                                    other.meta.loc[intersect, cols]]
-                                  ).drop_duplicates().index.drop_duplicates()
-                        )
+                                  ).drop_duplicates()
+                        .index.drop_duplicates()
+                                   )
                     msg = 'conflict in `meta` for scenarios {}'.format(
                         [i for i in pd.DataFrame(index=conflict_idx).index])
                     raise ValueError(msg)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -166,10 +166,10 @@ class IamDataFrame(object):
         if not isinstance(other, IamDataFrame):
             other = IamDataFrame(other, **kwargs)
 
-        # join other.meta for new scenarios
         diff = other.meta.index.difference(ret.meta.index)
         intersect = other.meta.index.intersection(ret.meta.index)
 
+        # join other.meta for new scenarios
         if not diff.empty:
             ret.meta = ret.meta.append(other.meta.loc[diff, :], sort=False)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -500,17 +500,61 @@ def test_load_RCP_database_downloaded_file(test_df):
     pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df.as_pandas())
 
 
-def test_append(test_df):
-    df2 = test_df.append(other=os.path.join(
-        TEST_DATA_DIR, 'testing_data_2.csv'))
+def test_append_other_scenario(meta_df):
+    other = meta_df.filter(scenario='a_scenario2')\
+        .rename({'scenario': {'a_scenario2': 'a_scenario3'}})
+
+    meta_df.set_meta([0, 1], name='col1')
+    meta_df.set_meta(['a', 'b'], name='col2')
+
+    other.set_meta(2, name='col1')
+    other.set_meta('x', name='col3')
+
+    df = meta_df.append(other)
+
+    # check that the original meta dataframe is not updated
+    obs = meta_df.meta.index.get_level_values(1)
+    npt.assert_array_equal(obs, ['a_scenario', 'a_scenario2'])
+
+    # assert that merging of meta works as expected
+    exp = pd.DataFrame([
+        ['a_model', 'a_scenario', False, 0, 'a', np.nan],
+        ['a_model', 'a_scenario2', False, 1, 'b', np.nan],
+        ['a_model', 'a_scenario3', False, 2, np.nan, 'x'],
+    ], columns=['model', 'scenario', 'exclude', 'col1', 'col2', 'col3']
+    ).set_index(['model', 'scenario'])
+
+    pd.testing.assert_frame_equal(df.meta, exp)
+
+    # assert that appending data works as expected
+    ts = df.timeseries()
+    npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
+
+
+def test_append_same_scenario(meta_df):
+    other = (
+            meta_df.filter(scenario='a_scenario2')
+            .rename({'variable': {'Primary Energy': 'Primary Energy clone'}})
+            )
+
+    meta_df.set_meta([0, 1], name='col1')
+
+    other.set_meta(2, name='col1')
+    other.set_meta('b', name='col2')
+
+    df = meta_df.append(other)
 
     # check that the new meta.index is updated, but not the original one
-    obs = test_df.meta.index.get_level_values(1)
-    npt.assert_array_equal(obs, ['a_scenario'])
+    npt.assert_array_equal(meta_df.meta.columns, ['exclude', 'col1'])
 
-    exp = ['a_scenario', 'append_scenario']
-    obs2 = df2.meta.index.get_level_values(1)
-    npt.assert_array_equal(obs2, exp)
+    # assert that merging of meta works as expected
+    exp = meta_df.meta.copy()
+    exp['col2'] = [np.nan, 'b']
+    pd.testing.assert_frame_equal(df.meta, exp)
+
+    # assert that appending data works as expected
+    ts = df.timeseries()
+    npt.assert_array_equal(ts.iloc[2], ts.iloc[3])
 
 
 def test_append_duplicates(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -524,6 +524,8 @@ def test_append_other_scenario(meta_df):
     ], columns=['model', 'scenario', 'exclude', 'col1', 'col2', 'col3']
     ).set_index(['model', 'scenario'])
 
+    # sort columns for assertion in older pandas versions
+    df.meta.reindex(columns=exp.columns, copy=False)
     pd.testing.assert_frame_equal(df.meta, exp)
 
     # assert that appending data works as expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -525,7 +525,7 @@ def test_append_other_scenario(meta_df):
     ).set_index(['model', 'scenario'])
 
     # sort columns for assertion in older pandas versions
-    df.meta.reindex(columns=exp.columns, copy=False)
+    df.meta = df.meta.reindex(columns=exp.columns)
     pd.testing.assert_frame_equal(df.meta, exp)
 
     # assert that appending data works as expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -532,10 +532,8 @@ def test_append_other_scenario(meta_df):
 
 
 def test_append_same_scenario(meta_df):
-    other = (
-            meta_df.filter(scenario='a_scenario2')
-            .rename({'variable': {'Primary Energy': 'Primary Energy clone'}})
-            )
+    other = meta_df.filter(scenario='a_scenario2')\
+        .rename({'variable': {'Primary Energy': 'Primary Energy clone'}})
 
     meta_df.set_meta([0, 1], name='col1')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -543,7 +543,7 @@ def test_append_same_scenario(meta_df):
     other.set_meta('b', name='col2')
 
     # check that non-matching meta raise an error
-    pytest.raises(AssertionError, meta_df.append, other=other)
+    pytest.raises(ValueError, meta_df.append, other=other)
 
     # check that ignoring meta conflict works as expetced
     df = meta_df.append(other, ignore_meta_conflict=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -540,7 +540,11 @@ def test_append_same_scenario(meta_df):
     other.set_meta(2, name='col1')
     other.set_meta('b', name='col2')
 
-    df = meta_df.append(other)
+    # check that non-matching meta raise an error
+    pytest.raises(AssertionError, meta_df.append, other=other)
+
+    # check that ignoring meta conflict works as expetced
+    df = meta_df.append(other, ignore_meta_conflict=True)
 
     # check that the new meta.index is updated, but not the original one
     npt.assert_array_equal(meta_df.meta.columns, ['exclude', 'col1'])


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR extends the `append()` function to allow adding data for existing scenarios in an IamDataFrame. Until now, the function only accepted data for model-scenarios that were not in the index of the IamDataFrame to which data was appended.

In practice, I often wanted to add data to an existing scenario, like pull out GDP and population data, compute a timeseries GDP per capita, and append it. I the implemented this by 
```
df.data = df.data.append(other.data)
```
The drawback here is that this creates duplicated timeseries data in the IamDataFrame if one executes this line more than once.

Now, the function accepts new timeseries data as long as there is no overlap with existing data.