### PR TITLE
WIP: Filling out data with pyam defaults

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1524,12 +1524,13 @@ def df_to_pyam(df, **kwargs):
 
     def _apply_defaults(df, defaults):
         for col, val in defaults.items():
-            df[col] = val
+            if col not in df:
+                df[col] = val
         return df
 
     # maybe only needed if variable is missing?
-    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
-    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
+    cols = list(set(df.columns) - set(GROUP_IDX))
+    idx = list(set(df.columns) & set(GROUP_IDX))
     df = df.set_index(idx)
     dfs = []
     for col in cols:
@@ -1538,4 +1539,4 @@ def df_to_pyam(df, **kwargs):
         dfs.append(_df.reset_index())
     df = pd.concat(dfs)
     df = _apply_defaults(df, defaults)
-    return pyam.IamDataFrame(df)
+    return IamDataFrame(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1507,7 +1507,10 @@ def concat(dfs):
     _df = None
     for df in dfs:
         if not isinstance(df, IamDataFrame):
-            raise TypeError('Input contains non-`pyam.IamDataFrame`')
+            try:
+                df = IamDataFrame(df)
+            except:
+                raise TypeError('Could not cast {} to IamDataFrame'.format(df))
         if _df is None:
             _df = copy.deepcopy(df)
         else:
@@ -1528,7 +1531,11 @@ def df_to_pyam(df, **kwargs):
                 df[col] = val
         return df
 
-    # maybe only needed if variable is missing?
+    # only need to fill in defaults
+    if 'variable' in df.columns:
+        return IamDataFrame(_apply_defaults(df, defaults))
+    
+    # variables are in columns and melt operation needed
     cols = list(set(df.columns) - set(GROUP_IDX))
     idx = list(set(df.columns) & set(GROUP_IDX))
     df = df.set_index(idx)
@@ -1539,4 +1546,5 @@ def df_to_pyam(df, **kwargs):
         dfs.append(_df.reset_index())
     df = pd.concat(dfs)
     df = _apply_defaults(df, defaults)
-    return IamDataFrame(df)
+    return IamDataFrame(_apply_defaults(df, defaults))
+    

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1534,7 +1534,7 @@ def df_to_pyam(df, **kwargs):
     # only need to fill in defaults
     if 'variable' in df.columns:
         return IamDataFrame(_apply_defaults(df, defaults))
-    
+
     # variables are in columns and melt operation needed
     cols = list(set(df.columns) - set(GROUP_IDX))
     idx = list(set(df.columns) & set(GROUP_IDX))
@@ -1547,4 +1547,3 @@ def df_to_pyam(df, **kwargs):
     df = pd.concat(dfs)
     df = _apply_defaults(df, defaults)
     return IamDataFrame(_apply_defaults(df, defaults))
-    

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1513,3 +1513,29 @@ def concat(dfs):
         else:
             _df.append(df, inplace=True)
     return _df
+
+
+def df_to_pyam(df, **kwargs):
+    numeric_cols = ['year']
+    defaults = {
+        x: x if x not in numeric_cols else 0 for x in GROUP_IDX
+    }
+    defaults.update(kwargs)
+
+    def _apply_defaults(df, defaults):
+        for col, val in defaults.items():
+            df[col] = val
+        return df
+
+    # maybe only needed if variable is missing?
+    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
+    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
+    df = df.set_index(idx)
+    dfs = []
+    for col in cols:
+        _df = df[col].to_frame().rename(columns={col: 'value'})
+        _df['variable'] = col
+        dfs.append(_df.reset_index())
+    df = pd.concat(dfs)
+    df = _apply_defaults(df, defaults)
+    return pyam.IamDataFrame(df)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -395,29 +395,3 @@ def to_int(x, index=False):
         return x
     else:
         return _x
-
-
-def df_to_pyam(df, **kwargs):
-    numeric_cols = ['year']
-    defaults = {
-        x: x if x not in numeric_cols else 0 for x in pyam.utils.GROUP_IDX
-    }
-    defaults.update(kwargs)
-
-    def _apply_defaults(df, defaults):
-        for col, val in defaults.items():
-            df[col] = val
-        return df
-
-    # maybe only needed if variable is missing?
-    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
-    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
-    df = df.set_index(idx)
-    dfs = []
-    for col in cols:
-        _df = df[col].to_frame().rename(columns={col: 'value'})
-        _df['variable'] = col
-        dfs.append(_df.reset_index())
-    df = pd.concat(dfs)
-    df = _apply_defaults(df, defaults)
-    return pyam.IamDataFrame(df)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -395,3 +395,29 @@ def to_int(x, index=False):
         return x
     else:
         return _x
+
+
+def df_to_pyam(df, **kwargs):
+    numeric_cols = ['year']
+    defaults = {
+        x: x if x not in numeric_cols else 0 for x in pyam.utils.GROUP_IDX
+    }
+    defaults.update(kwargs)
+
+    def _apply_defaults(df, defaults):
+        for col, val in defaults.items():
+            df[col] = val
+        return df
+
+    # maybe only needed if variable is missing?
+    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
+    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
+    df = df.set_index(idx)
+    dfs = []
+    for col in cols:
+        _df = df[col].to_frame().rename(columns={col: 'value'})
+        _df['variable'] = col
+        dfs.append(_df.reset_index())
+    df = pd.concat(dfs)
+    df = _apply_defaults(df, defaults)
+    return pyam.IamDataFrame(df)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

# Description of PR

The idea here is to provide a method that takes a pandas dataframe (currently assumed to be in so-called long-format) with additional observations as columns and pivot them into a 'variable' column. Then other required pyam defaults are added and a `pyam.IamDataFrame` is returned.

Tests etc to come.

@danielhuppmann maybe worth taking a look now, just to make sure this basically jives with what you also have been working on?
