### PR TITLE
Refactor to allow subclasses to set their own time format

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,9 @@
 
 # Next Release
 
+- [#177](https://github.com/IAMconsortium/pyam/pull/177) Modified formatting of time column on init to allow subclasses to avoid pandas limitation (https://stackoverflow.com/a/37226672)
 - [#176](https://github.com/IAMconsortium/pyam/pull/176) Corrected title setting operation in line_plot function
-- [#175](https://github.com/IAMconsortium/pyam/pull/175) Update link to tutorial in readme.md 
+- [#175](https://github.com/IAMconsortium/pyam/pull/175) Update link to tutorial in readme.md
 - [#174](https://github.com/IAMconsortium/pyam/pull/174) Add a function `difference()` to compare two IamDataFrames
 - [#171](https://github.com/IAMconsortium/pyam/pull/171) Fix a bug when reading from an `ixmp.TimeSeries` object, refactor to mitigate circular dependency
 - [#162](https://github.com/IAMconsortium/pyam/pull/162) Add a function to sum and append timeseries components to an aggregate variable

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -89,12 +89,12 @@ class IamDataFrame(object):
     def _format_data_time_col(self):
         # cast time_col to desired format
         if self.time_col == 'year':
-            if not df.year.dtype == 'int64':
+            if not self.data['year'].dtype == 'int64':
                 self.data['year'] = cast_years_to_int(pd.to_numeric(self.data['year']))
-        if self.time_col == 'time':
-            self.data = self._format_datetime_col()
+        elif self.time_col == 'time':
+            self._format_datetime_col()
 
-    def _format_datetime_col(self, df):
+    def _format_datetime_col(self):
         self.data['time'] = pd.to_datetime(self.data['time'])
 
     def __getitem__(self, key):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -23,7 +23,7 @@ from pyam.utils import (
     read_files,
     read_pandas,
     format_data,
-    cast_years_to_int,
+    to_int,
     pattern_match,
     years_match,
     month_match,
@@ -89,10 +89,7 @@ class IamDataFrame(object):
     def _format_data_time_col(self):
         # cast time_col to desired format
         if self.time_col == 'year':
-            if not self.data['year'].dtype == 'int64':
-                self.data['year'] = cast_years_to_int(
-                    pd.to_numeric(self.data['year'])
-                )
+            self.data['year'] = to_int(pd.to_numeric(self.data['year']))
         elif self.time_col == 'time':
             self._format_datetime_col()
 
@@ -905,7 +902,6 @@ class IamDataFrame(object):
             keep &= keep_col
 
         return keep
-
 
     def col_apply(self, col, func, *args, **kwargs):
         """Apply a function to a column

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -75,7 +75,12 @@ class IamDataFrame(object):
             _data = read_files(data, **kwargs)
 
         self.data, self.time_col, self.extra_cols = _data
-        self._format_data_time_col()
+        # cast time_col to desired format
+        if self.time_col == 'year':
+            self._format_year_col()
+        elif self.time_col == 'time':
+            self._format_datetime_col()
+
         self._LONG_IDX = IAMC_IDX + [self.time_col] + self.extra_cols
 
         # define a dataframe for categorization and other metadata indicators
@@ -86,12 +91,8 @@ class IamDataFrame(object):
         if 'exec' in run_control():
             self._execute_run_control()
 
-    def _format_data_time_col(self):
-        # cast time_col to desired format
-        if self.time_col == 'year':
-            self.data['year'] = to_int(pd.to_numeric(self.data['year']))
-        elif self.time_col == 'time':
-            self._format_datetime_col()
+    def _format_year_col(self):
+        self.data['year'] = to_int(pd.to_numeric(self.data['year']))
 
     def _format_datetime_col(self):
         self.data['time'] = pd.to_datetime(self.data['time'])

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -99,7 +99,6 @@ class IamDataFrame(object):
 
     def _format_datetime_col(self, df):
         df['time'] = pd.to_datetime(df['time'])
-
         return df
 
     def __getitem__(self, key):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -74,8 +74,8 @@ class IamDataFrame(object):
         else:
             _data = read_files(data, **kwargs)
 
-        _data = self._format_data_time_col(_data)
         self.data, self.time_col, self.extra_cols = _data
+        self._format_data_time_col()
         self._LONG_IDX = IAMC_IDX + [self.time_col] + self.extra_cols
 
         # define a dataframe for categorization and other metadata indicators
@@ -86,20 +86,16 @@ class IamDataFrame(object):
         if 'exec' in run_control():
             self._execute_run_control()
 
-    def _format_data_time_col(self, data):
-        df, time_col, extra_cols = data
+    def _format_data_time_col(self):
         # cast time_col to desired format
-        if time_col == 'year':
+        if self.time_col == 'year':
             if not df.year.dtype == 'int64':
-                df['year'] = cast_years_to_int(pd.to_numeric(df['year']))
-        if time_col == 'time':
-            df = self._format_datetime_col(df)
-
-        return (df, time_col, extra_cols)
+                self.data['year'] = cast_years_to_int(pd.to_numeric(self.data['year']))
+        if self.time_col == 'time':
+            self.data = self._format_datetime_col()
 
     def _format_datetime_col(self, df):
-        df['time'] = pd.to_datetime(df['time'])
-        return df
+        self.data['time'] = pd.to_datetime(self.data['time'])
 
     def __getitem__(self, key):
         _key_check = [key] if isstr(key) else key

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -90,7 +90,9 @@ class IamDataFrame(object):
         # cast time_col to desired format
         if self.time_col == 'year':
             if not self.data['year'].dtype == 'int64':
-                self.data['year'] = cast_years_to_int(pd.to_numeric(self.data['year']))
+                self.data['year'] = cast_years_to_int(
+                    pd.to_numeric(self.data['year'])
+                )
         elif self.time_col == 'time':
             self._format_datetime_col()
 

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from pyam.logger import logger
-from pyam.utils import isstr, cast_years_to_int
+from pyam.utils import isstr, to_int
 
 # %%
 
@@ -59,9 +59,8 @@ def cumulative(x, first_year, last_year):
                          .format(x.name or x, last_year))
         return np.nan
 
-    # cast tiemseries colums to `int` if necessary
-    if not x.index.dtype == 'int64':
-        cast_years_to_int(x, index=True)
+    # make sure we're using integers
+    to_int(x, index=True)
 
     x[first_year] = fill_series(x, first_year)
     x[last_year] = fill_series(x, last_year)
@@ -74,7 +73,7 @@ def cumulative(x, first_year, last_year):
     if not np.isnan(x[first_year]) and not np.isnan(x[last_year]):
         value = 0
         for (i, yr) in enumerate(years[:-1]):
-            next_yr = years[i+1]
+            next_yr = years[i + 1]
             # the summation is shifted to include the first year fully in sum,
             # otherwise, would return a weighted average of `yr` and `next_yr`
             value += ((next_yr - yr - 1) * x[next_yr] +

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -6,7 +6,7 @@ import re
 import glob
 import collections
 import datetime
-from dateutil import parser
+import dateutil
 import time
 
 import numpy as np
@@ -171,16 +171,14 @@ def format_data(df):
         year_cols, time_cols, extra_cols = [], [], []
         for i in cols:
             try:
-                year_cols.append(i) if int(i) else None
+                int(i)  # this is a year
+                year_cols.append(i)
             except (ValueError, TypeError):
-                if isinstance(i, datetime.datetime):
-                    time_cols.append(i)
-                    continue
                 try:
-                    parser.parse(i)
+                    dateutil.parser.parse(str(i))  # this is datetime
                     time_cols.append(i)
                 except ValueError:
-                    extra_cols.append(i)
+                    extra_cols.append(i)  # some other string
         if year_cols and not time_cols:
             time_col = 'year'
             melt_cols = year_cols
@@ -354,7 +352,7 @@ def datetime_match(data, dts):
     return data.isin(dts)
 
 
-def cast_years_to_int(x, index=False):
+def to_int(x, index=False):
     """Formatting series or timeseries columns to int and checking validity.
     If `index=False`, the function works on the `pd.Series x`; else,
     the function casts the index of `x` to int and returns x with a new index.

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -6,6 +6,7 @@ import re
 import glob
 import collections
 import datetime
+from dateutil import parser
 import time
 
 import numpy as np
@@ -172,8 +173,11 @@ def format_data(df):
             try:
                 year_cols.append(i) if int(i) else None
             except (ValueError, TypeError):
+                if isinstance(i, datetime.datetime):
+                    time_cols.append(i)
+                    continue
                 try:
-                    pd.to_datetime([i])
+                    parser.parse(i)
                     time_cols.append(i)
                 except ValueError:
                     extra_cols.append(i)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -189,13 +189,6 @@ def format_data(df):
         df = pd.melt(df, id_vars=IAMC_IDX + extra_cols, var_name=time_col,
                      value_vars=sorted(melt_cols), value_name='value')
 
-    # cast time_col to correct format
-    if time_col == 'year':
-        if not df.year.dtype == 'int64':
-            df['year'] = cast_years_to_int(pd.to_numeric(df['year']))
-    if time_col == 'time':
-        df['time'] = pd.to_datetime(df['time'])
-
     # cast value columns to numeric, drop NaN's, sort data
     df['value'] = df['value'].astype('float64')
     df.dropna(inplace=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,10 +108,10 @@ def test_init_datetime_long_timespan(test_pd_df):
 def test_init_datetime_subclass_long_timespan(test_pd_df):
     class TempSubClass(IamDataFrame):
         def _format_datetime_col(self):
-            # the subclass does not try to coerce the datetimes to pandas datetimes,
-            # instead simply leaving the time column as object type, so we don't run
-            # into the problem of pandas limited time period as discussed in
-            # https://stackoverflow.com/a/37226672
+            # the subclass does not try to coerce the datetimes to pandas
+            # datetimes, instead simply leaving the time column as object type,
+            # so we don't run into the problem of pandas limited time period as
+            # discussed in https://stackoverflow.com/a/37226672
             pass
 
     tdf = test_pd_df.copy()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,7 +66,7 @@ def test_init_df_with_extra_col(test_pd_df):
 
 
 @pytest.mark.xfail(reason=(
-    "pandas datetime is limited to ~584 year timespan, see "
+    "pandas datetime is limited to the time period of ~1677-2262, see "
     "https://stackoverflow.com/a/37226672"
 ))
 def test_init_df_long_timespan(test_pd_df):
@@ -85,7 +85,6 @@ def test_init_df_long_timespan(test_pd_df):
 
     assert df["time"].max() == tmax
     assert df["time"].min() == tmin
-
 
 
 def test_subclass_passesinit_df_long_timespan(test_pd_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,8 +89,8 @@ def test_init_df_long_timespan(test_pd_df):
 
 def test_subclass_passesinit_df_long_timespan(test_pd_df):
     class TempSubClass(IamDataFrame):
-        def _format_datetime_col(self, df):
-            return df
+        def _format_datetime_col(self):
+            pass
 
     tdf = test_pd_df.copy()
     tmin = datetime.datetime(2005, 6, 17)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -65,11 +65,29 @@ def test_init_df_with_extra_col(test_pd_df):
                                   tdf, check_like=True)
 
 
+def test_init_datetime(test_pd_df):
+    tdf = test_pd_df.copy()
+    tmin = datetime.datetime(2005, 6, 17)
+    tmax = datetime.datetime(2010, 6, 17)
+    tdf = tdf.rename(
+        {
+            2005: tmin,
+            2010: tmax,
+        },
+        axis="columns"
+    )
+
+    df = IamDataFrame(tdf)
+
+    assert df["time"].max() == tmax
+    assert df["time"].min() == tmin
+
+
 @pytest.mark.xfail(reason=(
     "pandas datetime is limited to the time period of ~1677-2262, see "
     "https://stackoverflow.com/a/37226672"
 ))
-def test_init_df_long_timespan(test_pd_df):
+def test_init_datetime_long_timespan(test_pd_df):
     tdf = test_pd_df.copy()
     tmin = datetime.datetime(2005, 6, 17)
     tmax = datetime.datetime(3005, 6, 17)
@@ -87,9 +105,13 @@ def test_init_df_long_timespan(test_pd_df):
     assert df["time"].min() == tmin
 
 
-def test_subclass_passesinit_df_long_timespan(test_pd_df):
+def test_init_datetime_subclass_long_timespan(test_pd_df):
     class TempSubClass(IamDataFrame):
         def _format_datetime_col(self):
+            # the subclass does not try to coerce the datetimes to pandas datetimes,
+            # instead simply leaving the time column as object type, so we don't run
+            # into the problem of pandas limited time period as discussed in
+            # https://stackoverflow.com/a/37226672
             pass
 
     tdf = test_pd_df.copy()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -65,6 +65,50 @@ def test_init_df_with_extra_col(test_pd_df):
                                   tdf, check_like=True)
 
 
+@pytest.mark.xfail(reason=(
+    "pandas datetime is limited to ~584 year timespan, see "
+    "https://stackoverflow.com/a/37226672"
+))
+def test_init_df_long_timespan(test_pd_df):
+    tdf = test_pd_df.copy()
+    tmin = datetime.datetime(2005, 6, 17)
+    tmax = datetime.datetime(3005, 6, 17)
+    tdf = tdf.rename(
+        {
+            2005: tmin,
+            2010: tmax,
+        },
+        axis="columns"
+    )
+
+    df = IamDataFrame(tdf)
+
+    assert df["time"].max() == tmax
+    assert df["time"].min() == tmin
+
+
+
+def test_subclass_passesinit_df_long_timespan(test_pd_df):
+    class TempSubClass(IamDataFrame):
+        def _format_datetime_col(self, df):
+            return df
+
+    tdf = test_pd_df.copy()
+    tmin = datetime.datetime(2005, 6, 17)
+    tmax = datetime.datetime(3005, 6, 17)
+    tdf = tdf.rename(
+        {
+            2005: tmin,
+            2010: tmax,
+        },
+        axis="columns"
+    )
+
+    df = TempSubClass(tdf)
+
+    assert df["time"].max() == tmax
+    assert df["time"].min() == tmin
+
 
 def test_to_excel(test_df):
     fname = 'foo_testing.xlsx'

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pandas as pd
 from pyam.logger import logger
-from pyam import fill_series, cumulative, cross_threshold, cast_years_to_int
+from pyam import fill_series, cumulative, cross_threshold, to_int
 import pytest
 
 
@@ -21,7 +21,7 @@ def test_fill_series_out_of_range():
 
 def test_cols_to_int():
     y = pd.Series(data=[np.nan, 1, 3, 1], index=[2002., 2007.5, 2003., 2013.])
-    pytest.raises(ValueError, cast_years_to_int, x=y)
+    pytest.raises(ValueError, to_int, x=y)
 
 
 def test_cumulative():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added (N/A)
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR moves the formatting of the time column from `pyam/utils.py` into a method of `IamDataFrame`. This allows subclasses to avoid converting to pandas datetime if their timespan is greater than the pandas maximum of 584 years (see https://stackoverflow.com/questions/32888124/pandas-out-of-bounds-nanosecond-timestamp-after-offset-rollforward-plus-adding-a).
