### PR TITLE
Extend the `utils.find_depth()` function to return depth

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,7 +2,7 @@ linters:
   flake8:
     max-line-length: 79
     fixer: false
-    ignore: I002, F403, E402
+    ignore: I002, F403, E402, E731
     # stickler doesn't support 'exclude' for flake8 properly, so we disable it
     # below with files.ignore:
     # https://github.com/markstory/lint-review/issues/184

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#192](https://github.com/IAMconsortium/pyam/pull/192) Extend `utils.find_depth()` to optionally return depth (as list of ints) rather than assert level tests
 - [#190](https://github.com/IAMconsortium/pyam/pull/190) Add `concat()` function
 - [#189](https://github.com/IAMconsortium/pyam/pull/189) Fix over-zealous `dropna()` in `scatter()`
 - [#186](https://github.com/IAMconsortium/pyam/pull/186) Fix over-zealous `dropna()` in `line_plot()`, rework `as_pandas()` to (optionally) discover meta columns to be joined

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -24,6 +24,7 @@ from pyam.utils import (
     read_pandas,
     format_data,
     to_int,
+    find_depth,
     pattern_match,
     years_match,
     month_match,
@@ -934,8 +935,7 @@ class IamDataFrame(object):
 
             elif col == 'level':
                 if 'variable' not in filters.keys():
-                    keep_col = pattern_match(self.data['variable'],
-                                             '*', values, regexp=regexp)
+                    keep_col = find_depth(self.data['variable'], level=values)
                 else:
                     continue
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -841,7 +841,7 @@ class IamDataFrame(object):
              - 'model', 'scenario', 'region', 'variable', 'unit':
                string or list of strings, where `*` can be used as a wildcard
              - 'level': the maximum "depth" of IAM variables (number of '|')
-               (exluding the strings given in the 'variable' argument)
+               (excluding the strings given in the 'variable' argument)
              - 'year': takes an integer, a list of integers or a range
                note that the last year of a range is not included,
                so `range(2010, 2015)` is interpreted as `[2010, ..., 2014]`

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -218,7 +218,7 @@ def find_depth(data, s='', level=None):
     pipe = re.compile('\\|')
     regexp = str(s).replace('*', '')
 
-    def find_depth(val):
+    def _find_depth(val):
         return len(pipe.findall(val.replace(regexp, '')))
 
     # if no level test is specified, return the depth as int
@@ -241,7 +241,7 @@ def find_depth(data, s='', level=None):
         raise ValueError('Unknown level type: {}'.format(level))
 
     def apply_test(val):
-        return test(find_depth(val))
+        return test(_find_depth(val))
 
     return list(map(apply_test, data))
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -223,13 +223,13 @@ def find_depth(data, s='', level=None):
         whether depth satisfies the condition (equality if `level` is int,
         >= if `.+`,  <= if `.-`)
     """
-    # remove wildcard as last character from string, find depth
-    s = s.rstrip('*')
-    regexp = re.compile('^' + _escape_regexp(s))
+    # remove wildcard as last character from string, escape regex characters
+    _s = re.compile('^' + _escape_regexp(s.rstrip('*')))
+    _p = re.compile('\\|')
 
+    # find depth
     def _count_pipes(val):
-        return len(re.compile('\\|').findall(re.sub(regexp, '', val))) \
-            if regexp.match(val) else None
+        return len(_p.findall(re.sub(_s, '', val))) if _s.match(val) else None
 
     n_pipes = map(_count_pipes, data)
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -224,7 +224,7 @@ def find_depth(data, s='', level=None):
     # if no level test is specified, return the depth as int
     if level is None:
         def return_depth(val):
-            return -1 if s not in val else find_depth(val)
+            return -1 if s not in val else _find_depth(val)
 
         return list(map(return_depth, data))
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -262,23 +262,27 @@ def pattern_match(data, values, level=None, regexp=False, has_nan=True):
 
     for s in values:
         if isstr(s):
-            _regexp = (str(s)
-                       .replace('|', '\\|')
-                       .replace('.', '\.')  # `.` has to be replaced before `*`
-                       .replace('*', '.*')
-                       .replace('+', '\+')
-                       .replace('(', '\(')
-                       .replace(')', '\)')
-                       .replace('$', '\\$')
-                       ) + "$"
-            pattern = re.compile(_regexp if not regexp else s)
-
+            pattern = re.compile(_escape_regexp(s) if not regexp else s)
             subset = filter(pattern.match, _data)
             depth = True if level is None else find_depth(_data, s, level)
             matches |= (_data.isin(subset) & depth)
         else:
             matches |= data == s
     return matches
+
+
+def _escape_regexp(s):
+    """escape characters with specific regexp use"""
+    return (
+        str(s)
+        .replace('|', '\\|')
+        .replace('.', '\.')  # `.` has to be replaced before `*`
+        .replace('*', '.*')
+        .replace('+', '\+')
+        .replace('(', '\(')
+        .replace(')', '\)')
+        .replace('$', '\\$')
+    ) + "$"
 
 
 def years_match(data, years):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -210,10 +210,9 @@ def style_df(df, style='heatmap'):
 
 def find_depth(data, s='', level=None):
     """
-    return a list of bools asserting the depth indicated by `level`;
-    or if level is None, return -1 if the string does not contain `s` and
-    the depth (number of `|`) otherwise.
-    string `s` is removed from `data` if at the start of a variable.
+    return a list of bools asserting the depth (number of `|`) trailing `s`
+    by `level` tests; or if `level` is None, return -1 if the string does not
+    contain `s` and the depth otherwise.
     """
     # remove wildcard as last character from string, find depth
     s = s.rstrip('*')

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -227,13 +227,15 @@ def find_depth(data, s='', level=None):
     s = s.rstrip('*')
     regexp = re.compile('^' + _escape_regexp(s))
 
-    def _pipe(val):
+    def _count_pipes(val):
         return len(re.compile('\\|').findall(re.sub(regexp, '', val))) \
             if regexp.match(val) else None
 
+    n_pipes = map(_count_pipes, data)
+
     # if no level test is specified, return the depth as int
     if level is None:
-        return list(map(lambda x: _pipe(x), data))
+        return list(n_pipes)
 
     # if `level` is given, set function for finding depth level =, >=, <= |s
     if not isstr(level):
@@ -247,7 +249,7 @@ def find_depth(data, s='', level=None):
     else:
         raise ValueError('Unknown level type: `{}`'.format(level))
 
-    return list(map(lambda x: test(_pipe(x)), data))
+    return list(map(test, n_pipes))
 
 
 def pattern_match(data, values, level=None, regexp=False, has_nan=True):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -216,18 +216,14 @@ def find_depth(data, s='', level=None):
     """
     # remove wildcard as last character from string, find depth
     s = s.rstrip('*')
-    pipe = re.compile('\\|')
     regexp = re.compile(_escape_regexp(s))
 
-    def _find_depth(val):
-        return len(pipe.findall(re.sub(regexp, '', val)))
+    def _pipe(val):
+        return len(re.compile('\\|').findall(re.sub(regexp, '', val)))
 
     # if no level test is specified, return the depth as int
     if level is None:
-        def return_depth(val):
-            return -1 if not val.startswith(s) else _find_depth(val)
-
-        return list(map(return_depth, data))
+        return list(map(lambda x: _pipe(x) if regexp.match(x) else None, data))
 
     # if `level` is given, set function for finding depth level =, >=, <= |s
     if not isstr(level):
@@ -241,10 +237,7 @@ def find_depth(data, s='', level=None):
     else:
         raise ValueError('Unknown level type: {}'.format(level))
 
-    def apply_test(val):
-        return test(_find_depth(val))
-
-    return list(map(apply_test, data))
+    return list(map(lambda x: test(_pipe(x)), data))
 
 
 def pattern_match(data, values, level=None, regexp=False, has_nan=True):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -208,8 +208,27 @@ def style_df(df, style='heatmap'):
         return df.style.background_gradient(cmap=cm)
 
 
-def find_depth(data, s, level):
-    # determine function for finding depth level =, >=, <= |s
+def find_depth(data, s='', level=None):
+    """
+    return a list of bools asserting the depth indicated by `level`;
+    or if level is None, return -1 if the string does not contain `s` and
+    the depth (number of `|`) otherwise
+    """
+    # determine depth
+    pipe = re.compile('\\|')
+    regexp = str(s).replace('*', '')
+
+    def find_depth(val):
+        return len(pipe.findall(val.replace(regexp, '')))
+
+    # if no level test is specified, return the depth as int
+    if level is None:
+        def return_depth(val):
+            return -1 if s not in val else find_depth(val)
+
+        return list(map(return_depth, data))
+
+    # if `level` is given, set function for finding depth level =, >=, <= |s
     if not isstr(level):
         test = lambda x: level == x
     elif level[-1] == '-':
@@ -221,10 +240,9 @@ def find_depth(data, s, level):
     else:
         raise ValueError('Unknown level type: {}'.format(level))
 
-    # determine depth
-    pipe = re.compile('\\|')
-    regexp = str(s).replace('*', '')
-    apply_test = lambda val: test(len(pipe.findall(val.replace(regexp, ''))))
+    def apply_test(val):
+        return test(find_depth(val))
+
     return list(map(apply_test, data))
 
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -216,7 +216,7 @@ def find_depth(data, s='', level=None):
     """
     # remove wildcard as last character from string, find depth
     s = s.rstrip('*')
-    regexp = re.compile(_escape_regexp(s))
+    regexp = re.compile('^' + _escape_regexp(s))
 
     def _pipe(val):
         return len(re.compile('\\|').findall(re.sub(regexp, '', val)))

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -215,8 +215,8 @@ def find_depth(data, s='', level=None):
     the depth (number of `|`) otherwise.
     string `s` is removed from `data` if at the start of a variable.
     """
-    # remove wildcard from string, determine depth
-    s = s.replace('*', '')
+    # remove wildcard as last character from string, find depth
+    s = s.rstrip('*')
     pipe = re.compile('\\|')
     regexp = re.compile(_escape_regexp(s))
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -210,9 +210,18 @@ def style_df(df, style='heatmap'):
 
 def find_depth(data, s='', level=None):
     """
-    return a list of bools asserting the depth (number of `|`) trailing `s`
-    by `level` tests; or if `level` is None, return -1 if the string does not
-    contain `s` and the depth otherwise.
+    return or assert the depth (number of `|`) of variables
+
+    Parameters
+    ----------
+    data : pd.Series of strings
+        IAMC-style variables
+    s : str, default ''
+        remove leading `s` from any variable in `data`
+    level : int or str, default None
+        if None, return depth (number of `|`); else, return list of booleans
+        whether depth satisfies the condition (equality if `level` is int,
+        >= if `.+`,  <= if `.-`)
     """
     # remove wildcard as last character from string, find depth
     s = s.rstrip('*')

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -237,17 +237,17 @@ def find_depth(data, s='', level=None):
 
     # if `level` is given, set function for finding depth level =, >=, <= |s
     if not isstr(level):
-        test = lambda x: level == x
+        test = lambda x: level == x if x is not None else False
     elif level[-1] == '-':
         level = int(level[:-1])
-        test = lambda x: level >= x
+        test = lambda x: level >= x if x is not None else False
     elif level[-1] == '+':
         level = int(level[:-1])
-        test = lambda x: level <= x
+        test = lambda x: level <= x if x is not None else False
     else:
         raise ValueError('Unknown level type: `{}`'.format(level))
 
-    return list(map(lambda x: test(_pipe(x)) or False, data))
+    return list(map(lambda x: test(_pipe(x)), data))
 
 
 def pattern_match(data, values, level=None, regexp=False, has_nan=True):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -219,11 +219,12 @@ def find_depth(data, s='', level=None):
     regexp = re.compile('^' + _escape_regexp(s))
 
     def _pipe(val):
-        return len(re.compile('\\|').findall(re.sub(regexp, '', val)))
+        return len(re.compile('\\|').findall(re.sub(regexp, '', val))) \
+            if regexp.match(val) else None
 
     # if no level test is specified, return the depth as int
     if level is None:
-        return list(map(lambda x: _pipe(x) if regexp.match(x) else None, data))
+        return list(map(lambda x: _pipe(x), data))
 
     # if `level` is given, set function for finding depth level =, >=, <= |s
     if not isstr(level):
@@ -235,9 +236,9 @@ def find_depth(data, s='', level=None):
         level = int(level[:-1])
         test = lambda x: level <= x
     else:
-        raise ValueError('Unknown level type: {}'.format(level))
+        raise ValueError('Unknown level type: `{}`'.format(level))
 
-    return list(map(lambda x: test(_pipe(x)), data))
+    return list(map(lambda x: test(_pipe(x)) or False, data))
 
 
 def pattern_match(data, values, level=None, regexp=False, has_nan=True):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -212,19 +212,21 @@ def find_depth(data, s='', level=None):
     """
     return a list of bools asserting the depth indicated by `level`;
     or if level is None, return -1 if the string does not contain `s` and
-    the depth (number of `|`) otherwise
+    the depth (number of `|`) otherwise.
+    string `s` is removed from `data` if at the start of a variable.
     """
-    # determine depth
+    # remove wildcard from string, determine depth
+    s = s.replace('*', '')
     pipe = re.compile('\\|')
-    regexp = str(s).replace('*', '')
+    regexp = re.compile(_escape_regexp(s))
 
     def _find_depth(val):
-        return len(pipe.findall(val.replace(regexp, '')))
+        return len(pipe.findall(re.sub(regexp, '', val)))
 
     # if no level test is specified, return the depth as int
     if level is None:
         def return_depth(val):
-            return -1 if s not in val else _find_depth(val)
+            return -1 if not val.startswith(s) else _find_depth(val)
 
         return list(map(return_depth, data))
 
@@ -262,7 +264,7 @@ def pattern_match(data, values, level=None, regexp=False, has_nan=True):
 
     for s in values:
         if isstr(s):
-            pattern = re.compile(_escape_regexp(s) if not regexp else s)
+            pattern = re.compile(_escape_regexp(s) + '$' if not regexp else s)
             subset = filter(pattern.match, _data)
             depth = True if level is None else find_depth(_data, s, level)
             matches |= (_data.isin(subset) & depth)
@@ -282,7 +284,7 @@ def _escape_regexp(s):
         .replace('(', '\(')
         .replace(')', '\)')
         .replace('$', '\\$')
-    ) + "$"
+    )
 
 
 def years_match(data, years):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,7 +176,7 @@ def test_variable_unit(test_df):
     npt.assert_array_equal(test_df.variables(include_units=True), exp)
 
 
-def test_variable_variable_and_depth(test_df):
+def test_filter_variable_and_depth(test_df):
     obs = list(test_df.filter(variable='*rimary*C*', level=0).variables())
     exp = ['Primary Energy|Coal']
     assert obs == exp
@@ -185,44 +185,8 @@ def test_variable_variable_and_depth(test_df):
     assert len(obs) == 0
 
 
-def test_variable_depth_0(test_df):
-    obs = list(test_df.filter(level=0)['variable'].unique())
-    exp = ['Primary Energy']
-    assert obs == exp
-
-
 def test_variable_depth_0_keep_false(test_df):
     obs = list(test_df.filter(level=0, keep=False)['variable'].unique())
-    exp = ['Primary Energy|Coal']
-    assert obs == exp
-
-
-def test_variable_depth_0_minus(test_df):
-    obs = list(test_df.filter(level='0-')['variable'].unique())
-    exp = ['Primary Energy']
-    assert obs == exp
-
-
-def test_variable_depth_0_plus(test_df):
-    obs = list(test_df.filter(level='0+')['variable'].unique())
-    exp = ['Primary Energy', 'Primary Energy|Coal']
-    assert obs == exp
-
-
-def test_variable_depth_1(test_df):
-    obs = list(test_df.filter(level=1)['variable'].unique())
-    exp = ['Primary Energy|Coal']
-    assert obs == exp
-
-
-def test_variable_depth_1_minus(test_df):
-    obs = list(test_df.filter(level='1-')['variable'].unique())
-    exp = ['Primary Energy', 'Primary Energy|Coal']
-    assert obs == exp
-
-
-def test_variable_depth_1_plus(test_df):
-    obs = list(test_df.filter(level='1+')['variable'].unique())
     exp = ['Primary Energy|Coal']
     assert obs == exp
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,6 +176,15 @@ def test_variable_unit(test_df):
     npt.assert_array_equal(test_df.variables(include_units=True), exp)
 
 
+def test_variable_variable_and_depth(test_df):
+    obs = list(test_df.filter(variable='*rimary*C*', level=0).variables())
+    exp = ['Primary Energy|Coal']
+    assert obs == exp
+
+    obs = list(test_df.filter(variable='*rimary*C*', level=1).variables())
+    assert len(obs) == 0
+
+
 def test_variable_depth_0(test_df):
     obs = list(test_df.filter(level=0)['variable'].unique())
     exp = ['Primary Energy']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,5 +124,5 @@ def test_find_depth(test_df):
 def test_find_depth_with_str(test_df):
     data = pd.Series(['foo', 'foo|bar|baz', 'bar|baz', 'bar|baz|foo'])
     obs = utils.find_depth(data, 'bar')
-    exp = [-1, -1, 1, 2]
+    exp = [None, None, 1, 2]
     assert obs == exp

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,7 +112,7 @@ def test_find_depth(test_df):
 
 
 def test_find_depth_with_str(test_df):
-    data = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
-    obs = utils.find_depth(data, 'foo|b')
-    exp = [-1, 0, 1]
+    data = pd.Series(['foo', 'foo|bar|baz', 'bar|baz', 'bar|baz|foo'])
+    obs = utils.find_depth(data, 'bar')
+    exp = [-1, -1, 1, 2]
     assert obs == exp

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,15 +3,15 @@ import numpy as np
 
 from pyam import utils
 
+TEST_VARS = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
+
 
 def test_pattern_match_none():
     data = pd.Series(['foo', 'bar'])
     values = ['baz']
 
     obs = utils.pattern_match(data, values)
-    exp = [False, False]
-
-    assert (obs == exp).all()
+    assert (obs == [False, False]).all()
 
 
 def test_pattern_match_nan():
@@ -19,9 +19,7 @@ def test_pattern_match_nan():
     values = ['baz']
 
     obs = utils.pattern_match(data, values)
-    exp = [False, False]
-
-    assert (obs == exp).all()
+    assert (obs == [False, False]).all()
 
 
 def test_pattern_match_one():
@@ -29,9 +27,7 @@ def test_pattern_match_one():
     values = ['foo']
 
     obs = utils.pattern_match(data, values)
-    exp = [True, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, False]).all()
 
 
 def test_pattern_match_str_regex():
@@ -39,9 +35,7 @@ def test_pattern_match_str_regex():
     values = ['foo']
 
     obs = utils.pattern_match(data, values)
-    exp = [True, False, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, False, False]).all()
 
 
 def test_pattern_match_ast_regex():
@@ -49,9 +43,7 @@ def test_pattern_match_ast_regex():
     values = ['foo*']
 
     obs = utils.pattern_match(data, values)
-    exp = [True, True, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, True, False]).all()
 
 
 def test_pattern_match_ast2_regex():
@@ -59,9 +51,7 @@ def test_pattern_match_ast2_regex():
     values = ['*o*b*']
 
     obs = utils.pattern_match(data, values)
-    exp = [True, False, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, False, False]).all()
 
 
 def test_pattern_match_plus():
@@ -69,9 +59,7 @@ def test_pattern_match_plus():
     values = ['*+*']
 
     obs = utils.pattern_match(data, values)
-    exp = [False, True, True, True]
-
-    assert (obs == exp).all()
+    assert (obs == [False, True, True, True]).all()
 
 
 def test_pattern_match_dot():
@@ -79,9 +67,7 @@ def test_pattern_match_dot():
     values = ['fo.']
 
     obs = utils.pattern_match(data, values)
-    exp = [False, True]
-
-    assert (obs == exp).all()
+    assert (obs == [False, True]).all()
 
 
 def test_pattern_match_brackets():
@@ -89,9 +75,7 @@ def test_pattern_match_brackets():
     values = ['foo (bar)']
 
     obs = utils.pattern_match(data, values)
-    exp = [True, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, False]).all()
 
 
 def test_pattern_match_dollar():
@@ -99,9 +83,7 @@ def test_pattern_match_dollar():
     values = ['foo$bar']
 
     obs = utils.pattern_match(data, values)
-    exp = [True, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, False]).all()
 
 
 def test_pattern_regexp():
@@ -109,20 +91,22 @@ def test_pattern_regexp():
     values = ['fo.$']
 
     obs = utils.pattern_match(data, values, regexp=True)
-    exp = [True, True, False]
-
-    assert (obs == exp).all()
+    assert (obs == [True, True, False]).all()
 
 
-def test_find_depth(test_df):
-    data = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
-    obs = utils.find_depth(data)
-    exp = [0, 1, 2]
-    assert obs == exp
+def test_find_depth():
+    obs = utils.find_depth(TEST_VARS)
+    assert obs == [0, 1, 2]
 
 
-def test_find_depth_with_str(test_df):
+def test_find_depth_with_str():
     data = pd.Series(['foo', 'foo|bar|baz', 'bar|baz', 'bar|baz|foo'])
     obs = utils.find_depth(data, 'bar')
-    exp = [None, None, 1, 2]
-    assert obs == exp
+    assert obs == [None, None, 1, 2]
+
+
+def test_find_depth_with_str_0():
+    data = pd.Series(['foo', 'foo|bar|baz', 'bar|baz', 'bar|baz|foo'])
+    obs = utils.find_depth(data, 'bar|', 1)
+    assert obs == [False, False, False, True]
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,3 +109,10 @@ def test_find_depth(test_df):
     obs = utils.find_depth(data)
     exp = [0, 1, 2]
     assert obs == exp
+
+
+def test_find_depth_with_str(test_df):
+    data = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
+    obs = utils.find_depth(data, 'foo|b')
+    exp = [-1, 0, 1]
+    assert obs == exp

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,10 +105,16 @@ def test_find_depth_with_str():
     assert obs == [None, None, 1, 2]
 
 
-def test_find_depth_with_str_0():
+def test_find_depth_with_str_1():
     data = pd.Series(['foo', 'foo|bar|baz', 'bar|baz', 'bar|baz|foo'])
     obs = utils.find_depth(data, 'bar|', 1)
     assert obs == [False, False, False, True]
+
+
+def test_find_depth_with_str_0():
+    data = pd.Series(['foo', 'foo|bar|baz', 'bar|baz', 'bar|baz|foo'])
+    obs = utils.find_depth(data, '*bar|', 0)
+    assert obs == [False, True, True, False]
 
 
 def test_find_depth_0():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,6 +54,16 @@ def test_pattern_match_ast_regex():
     assert (obs == exp).all()
 
 
+def test_pattern_match_ast2_regex():
+    data = pd.Series(['foo|bar', 'foo', 'bar'])
+    values = ['*o*b*']
+
+    obs = utils.pattern_match(data, values)
+    exp = [True, False, False]
+
+    assert (obs == exp).all()
+
+
 def test_pattern_match_plus():
     data = pd.Series(['foo', 'foo+', '+bar', 'b+az'])
     values = ['*+*']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,3 +110,32 @@ def test_find_depth_with_str_0():
     obs = utils.find_depth(data, 'bar|', 1)
     assert obs == [False, False, False, True]
 
+
+def test_find_depth_0():
+    obs = utils.find_depth(TEST_VARS, level=0)
+    assert obs == [True, False, False]
+
+
+def test_find_depth_0_minus():
+    obs = utils.find_depth(TEST_VARS, level='0-')
+    assert obs == [True, False, False]
+
+
+def test_find_depth_0_plus():
+    obs = utils.find_depth(TEST_VARS, level='0+')
+    assert obs == [True, True, True]
+
+
+def test_find_depth_1():
+    obs = utils.find_depth(TEST_VARS, level=1)
+    assert obs == [False, True, False]
+
+
+def test_find_depth_1_minus():
+    obs = utils.find_depth(TEST_VARS, level='1-')
+    assert obs == [True, True, False]
+
+
+def test_find_depth_1_plus():
+    obs = utils.find_depth(TEST_VARS, level='1+')
+    assert obs == [False, True, True]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,3 +102,10 @@ def test_pattern_regexp():
     exp = [True, True, False]
 
     assert (obs == exp).all()
+
+
+def test_find_depth(test_df):
+    data = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
+    obs = utils.find_depth(data)
+    exp = [0, 1, 2]
+    assert obs == exp


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR extends the function `utils.find_depth()` to return the depth (as integers) if no test assertion using `level` is given.