### PR TITLE
Bugfix for filtering by `time` and `year`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#195](https://github.com/IAMconsortium/pyam/pull/195) Fix filtering for `time`, `day` and `hour` to use generic `pattern_match()` (if such a column exists) in 'year'-formmatted IamDataFrames
 - [#192](https://github.com/IAMconsortium/pyam/pull/192) Extend `utils.find_depth()` to optionally return depth (as list of ints) rather than assert level tests
 - [#190](https://github.com/IAMconsortium/pyam/pull/190) Add `concat()` function
 - [#189](https://github.com/IAMconsortium/pyam/pull/189) Fix over-zealous `dropna()` in `scatter()`

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -896,16 +896,12 @@ class IamDataFrame(object):
                     else self.data['time'].apply(lambda x: x.year)
                 keep_col = years_match(_data, values)
 
-            elif col == 'month':
-                if self.time_col is not 'time':
-                    _raise_filter_error(col)
+            elif col == 'month' and self.time_col is 'time':
                 keep_col = month_match(self.data['time']
                                            .apply(lambda x: x.month),
                                        values)
 
-            elif col == 'day':
-                if self.time_col is not 'time':
-                    _raise_filter_error(col)
+            elif col == 'day' and self.time_col is 'time':
                 if isinstance(values, str):
                     wday = True
                 elif isinstance(values, list) and isinstance(values[0], str):
@@ -920,14 +916,12 @@ class IamDataFrame(object):
 
                 keep_col = day_match(days, values)
 
-            elif col == 'hour':
-                if self.time_col is not 'time':
-                    _raise_filter_error(col)
+            elif col == 'hour' and self.time_col is 'time':
                 keep_col = hour_match(self.data['time']
                                           .apply(lambda x: x.hour),
                                       values)
 
-            elif col == 'time':
+            elif col == 'time' and self.time_col is 'time':
                 keep_col = datetime_match(self.data[col], values)
 
             elif col == 'level':

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -892,12 +892,9 @@ class IamDataFrame(object):
                 keep_col = pattern_match(self.data[col], values, level, regexp)
 
             elif col == 'year':
-                if self.time_col is 'time':
-                    keep_col = years_match(self.data['time']
-                                               .apply(lambda x: x.year),
-                                           values)
-                else:
-                    keep_col = years_match(self.data[col], values)
+                _data = self.data[col] if self.time_col is not 'time' \
+                    else self.data['time'].apply(lambda x: x.year)
+                keep_col = years_match(_data, values)
 
             elif col == 'month':
                 if self.time_col is not 'time':

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -371,10 +371,10 @@ def datetime_match(data, dts):
     """
     matching of datetimes in time columns for data filtering
     """
-    dts = [dts] if isinstance(dts, datetime.datetime) else dts
-    if isinstance(dts, int) or isinstance(dts[0], int):
+    dts = dts if islistable(dts) else [dts]
+    if any([not isinstance(i, datetime.datetime) for i in dts]):
         error_msg = (
-            "`time` can only be filtered with datetimes or lists of datetimes"
+            "`time` can only be filtered by datetimes"
         )
         raise TypeError(error_msg)
     return data.isin(dts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,7 +175,7 @@ def test_df_year():
 
 @pytest.fixture(scope="function")
 def test_pd_df():
-    yield TEST_DF
+    yield TEST_DF.copy()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -396,7 +396,7 @@ def test_filter_time_not_datetime_error(test_df):
             test_df.filter(time=datetime.datetime(2004, 6, 18))
     else:
         error_msg = re.escape(
-            "`time` can only be filtered with datetimes or lists of datetimes"
+            "`time` can only be filtered by datetimes"
         )
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(time=2005)
@@ -410,7 +410,7 @@ def test_filter_time_not_datetime_range_error(test_df):
             test_df.filter(time=range(2000, 2008))
     else:
         error_msg = re.escape(
-            "`time` can only be filtered with datetimes or lists of datetimes"
+            "`time` can only be filtered by datetimes"
         )
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(time=range(2000, 2008))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -392,7 +392,7 @@ def test_filter_time_no_match(test_df):
 
 def test_filter_time_not_datetime_error(test_df):
     if "year" in test_df.data.columns:
-        with pytest.raises(KeyError, match=re.escape("'time")):
+        with pytest.raises(ValueError, match=re.escape("`time`")):
             test_df.filter(time=datetime.datetime(2004, 6, 18))
     else:
         error_msg = re.escape(
@@ -406,7 +406,7 @@ def test_filter_time_not_datetime_error(test_df):
 
 def test_filter_time_not_datetime_range_error(test_df):
     if "year" in test_df.data.columns:
-        with pytest.raises(KeyError, match=re.escape("'time")):
+        with pytest.raises(ValueError, match=re.escape("`time`")):
             test_df.filter(time=range(2000, 2008))
     else:
         error_msg = re.escape(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -419,13 +419,13 @@ def test_filter_time_not_datetime_range_error(test_df):
 
 
 def test_filter_year_with_time_col(test_pd_df):
-    test_pd_df['time'] = 'summer'
+    test_pd_df['time'] = ['summer', 'summer', 'winter']
     df = IamDataFrame(test_pd_df)
     obs = df.filter(time='summer').timeseries()
 
     exp = test_pd_df.set_index(IAMC_IDX + ['time'])
     exp.columns = list(map(int, exp.columns))
-    pd.testing.assert_frame_equal(obs, exp)
+    pd.testing.assert_frame_equal(obs, exp[0:2])
 
 
 def test_filter_as_kwarg(meta_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import pandas as pd
 from numpy import testing as npt
 
 from pyam import IamDataFrame, validate, categorize, \
-    require_variable, filter_by_meta, META_IDX
+    require_variable, filter_by_meta, META_IDX, IAMC_IDX
 from pyam.core import _meta_idx, concat
 
 from conftest import TEST_DATA_DIR
@@ -416,6 +416,16 @@ def test_filter_time_not_datetime_range_error(test_df):
             test_df.filter(time=range(2000, 2008))
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(time=['summer', 'winter'])
+
+
+def test_filter_year_with_time_col(test_pd_df):
+    test_pd_df['time'] = 'summer'
+    df = IamDataFrame(test_pd_df)
+    obs = df.filter(time='summer').timeseries()
+
+    exp = test_pd_df.set_index(IAMC_IDX + ['time'])
+    exp.columns = list(map(int, exp.columns))
+    pd.testing.assert_frame_equal(obs, exp)
 
 
 def test_filter_as_kwarg(meta_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -400,6 +400,8 @@ def test_filter_time_not_datetime_error(test_df):
         )
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(time=2005)
+        with pytest.raises(TypeError, match=error_msg):
+            test_df.filter(time='summer')
 
 
 def test_filter_time_not_datetime_range_error(test_df):
@@ -412,6 +414,8 @@ def test_filter_time_not_datetime_range_error(test_df):
         )
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(time=range(2000, 2008))
+        with pytest.raises(TypeError, match=error_msg):
+            test_df.filter(time=['summer', 'winter'])
 
 
 def test_filter_as_kwarg(meta_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR fixes two issues when using an `IamDataFrame` with the `year` format (i.e., column `year` with integers) and adding a new column `time` for sub-annual (non-continuous) timeslices (e.g., 'summer', 'winter'). My expectation was that if `df.time_col = 'year'`, an extra column `time` can be filtered using the generic `pattern_match()` function.

 - [x] *Issue 1*: The type-assertion in `time_match()` only raised an error message when receiving an integer, not for any non-datetime type.
 - [x] *Issue 2*: When `df.time_col = 'year'`, filtering by `month`, `hour` or `time` always raised an error (implemented in the respective part of the if-else-statement), even if an additional column with that name exists in `df.data`. The PR changes that behaviour for a non-datetime-formatted `IamDataFrame` to check if a column exists and use the generic `pattern_match()` (or raise an error if it doesn't exist).
