### PR TITLE
Fix `line_plot()` to work with `nan` in meta columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#186](https://github.com/IAMconsortium/pyam/pull/186) Quickfix for over-zealous `dropna()` in `line_plot()`
 - [#178](https://github.com/IAMconsortium/pyam/pull/178) Add a kwarg `append` to the function `rename()`, change behaviour of mapping to only apply to data where all given columns are matched
 - [#177](https://github.com/IAMconsortium/pyam/pull/177) Modified formatting of time column on init to allow subclasses to avoid pandas limitation (https://stackoverflow.com/a/37226672)
 - [#176](https://github.com/IAMconsortium/pyam/pull/176) Corrected title setting operation in line_plot function

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -331,11 +331,11 @@ class IamDataFrame(object):
                 cols.add(value)
 
         return (
-                self.data
-                .set_index(META_IDX)
-                .join(self.meta[list(cols)])
-                .reset_index()
-               )
+            self.data
+            .set_index(META_IDX)
+            .join(self.meta[list(cols)])
+            .reset_index()
+        )
 
     def timeseries(self, iamc_index=False):
         """Returns a pd.DataFrame in wide format (years or timedate as columns)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -325,7 +325,7 @@ class IamDataFrame(object):
         kwargs: arguments passed to plotting library, meta columns (as values)
            are joined to returned dataframe
         """
-        cols = set()
+        cols = set(['exclude'])
         for arg, value in kwargs.items():
             if isstr(value) and value in self.meta.columns:
                 cols.add(value)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -327,7 +327,7 @@ class IamDataFrame(object):
         """
         cols = set()
         for arg, value in kwargs.items():
-            if value in self.meta.columns:
+            if isstr(value) and value in self.meta.columns:
                 cols.add(value)
 
         return (

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -317,6 +317,26 @@ class IamDataFrame(object):
                   )
         return df
 
+    def join_meta(self, **kwargs):
+        """Return data and selected meta columns as a pd.DataFrame
+
+        Parameters
+        ----------
+        kwargs: arguments passed to plotting library, meta columns (as values)
+           are joined to returned dataframe
+        """
+        cols = set()
+        for arg, value in kwargs.items():
+            if value in self.meta.columns:
+                cols.add(value)
+
+        return (
+                self.data
+                .set_index(META_IDX)
+                .join(self.meta[list(cols)])
+                .reset_index()
+               )
+
     def timeseries(self, iamc_index=False):
         """Returns a pd.DataFrame in wide format (years or timedate as columns)
 
@@ -1059,7 +1079,7 @@ class IamDataFrame(object):
 
         see pyam.plotting.line_plot() for all available options
         """
-        df = self.as_pandas(with_metadata=True)
+        df = self.join_meta(x=x, y=y, **kwargs)
 
         # pivot data if asked for explicit variable name
         variables = df['variable'].unique()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,8 @@
 import matplotlib
 import pytest
 import os
+import copy
+import numpy as np
 import pyam
 
 
@@ -45,6 +47,8 @@ def update_run_control(update):
 
 @pytest.mark.mpl_image_compare(**MPL_KWARGS)
 def test_line_plot(plot_df):
+    _plot_df = copy.deepcopy(plot_df)
+    _plot_df.set_meta(meta=[np.nan] * 4, name='test')
     fig, ax = plt.subplots(figsize=(8, 8))
     plot_df.line_plot(ax=ax, legend=True)
     return fig

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -50,7 +50,7 @@ def test_line_plot(plot_df):
     _plot_df = copy.deepcopy(plot_df)
     _plot_df.set_meta(meta=[np.nan] * 4, name='test')
     fig, ax = plt.subplots(figsize=(8, 8))
-    plot_df.line_plot(ax=ax, legend=True)
+    _plot_df.line_plot(ax=ax, legend=True)
     return fig
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added (extended existing `line_plot()` test with metadata, first failed, then passed)
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

The function `line_plot()` drops all rows where any value is `nan` in the data or meta tables, even if the columns in questions aren't used. This PR adds a function `join_meta()` where only columns (in particular those relevant to the plotting library) are joined to the dataframe which is passed to the plotting functions.
