### PR TITLE
Add variable infilling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,14 @@
 
 # Next Release
 
+- (#127)[https://github.com/IAMconsortium/pyam/pull/127] add `add_missing_variables` method which allows users to add a missing variable in very simple ways as required
 - (#114)[https://github.com/IAMconsortium/pyam/pull/114] extends `append()` such that data can be added to existing scenarios
 - (#111)[https://github.com/IAMconsortium/pyam/pull/111] extends `set_meta()` such that it requires a name (not None)
 - (#109)[https://github.com/IAMconsortium/pyam/pull/109] add ability to fill between and add data ranges in `line_plot()`
 - (#104)[https://github.com/IAMconsortium/pyam/pull/104] fixes a bug with timeseries utils functions, ensures that years are cast as integers
 - (#101)[https://github.com/IAMconsortium/pyam/pull/101] add function `cross_threshold()` to determine years where a timeseries crosses a given threshold
 - (#98)[https://github.com/IAMconsortium/pyam/pull/98] add a module to compute and format summary statistics for timeseries data (wrapper for `pd.describe()`
-- (#95)[https://github.com/IAMconsortium/pyam/pull/95] add a `scatter()` chart in the plotting library using metadata 
+- (#95)[https://github.com/IAMconsortium/pyam/pull/95] add a `scatter()` chart in the plotting library using metadata
 - (#94)[https://github.com/IAMconsortium/pyam/pull/94] `set_meta()` can take pd.DataFrame (with columns `['model', 'scenario']`) as `index` arg
 - (#93)[https://github.com/IAMconsortium/pyam/pull/93] IamDataFrame can be initilialzed from pd.DataFrame with index
 - (#92)[https://github.com/IAMconsortium/pyam/pull/92] Adding `$` to the pseudo-regexp syntax in `pattern_match()`, adds override option

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -454,6 +454,16 @@ class _PyamDataFrame(object):
         logger().info(msg.format(n, variable))
         return pd.DataFrame(index=idx).reset_index()
 
+
+    def add_missing_variables(self, variables_to_add, inplace=False):
+        """Add a variable to all scenarios
+
+        """
+        import pdb
+        pdb.set_trace()
+        return df
+
+
     def validate(self, criteria={}, exclude_on_fail=False):
         """Validate scenarios using criteria on timeseries values
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ seaborn
 six
 geopandas
 cartopy
+nbconvert
+jupyter_contrib_nbextensions


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR adds a `add_missing_variable` method to `_PyamDataFrame` to allow users to easily add variables which aren't in their dataframes. The variables can simply be added as zeros, or made to follow the lead trajectory of another gas (a poor man's version of Aneris). 

This functionality is useful if your climate model requires a variable that isn't produced in your scenario. It's basically a cheat way of saying, fill with zeros before you pass to your climate model (rather than hoping that the climate model does something sensible with missing data).
