### PR TITLE
[TEST] Trying to relax ci install reqs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,6 @@ build: false
 
 test_script:
   - pip install -e .[tests]
-  # pyam currently does not support pandas 0.24.0
-  # this is specified in requirements.py, but AppVeyor seems to ignore that
-  - pip install pandas==0.23.4
   - pytest -v --mpl tests --mpl-results-path=test-artifacts
 
 artifacts:

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -23,10 +23,10 @@ conda create -n testing python=$PYVERSION --yes
 # install deps, specific versions are used to guarantee consistency with
 # plotting tests
 conda install -n testing --yes \
-      numpy \
+      numpy==1.14.0 \
       pandas \
-      matplotlib \
-      seaborn \
+      matplotlib==2.1.2 \
+      seaborn==0.8.1 \
       six \
       pyyaml \
       xlrd \

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -24,7 +24,7 @@ conda create -n testing python=$PYVERSION --yes
 # plotting tests
 conda install -n testing --yes \
       numpy==1.14.0 \
-      pandas \
+      pandas==0.22.0 \
       matplotlib==2.1.2 \
       seaborn==0.8.1 \
       six \

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -23,10 +23,10 @@ conda create -n testing python=$PYVERSION --yes
 # install deps, specific versions are used to guarantee consistency with
 # plotting tests
 conda install -n testing --yes \
-      numpy==1.14.0 \
-      pandas==0.22.0 \
-      matplotlib==2.1.2 \
-      seaborn==0.8.1 \
+      numpy \
+      pandas \
+      matplotlib \
+      seaborn \
       six \
       pyyaml \
       xlrd \

--- a/requirements.py
+++ b/requirements.py
@@ -2,7 +2,7 @@ install_requirements = [
     "argparse",
     "numpy",
     "requests",
-    "pandas>=0.21.0, <=0.23.4",
+    "pandas>=0.21.0",
     "PyYAML",
     "xlrd",
     "xlsxwriter",


### PR DESCRIPTION
Here I am testing the issues with pandas>24, which have been observed on windows, but not linux thus far.