### PR TITLE
Fix wrong links and RST

### DIFF
--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -16,23 +16,23 @@ MESSAGE V.4   AMPERE3-Base   World       Primary Energy  EJ/y      454.5     479
 ============  =============  ==========  ==============  ========  ========  ========  ========
 
 
-`pyam.IamDataFrame`
-^^^^^^^^^^^^^^^^^^^
+``pyam.IamDataFrame``
+^^^^^^^^^^^^^^^^^^^^^
 
-A `pyam.IamDataFrame` is a wrapper for two `pandas.DataFrame` instances:
+A ``pyam.IamDataFrame`` is a wrapper for two ``pandas.DataFrame`` instances:
 
  - `data`: The data table is a dataframe containing the timeseries data in
-   "long format". It has the columns `pyam.LONG_IDX = ['model', 'scenario',
-   'region', 'unit', 'year', 'value']`.
+   "long format". It has the columns ``pyam.LONG_IDX = ['model', 'scenario',
+   'region', 'unit', 'year', 'value']``.
 
  - `meta`: The meta table is a dataframe containing categorisation and
-   descriptive indicators. It has the index `pyam.META_IDX = ['model',
-   'scenario']`.
+   descriptive indicators. It has the index ``pyam.META_IDX = ['model',
+   'scenario']``.
 
 The standard output format is the IAMC-style "wide format", see the example
-above. This format can be accessed using `pd.IamDataFrame.timeseries()`,
-which returns a `pandas.DataFrame` with the index `pyam.IAMC_IDX = ['model',
-'scenario', 'region', 'variable', 'unit']` and the years as columns.
+above. This format can be accessed using :meth:`pyam.IamDataFrame.timeseries`,
+which returns a ``pandas.DataFrame`` with the index ``pyam.IAMC_IDX = ['model',
+'scenario', 'region', 'variable', 'unit']`` and the years as columns.
 
 Filtering
 ^^^^^^^^^
@@ -40,18 +40,14 @@ Filtering
 The `pyam` package provides two methods for filtering timeseries data:
 
 An existing IamDataFrame can be filtered using
-`pyam.IamDataFrame.filter(col=...)`_, where `col` can be any column of the
-`data` table (i.e., `['model', 'scenario', 'region', 'unit', 'year']) or any
-column of the `meta` table. The returned object is a new `pyam.IamDataFrame`
+:meth:`pyam.IamDataFrame.filter(col=...) <pyam.IamDataFrame.filter>`, where `col` can be any column of the
+`data` table (i.e., ``['model', 'scenario', 'region', 'unit', 'year']``) or any
+column of the `meta` table. The returned object is a new ``pyam.IamDataFrame``
 instance.
 
-A `pandas.DataFrame` with columns or index `['model', 'scenario']` can be
-filtered by any `meta` columns from a `pyam.IamDataFrame` using
-`pyam.filter_by_meta(data, df, col=..., join_meta=False)`_. The returned
-object is a `pandas.DataFrame` downselected to those models-and-scenarios where
+A ``pandas.DataFrame`` with columns or index ``['model', 'scenario']`` can be
+filtered by any `meta` columns from a ``pyam.IamDataFrame`` using
+:func:`pyam.filter_by_meta(data, df, col=..., join_meta=False) <pyam.filter_by_meta>`. The returned
+object is a ``pandas.DataFrame`` downselected to those models-and-scenarios where
 the `meta` column satisfies the criteria given by `col=...` .
 Optionally, the `meta` columns are joined to the returned dataframe.
-
- .. _`pyam.IamDataFrame.filter(col=...)` : IamDataFrame.html#pyam.IamDataFrame.filter
-
- .. _`pyam.filter_by_meta(data, df, col=..., join_meta=False)` : pyam_functions.html


### PR DESCRIPTION
It seems like that the code in this file was marked with markdown style instead of RST. Furthermore, the links to `pyam.IamDataFrame.filter` and `pyam.filter_by_meta` where not correctly specified.

# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Inline with https://github.com/openjournals/joss-reviews/issues/1095 this PR fixes some wrong formatting in data.rst. I don't think it is worth adding something to RELEASE_NOTES.md, but if you like, tell me and I will do it.
