### PR TITLE
WIP - do not merge - fix pandas 0.24 compatibility issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,6 @@ build: false
 
 test_script:
   - pip install -e .[tests]
-  # pyam currently does not support pandas 0.24.0
-  # this is specified in requirements.py, but AppVeyor seems to ignore that
-  - pip install pandas==0.23.4
   - pytest -v --mpl tests --mpl-results-path=test-artifacts
 
 artifacts:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,7 +31,9 @@ df_filter_by_meta_nonmatching_idx = pd.DataFrame([
 
 def test_init_df_with_index(test_pd_df):
     df = IamDataFrame(test_pd_df.set_index(META_IDX))
-    pd.testing.assert_frame_equal(df.timeseries().reset_index(), test_pd_df)
+    obs = df.timeseries().reset_index()
+    obs.columns.name = None  # fix compatibility with pandas 24.0
+    pd.testing.assert_frame_equal(obs, test_pd_df)
 
 
 def test_init_df_with_float_cols_raises(test_pd_df):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -8,6 +8,7 @@ def test_do_aggregate_append(meta_df):
                    inplace=True)
     meta_df.aggregate('Primary Energy', append=True)
     obs = meta_df.filter(variable='Primary Energy').timeseries()
+    obs.columns.name = None  # fix compatibility with pandas 24.0
 
     exp = pd.DataFrame([
         ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/y', 1.5, 9.],

--- a/tests/test_feature_append_rename_convert.py
+++ b/tests/test_feature_append_rename_convert.py
@@ -143,7 +143,7 @@ def test_rename_index(meta_df):
     ], columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
     ).set_index(IAMC_IDX).sort_index()
     exp.columns = exp.columns.map(int)
-    pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
+    assert_timeseries(obs, exp)
 
     # test meta changes
     exp = pd.DataFrame([
@@ -169,7 +169,7 @@ def test_rename_append(meta_df):
     ], columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
     ).set_index(IAMC_IDX).sort_index()
     exp.columns = exp.columns.map(int)
-    pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
+    assert_timeseries(obs, exp)
 
     # test meta changes
     exp = pd.DataFrame([
@@ -179,6 +179,12 @@ def test_rename_append(meta_df):
     ], columns=['model', 'scenario', 'exclude']
     ).set_index(META_IDX)
     pd.testing.assert_frame_equal(obs.meta, exp)
+
+
+def assert_timeseries(df, exp):
+    obs = df.timeseries()
+    obs.columns.name = None  # fix compatibility with pandas 24.0
+    pd.testing.assert_frame_equal(obs, exp)
 
 
 def test_convert_unit():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR fixes compatibility issues with pandas 0.24.
 - [x] `reset_index()` keeps names of indices
 - [ ] changed behaviour of `combine_first()`, using it in the `statistics` module raises an error from the depths of pandas

closes #180

