### PR TITLE
add contributor guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,22 @@
+Contributor Guidelines
+======================
+
+The pyam package has been developed with the explicit aim to facilitate
+open and collaborative analysis of integrated assessment and climate models.
+We appreciate contributions to the code base and development of new features.
+
+Please use the GitHub *Issues* feature to raise questions concerning potential
+bugs or to propose new features, but search and read resolved/closed topics on
+similar subjects before raising a new issue.
+
+For contributions to the code base, please use GitHub *Pull Requests*,
+including a detailed description of the new feature and unit tests
+to illustrate the intended functionality.
+Code submitted via pull requests must adhere to the `pep8`_ style formats.
+
+We do not require anyone to sign a *Contributor License Agreement*, because we
+believe that when posting ideas or submitting code to an open-source project,
+it should be obvious and self-evident that any such contributions
+are made in the spirit of open collaborative development.
+
+.. _`pep8`: https://www.python.org/dev/peps/pep-0008/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,10 @@ The pyam package has been developed with the explicit aim to facilitate
 open and collaborative analysis of integrated assessment and climate models.
 We appreciate contributions to the code base and development of new features.
 
+The community mailing list for questions and discussions on new features is
+hosted by Googlegroups. Please join at `groups.google.com/d/forum/pyam`_
+and use <pyam@googlegroups.com> to send an email to the *pyam* community.
+
 Please use the GitHub *Issues* feature to raise questions concerning potential
 bugs or to propose new features, but search and read resolved/closed topics on
 similar subjects before raising a new issue.
@@ -18,5 +22,7 @@ We do not require anyone to sign a *Contributor License Agreement*, because we
 believe that when posting ideas or submitting code to an open-source project,
 it should be obvious and self-evident that any such contributions
 are made in the spirit of open collaborative development.
+
+.. _`groups.google.com/d/forum/pyam` : https://groups.google.com/d/forum/pyam
 
 .. _`pep8`: https://www.python.org/dev/peps/pep-0008/

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,10 +34,17 @@ Release v\ |version|.
 The **pyam** Python package provides a range of diagnostic tools and functions
 for analyzing and visualizing data from your favorite assessment model(s).
 
+The *community mailing* list for questions and discussions on new features is
+hosted by Googlegroups. Please join at `groups.google.com/d/forum/pyam`_
+and use <pyam@googlegroups.com> to send an email to the *pyam* community.
+
 The source code for **pyam** is available on `Github`_.
 
 .. _`Github`:
    https://github.com/IAMconsortium/pyam
+
+.. _`groups.google.com/d/forum/pyam` :
+   https://groups.google.com/d/forum/pyam
 
 Overview
 --------


### PR DESCRIPTION
This PR adds a simple contributor guidelines document following the suggestion of reviewers at https://github.com/openjournals/joss-reviews/issues/1095.

> Are there clear guidelines for third parties wishing to 
 - [x] 1) Contribute to the software 
 - [x] 2) Report issues or problems with the software
 - [x] 3) Seek support
