### PR TITLE
Initialize an `IamDataFrame` from `pd.DataFrame` with formatting specs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#199](https://github.com/IAMconsortium/pyam/pull/199) Initializing an `IamDataFrame` accepts kwargs to fill or create from the data any missing required columns
 - [#195](https://github.com/IAMconsortium/pyam/pull/195) Fix filtering for `time`, `day` and `hour` to use generic `pattern_match()` (if such a column exists) in 'year'-formmatted IamDataFrames
 - [#192](https://github.com/IAMconsortium/pyam/pull/192) Extend `utils.find_depth()` to optionally return depth (as list of ints) rather than assert level tests
 - [#190](https://github.com/IAMconsortium/pyam/pull/190) Add `concat()` function

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -26,6 +26,7 @@ from pyam.utils import (
     sort_data,
     to_int,
     find_depth,
+    concat_with_pipe,
     pattern_match,
     years_match,
     month_match,
@@ -1524,11 +1525,17 @@ def df_to_pyam(df, **kwargs):
         the data to be cast to an `IamDataFrame`
     value: str or list, must be columns of `df`
         use data in these columns as `value`, use column name as `variable`
+    kwargs
+        mapping of column required for an `IamDataFrame` to
+        - one column in `df`
+        - multiple columns, which will be concatenated by pipe
+        - a string to be used as value for this column
     """
     # ensure that only either `value` or `variable` custom setting is used
     if all([i in kwargs or i in df.columns for i in ['value', 'variable']]):
         raise ValueError('using both `value` and `variable` is not valid!')
 
+    # if `value` arg is given, melt columns and use column name as `variable`
     if 'value' in kwargs:
         value = kwargs.pop('value')
         idx = set(df.columns) & (set(IAMC_IDX) | set(['year', 'time']))
@@ -1543,10 +1550,19 @@ def df_to_pyam(df, **kwargs):
             dfs.append(vdf.reset_index())
         df = pd.concat(dfs).reset_index(drop=True)
 
+    # for other columns, do a rename or concat multiple columns to IAMC-style
     for col, value in kwargs.items():
         if col in df:
             raise ValueError('conflict of kwarg with column in dataframe!')
+
         if isstr(value) and value in df:
             df.rename(columns={value: col}, inplace=True)
-
+        elif islistable(value) and all([c in df.columns for c in value]):
+            df[col] = df.apply(lambda x: concat_with_pipe(x, value), axis=1)
+            df.drop(value, axis=1, inplace=True)
+        elif isstr(value):
+            df[col] = value
+        else:
+            raise ValueError('invalid argument for casting `{}: {}`'
+                             .format(col, value))
     return IamDataFrame(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -26,7 +26,6 @@ from pyam.utils import (
     sort_data,
     to_int,
     find_depth,
-    concat_with_pipe,
     pattern_match,
     years_match,
     month_match,
@@ -40,7 +39,6 @@ from pyam.utils import (
     REGION_IDX,
     IAMC_IDX,
     SORT_IDX,
-    LONG_IDX,
     GROUP_IDX
 )
 from pyam.read_ixmp import read_ix
@@ -182,6 +180,7 @@ class IamDataFrame(object):
             any meta columns present in `self` and `other` are not identical.
         inplace : bool, default False
             If True, do operation inplace and return None
+        kwargs are passed through to `IamDataFrame(other, **kwargs)`
         """
         if not isinstance(other, IamDataFrame):
             other = IamDataFrame(other, **kwargs)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1524,12 +1524,13 @@ def df_to_pyam(df, **kwargs):
 
     def _apply_defaults(df, defaults):
         for col, val in defaults.items():
-            df[col] = val
+            if col not in df:
+                df[col] = val
         return df
 
     # maybe only needed if variable is missing?
-    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
-    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
+    cols = list(set(df.columns) - set(GROUP_IDX))
+    idx = list(set(df.columns) & set(GROUP_IDX))
     df = df.set_index(idx)
     dfs = []
     for col in cols:
@@ -1538,4 +1539,4 @@ def df_to_pyam(df, **kwargs):
         dfs.append(_df.reset_index())
     df = pd.concat(dfs)
     df = _apply_defaults(df, defaults)
-    return pyam.IamDataFrame(df)
+    return IamDataFrame(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1516,21 +1516,15 @@ def concat(dfs):
 
 
 def df_to_pyam(df, **kwargs):
-    numeric_cols = ['year']
-    defaults = {
-        x: x if x not in numeric_cols else 0 for x in IAMC_IDX
-    }
-    defaults.update(kwargs)
-
-    def _apply_defaults(df, defaults):
-        for col, val in defaults.items():
+    def _apply_defaults(df, kwargs):
+        for col, val in kwargs.items():
             if col not in df:
                 df[col] = val
         return df
 
     # only need to fill in defaults
     if 'variable' in df.columns:
-        return IamDataFrame(_apply_defaults(df, defaults))
+        return IamDataFrame(_apply_defaults(df, kwargs))
 
     # variables are in columns and melt operation needed
     cols = list(set(df.columns) - set(GROUP_IDX))
@@ -1541,5 +1535,4 @@ def df_to_pyam(df, **kwargs):
         _df = df[col].to_frame().rename(columns={col: 'value'})
         _df['variable'] = col
         dfs.append(_df)
-    return IamDataFrame(_apply_defaults(pd.concat(dfs).reset_index(),
-                                        defaults))
+    return IamDataFrame(_apply_defaults(pd.concat(dfs).reset_index(), kwargs))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1507,7 +1507,10 @@ def concat(dfs):
     _df = None
     for df in dfs:
         if not isinstance(df, IamDataFrame):
-            raise TypeError('Input contains non-`pyam.IamDataFrame`')
+            try:
+                df = IamDataFrame(df)
+            except:
+                raise TypeError('Could not cast {} to IamDataFrame'.format(df))
         if _df is None:
             _df = copy.deepcopy(df)
         else:
@@ -1528,7 +1531,11 @@ def df_to_pyam(df, **kwargs):
                 df[col] = val
         return df
 
-    # maybe only needed if variable is missing?
+    # only need to fill in defaults
+    if 'variable' in df.columns:
+        return IamDataFrame(_apply_defaults(df, defaults))
+    
+    # variables are in columns and melt operation needed
     cols = list(set(df.columns) - set(GROUP_IDX))
     idx = list(set(df.columns) & set(GROUP_IDX))
     df = df.set_index(idx)
@@ -1539,4 +1546,5 @@ def df_to_pyam(df, **kwargs):
         dfs.append(_df.reset_index())
     df = pd.concat(dfs)
     df = _apply_defaults(df, defaults)
-    return IamDataFrame(df)
+    return IamDataFrame(_apply_defaults(df, defaults))
+    

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1534,7 +1534,7 @@ def df_to_pyam(df, **kwargs):
     # only need to fill in defaults
     if 'variable' in df.columns:
         return IamDataFrame(_apply_defaults(df, defaults))
-    
+
     # variables are in columns and melt operation needed
     cols = list(set(df.columns) - set(GROUP_IDX))
     idx = list(set(df.columns) & set(GROUP_IDX))
@@ -1547,4 +1547,3 @@ def df_to_pyam(df, **kwargs):
     df = pd.concat(dfs)
     df = _apply_defaults(df, defaults)
     return IamDataFrame(_apply_defaults(df, defaults))
-    

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1513,3 +1513,29 @@ def concat(dfs):
         else:
             _df.append(df, inplace=True)
     return _df
+
+
+def df_to_pyam(df, **kwargs):
+    numeric_cols = ['year']
+    defaults = {
+        x: x if x not in numeric_cols else 0 for x in GROUP_IDX
+    }
+    defaults.update(kwargs)
+
+    def _apply_defaults(df, defaults):
+        for col, val in defaults.items():
+            df[col] = val
+        return df
+
+    # maybe only needed if variable is missing?
+    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
+    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
+    df = df.set_index(idx)
+    dfs = []
+    for col in cols:
+        _df = df[col].to_frame().rename(columns={col: 'value'})
+        _df['variable'] = col
+        dfs.append(_df.reset_index())
+    df = pd.concat(dfs)
+    df = _apply_defaults(df, defaults)
+    return pyam.IamDataFrame(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1540,7 +1540,6 @@ def df_to_pyam(df, **kwargs):
     for col in cols:
         _df = df[col].to_frame().rename(columns={col: 'value'})
         _df['variable'] = col
-        dfs.append(_df.reset_index())
-    df = pd.concat(dfs)
-    df = _apply_defaults(df, defaults)
+        dfs.append(_df)
+    df = _apply_defaults(pd.concat(dfs).reset_index(), defaults)
     return IamDataFrame(_apply_defaults(df, defaults))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1501,16 +1501,13 @@ def compare(left, right, left_label='left', right_label='right',
 
 def concat(dfs):
     """Concatenate a series of `pyam.IamDataFrame`-like objects together"""
-    if not hasattr(dfs, '__iter__'):
+    if isstr(dfs) or not hasattr(dfs, '__iter__'):
         raise TypeError('Input data must be iterable (e.g., list or tuple)')
 
     _df = None
     for df in dfs:
         if not isinstance(df, IamDataFrame):
-            try:
-                df = IamDataFrame(df)
-            except:
-                raise TypeError('Could not cast {} to IamDataFrame'.format(df))
+            df = IamDataFrame(df)
         if _df is None:
             _df = copy.deepcopy(df)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -23,6 +23,7 @@ from pyam.utils import (
     read_files,
     read_pandas,
     format_data,
+    sort_data,
     to_int,
     find_depth,
     pattern_match,
@@ -224,15 +225,14 @@ class IamDataFrame(object):
             ret.meta = ret.meta.append(other.meta.loc[diff, :], **sort_kwarg)
 
         # append other.data (verify integrity for no duplicates)
-        ret.data.set_index(ret._LONG_IDX, inplace=True)
-        _other = other.data.set_index(other._LONG_IDX)
-        ret.data = ret.data.append(_other, verify_integrity=True)\
-            .reset_index(drop=False)
+        _data = ret.data.set_index(ret._LONG_IDX).append(
+            other.data.set_index(other._LONG_IDX), verify_integrity=True)
 
         # merge extra columns in `data` and set `LONG_IDX`
         ret.extra_cols += [i for i in other.extra_cols
                            if i not in ret.extra_cols]
         ret._LONG_IDX = IAMC_IDX + [ret.time_col] + ret.extra_cols
+        ret.data = sort_data(_data.reset_index(), ret._LONG_IDX)
 
         if not inplace:
             return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1501,12 +1501,12 @@ def compare(left, right, left_label='left', right_label='right',
 def concat(dfs):
     """Concatenate a series of `pyam.IamDataFrame`-like objects together"""
     if isstr(dfs) or not hasattr(dfs, '__iter__'):
-        raise TypeError('Input data must be iterable (e.g., list or tuple)')
+        msg = 'Argument must be a non-string iterable (e.g., list or tuple)'
+        raise TypeError(msg)
 
     _df = None
     for df in dfs:
-        if not isinstance(df, IamDataFrame):
-            df = IamDataFrame(df)
+        df = df if isinstance(df, IamDataFrame) else IamDataFrame(df)
         if _df is None:
             _df = copy.deepcopy(df)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1546,5 +1546,7 @@ def df_to_pyam(df, **kwargs):
     for col, value in kwargs.items():
         if col in df:
             raise ValueError('conflict of kwarg with column in dataframe!')
+        if isstr(value) and value in df:
+            df.rename(columns={value: col}, inplace=True)
 
     return IamDataFrame(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1518,7 +1518,7 @@ def concat(dfs):
 def df_to_pyam(df, **kwargs):
     numeric_cols = ['year']
     defaults = {
-        x: x if x not in numeric_cols else 0 for x in GROUP_IDX
+        x: x if x not in numeric_cols else 0 for x in IAMC_IDX
     }
     defaults.update(kwargs)
 
@@ -1541,5 +1541,5 @@ def df_to_pyam(df, **kwargs):
         _df = df[col].to_frame().rename(columns={col: 'value'})
         _df['variable'] = col
         dfs.append(_df)
-    df = _apply_defaults(pd.concat(dfs).reset_index(), defaults)
-    return IamDataFrame(_apply_defaults(df, defaults))
+    return IamDataFrame(_apply_defaults(pd.concat(dfs).reset_index(),
+                                        defaults))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1543,4 +1543,8 @@ def df_to_pyam(df, **kwargs):
             dfs.append(vdf.reset_index())
         df = pd.concat(dfs).reset_index(drop=True)
 
+    for col, value in kwargs.items():
+        if col in df:
+            raise ValueError('conflict of kwarg with column in dataframe!')
+
     return IamDataFrame(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -20,7 +20,7 @@ from pyam.logger import logger
 from pyam.run_control import run_control
 from pyam.utils import (
     write_sheet,
-    read_files,
+    read_file,
     read_pandas,
     format_data,
     sort_data,
@@ -74,7 +74,7 @@ class IamDataFrame(object):
         elif has_ix and isinstance(data, ixmp.TimeSeries):
             _data = read_ix(data, **kwargs)
         else:
-            _data = read_files(data, **kwargs)
+            _data = read_file(data, **kwargs)
 
         self.data, self.time_col, self.extra_cols = _data
         # cast time_col to desired format

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -194,10 +194,13 @@ def format_data(df):
     # cast value columns to numeric, drop NaN's, sort data
     df['value'] = df['value'].astype('float64')
     df.dropna(inplace=True)
-    df.sort_values(META_IDX + ['variable', time_col, 'region'] + extra_cols,
-                   inplace=True)
 
-    return df, time_col, extra_cols
+    # check for duplicates and return sorted data
+    idx_cols = META_IDX + ['variable', time_col, 'region'] + extra_cols
+    if any(df[idx_cols].duplicated()):
+        raise ValueError('duplicate rows in `data`!')
+
+    return df.sort_values(idx_cols), time_col, extra_cols
 
 
 def style_df(df, style='heatmap'):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -395,29 +395,3 @@ def to_int(x, index=False):
         return x
     else:
         return _x
-
-
-def df_to_pyam(df, **kwargs):
-    numeric_cols = ['year']
-    defaults = {
-        x: x if x not in numeric_cols else 0 for x in pyam.utils.GROUP_IDX
-    }
-    defaults.update(kwargs)
-
-    def _apply_defaults(df, defaults):
-        for col, val in defaults.items():
-            df[col] = val
-        return df
-
-    # maybe only needed if variable is missing?
-    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
-    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
-    df = df.set_index(idx)
-    dfs = []
-    for col in cols:
-        _df = df[col].to_frame().rename(columns={col: 'value'})
-        _df['variable'] = col
-        dfs.append(_df.reset_index())
-    df = pd.concat(dfs)
-    df = _apply_defaults(df, defaults)
-    return pyam.IamDataFrame(df)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -121,6 +121,10 @@ def read_file(fname, *args, **kwargs):
                          'please use `pyam.IamDataFrame.append()`')
     logger().info('Reading `{}`'.format(fname))
     format_kwargs = {}
+    # extract kwargs that are intended for `format_data`
+    for c in [i for i in IAMC_IDX + ['year', 'time', 'value'] if i in kwargs]:
+        format_kwargs[c] = kwargs.pop(c)
+    return format_data(read_pandas(fname, *args, **kwargs), **format_kwargs)
 
 
 def format_data(df, **kwargs):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -440,8 +440,8 @@ def to_int(x, index=False):
 
 def concat_with_pipe(x, cols=None):
     """Concatenate a `pd.Series` separated by `|`, drop `None` or `np.nan`"""
-    return '|'.join([x[i] for i in cols or x.index
-                     if x[i] is not None and x[i] is not np.nan])
+    cols = cols or x.index
+    return '|'.join([x[i] for i in cols if x[i] not in [None, np.nan]])
 
 
 def reduce_hierarchy(x, depth):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -112,15 +112,15 @@ def read_pandas(fname, *args, **kwargs):
     return df
 
 
-def read_files(fnames, *args, **kwargs):
+def read_file(fname, *args, **kwargs):
     """Read data from a file saved in the standard IAMC format
     or a table with year/value columns
     """
-    if not isstr(fnames):
+    if not isstr(fname):
         raise ValueError('reading multiple files not supported, '
                          'please use `pyam.IamDataFrame.append()`')
-    logger().info('Reading `{}`'.format(fnames))
-    return format_data(read_pandas(fnames, *args, **kwargs))
+    logger().info('Reading `{}`'.format(fname))
+    format_kwargs = {}
 
 
 def format_data(df, **kwargs):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -398,5 +398,6 @@ def to_int(x, index=False):
 
 
 def concat_with_pipe(x, cols=None):
-    """Concatenate elements from `pd.Series` separated by `|`, drop `None`"""
-    return '|'.join([str(x[i]) for i in cols or x.index if x[i] is not None])
+    """Concatenate a `pd.Series` separated by `|`, drop `None` or `np.nan`"""
+    return '|'.join([x[i] for i in cols or x.index
+                     if x[i] is not None and x[i] is not np.nan])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -395,3 +395,29 @@ def to_int(x, index=False):
         return x
     else:
         return _x
+
+
+def df_to_pyam(df, **kwargs):
+    numeric_cols = ['year']
+    defaults = {
+        x: x if x not in numeric_cols else 0 for x in pyam.utils.GROUP_IDX
+    }
+    defaults.update(kwargs)
+
+    def _apply_defaults(df, defaults):
+        for col, val in defaults.items():
+            df[col] = val
+        return df
+
+    # maybe only needed if variable is missing?
+    cols = list(set(df.columns) - set(pyam.utils.LONG_IDX))
+    idx = list(set(df.columns) & set(pyam.utils.LONG_IDX))
+    df = df.set_index(idx)
+    dfs = []
+    for col in cols:
+        _df = df[col].to_frame().rename(columns={col: 'value'})
+        _df['variable'] = col
+        dfs.append(_df.reset_index())
+    df = pd.concat(dfs)
+    df = _apply_defaults(df, defaults)
+    return pyam.IamDataFrame(df)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -398,5 +398,5 @@ def to_int(x, index=False):
 
 
 def concat_with_pipe(x, cols=None):
-    """Concatenate elements from `pd.Series` separated by `|`"""
-    return '|'.join([x[i] for i in cols or x.index if x[i] is not None])
+    """Concatenate elements from `pd.Series` separated by `|`, drop `None`"""
+    return '|'.join([str(x[i]) for i in cols or x.index if x[i] is not None])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -113,7 +113,7 @@ def read_pandas(fname, *args, **kwargs):
 
 
 def read_files(fnames, *args, **kwargs):
-    """Read data from a snapshot file saved in the standard IAMC format
+    """Read data from a file saved in the standard IAMC format
     or a table with year/value columns
     """
     if not isstr(fnames):
@@ -124,7 +124,7 @@ def read_files(fnames, *args, **kwargs):
 
 
 def format_data(df):
-    """Convert an imported dataframe and check all required columns"""
+    """Convert a `pd.Dataframe` or `pd.Series` to the required format"""
     if isinstance(df, pd.Series):
         df = df.to_frame()
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -401,3 +401,10 @@ def concat_with_pipe(x, cols=None):
     """Concatenate a `pd.Series` separated by `|`, drop `None` or `np.nan`"""
     return '|'.join([x[i] for i in cols or x.index
                      if x[i] is not None and x[i] is not np.nan])
+
+
+def reduce_hierarchy(x, depth):
+    """Reduce the hierarchy (depth by `|`) string to the specified level"""
+    _x = x.split('|')
+    depth = len(_x) + depth - 1 if depth < 0 else depth
+    return '|'.join(_x[0:(depth + 1)])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -395,3 +395,8 @@ def to_int(x, index=False):
         return x
     else:
         return _x
+
+
+def concat_with_pipe(x, cols=None):
+    """Concatenate elements from `pd.Series` separated by `|`"""
+    return '|'.join([x[i] for i in cols or x.index if x[i] is not None])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -157,9 +157,9 @@ def format_data(df):
     if 'value' in df.columns:
         # check if time column is given as `year` (int) or `time` (datetime)
         cols = df.columns
-        if 'year' in cols and 'time' not in cols:
+        if 'year' in cols:
             time_col = 'year'
-        elif 'time' in cols and 'year' not in cols:
+        elif 'time' in cols:
             time_col = 'time'
         else:
             msg = 'invalid time format, must have either `year` or `time`!'

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -203,14 +203,6 @@ def format_data(df):
     return df.sort_values(idx_cols), time_col, extra_cols
 
 
-def style_df(df, style='heatmap'):
-    if style == 'highlight_not_max':
-        return df.style.apply(lambda s: ['' if v else 'background-color: yellow' for v in s == s.max()])
-    if style == 'heatmap':
-        cm = sns.light_palette("green", as_cmap=True)
-        return df.style.background_gradient(cmap=cm)
-
-
 def find_depth(data, s='', level=None):
     """
     return or assert the depth (number of `|`) of variables

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -196,11 +196,16 @@ def format_data(df):
     df.dropna(inplace=True)
 
     # check for duplicates and return sorted data
-    idx_cols = META_IDX + ['variable', time_col, 'region'] + extra_cols
+    idx_cols = IAMC_IDX + [time_col] + extra_cols
     if any(df[idx_cols].duplicated()):
         raise ValueError('duplicate rows in `data`!')
 
-    return df.sort_values(idx_cols), time_col, extra_cols
+    return sort_data(df, idx_cols), time_col, extra_cols
+
+
+def sort_data(data, cols):
+    """Sort `data` rows and order columns"""
+    return data.sort_values(cols)[cols + ['value']].reset_index(drop=True)
 
 
 def find_depth(data, s='', level=None):

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -1,6 +1,6 @@
 import pytest
 import pandas as pd
-from pyam import compare, df_to_pyam
+from pyam import IamDataFrame, compare
 
 
 def test_cast_from_value_col(meta_df):
@@ -13,8 +13,8 @@ def test_cast_from_value_col(meta_df):
         columns=['model', 'scenario', 'region', 'unit', 'year',
                  'Primary Energy', 'Primary Energy|Coal'],
     )
-    df = df_to_pyam(df_with_value_cols,
-                    value=['Primary Energy', 'Primary Energy|Coal'])
+    df = IamDataFrame(df_with_value_cols,
+                      value=['Primary Energy', 'Primary Energy|Coal'])
 
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)
@@ -27,14 +27,14 @@ def test_cast_with_model_arg_raises():
         columns=['model', 'scenario', 'region', 'unit', 'year',
                  'Primary Energy', 'Primary Energy|Coal'],
     )
-    pytest.raises(ValueError, df_to_pyam, df=df, model='foo')
+    pytest.raises(ValueError, IamDataFrame, df, model='foo')
 
 
 def test_cast_with_model_arg(meta_df):
     df = meta_df.timeseries().reset_index()
     df.rename(columns={'model': 'foo'}, inplace=True)
 
-    df = df_to_pyam(df, model='foo')
+    df = IamDataFrame(df, model='foo')
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)
 
@@ -48,6 +48,6 @@ def test_cast_by_column_concat(meta_df):
         columns=['scenario', 'region', 'var_1', 'var_2', 'unit', 2005, 2010],
     )
 
-    df = df_to_pyam(df, model='model_a', variable=['var_1', 'var_2'])
+    df = IamDataFrame(df, model='model_a', variable=['var_1', 'var_2'])
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -1,10 +1,5 @@
-import copy
-import pytest
-
-import numpy as np
 import pandas as pd
-
-from pyam import IamDataFrame, compare, df_to_pyam
+from pyam import compare, df_to_pyam
 
 
 def test_cast_from_value_col(meta_df):
@@ -16,11 +11,8 @@ def test_cast_from_value_col(meta_df):
     ],
         columns=['model', 'scenario', 'region', 'unit', 'year',
                  'Primary Energy', 'Primary Energy|Coal'],
-    )    
+    )
     df = df_to_pyam(df_with_value_cols)
-
-    print(df.timeseries())
-    print(meta_df.timeseries())
 
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -1,0 +1,26 @@
+import copy
+import pytest
+
+import numpy as np
+import pandas as pd
+
+from pyam import IamDataFrame, compare, df_to_pyam
+
+
+def test_cast_from_value_col(meta_df):
+    df_with_value_cols = pd.DataFrame([
+        ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],
+        ['model_a', 'scen_a', 'World', 'EJ/y', 2010, 6., 3],
+        ['model_a', 'scen_b', 'World', 'EJ/y', 2005, 2, None],
+        ['model_a', 'scen_b', 'World', 'EJ/y', 2010, 7, None]
+    ],
+        columns=['model', 'scenario', 'region', 'unit', 'year',
+                 'Primary Energy', 'Primary Energy|Coal'],
+    )    
+    df = df_to_pyam(df_with_value_cols)
+
+    print(df.timeseries())
+    print(meta_df.timeseries())
+
+    assert compare(meta_df, df).empty
+    pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -20,7 +20,7 @@ def test_cast_from_value_col(meta_df):
     pd.testing.assert_frame_equal(df.data, meta_df.data)
 
 
-def test_cast_with_model_arg_raises(meta_df):
+def test_cast_with_model_arg_raises():
     df = pd.DataFrame([
         ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],
     ],
@@ -28,3 +28,12 @@ def test_cast_with_model_arg_raises(meta_df):
                  'Primary Energy', 'Primary Energy|Coal'],
     )
     pytest.raises(ValueError, df_to_pyam, df=df, model='foo')
+
+
+def test_cast_with_model_arg(meta_df):
+    df = meta_df.timeseries().reset_index()
+    df.rename(columns={'model': 'foo'}, inplace=True)
+
+    df = df_to_pyam(df, model='foo')
+    assert compare(meta_df, df).empty
+    pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -1,3 +1,4 @@
+import pytest
 import pandas as pd
 from pyam import compare, df_to_pyam
 
@@ -17,3 +18,13 @@ def test_cast_from_value_col(meta_df):
 
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)
+
+
+def test_cast_with_model_arg_raises(meta_df):
+    df = pd.DataFrame([
+        ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],
+    ],
+        columns=['model', 'scenario', 'region', 'unit', 'year',
+                 'Primary Energy', 'Primary Energy|Coal'],
+    )
+    pytest.raises(ValueError, df_to_pyam, df=df, model='foo')

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -37,3 +37,17 @@ def test_cast_with_model_arg(meta_df):
     df = df_to_pyam(df, model='foo')
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)
+
+
+def test_cast_by_column_concat(meta_df):
+    df = pd.DataFrame([
+        ['scen_a', 'World', 'Primary Energy', None, 'EJ/y', 1, 6.],
+        ['scen_a', 'World', 'Primary Energy', 'Coal', 'EJ/y', 0.5, 3],
+        ['scen_b', 'World', 'Primary Energy', None, 'EJ/y', 2, 7],
+    ],
+        columns=['scenario', 'region', 'var_1', 'var_2', 'unit', 2005, 2010],
+    )
+
+    df = df_to_pyam(df, model='model_a', variable=['var_1', 'var_2'])
+    assert compare(meta_df, df).empty
+    pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -12,7 +12,8 @@ def test_cast_from_value_col(meta_df):
         columns=['model', 'scenario', 'region', 'unit', 'year',
                  'Primary Energy', 'Primary Energy|Coal'],
     )
-    df = df_to_pyam(df_with_value_cols)
+    df = df_to_pyam(df_with_value_cols,
+                    value=['Primary Energy', 'Primary Energy|Coal'])
 
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,12 @@ def test_init_df_with_float_cols_raises(test_pd_df):
     pytest.raises(ValueError, IamDataFrame, data=_test_df)
 
 
+def test_init_df_with_duplicates_raises(test_df):
+    _df = test_df.timeseries()
+    _df = _df.append(_df.iloc[0]).reset_index()
+    pytest.raises(ValueError, IamDataFrame, data=_df)
+
+
 def test_init_df_with_float_cols(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005., 2010: 2010.})
     obs = IamDataFrame(_test_df).timeseries().reset_index()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import pandas as pd
 from numpy import testing as npt
 
 from pyam import IamDataFrame, validate, categorize, \
-    require_variable, filter_by_meta, META_IDX, IAMC_IDX
+    require_variable, filter_by_meta, META_IDX, IAMC_IDX, sort_data
 from pyam.core import _meta_idx, concat
 
 from conftest import TEST_DATA_DIR
@@ -778,7 +778,7 @@ def test_filter_by_int(meta_df):
 def _r5_regions_exp(df):
     df = df.filter(region='World', keep=False)
     df['region'] = 'R5MAF'
-    return df.data.reset_index(drop=True)
+    return sort_data(df.data, df._LONG_IDX)
 
 
 def test_map_regions_r5(reg_df):
@@ -847,7 +847,7 @@ def test_48b():
         ['model', 'scen1', 'SDN', 'var', 'unit', 2, 7],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
-    )).data.reset_index(drop=True)
+    )).data
 
     df = IamDataFrame(pd.DataFrame([
         ['model', 'scen', 'R5MAF', 'var', 'unit', 1, 6],
@@ -856,7 +856,7 @@ def test_48b():
                 'variable', 'unit', 2005, 2010],
     ))
     obs = df.map_regions('iso', region_col='r5_region').data
-    obs = obs[obs.region.isin(['SSD', 'SDN'])].reset_index(drop=True)
+    obs = sort_data(obs[obs.region.isin(['SSD', 'SDN'])], df._LONG_IDX)
 
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 from pyam import utils
 
 TEST_VARS = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
+TEST_CONCAT_SERIES = pd.Series(['foo', 'bar', 'baz'], index=['f', 'b', 'z'])
 
 
 def test_pattern_match_none():
@@ -145,3 +146,20 @@ def test_find_depth_1_minus():
 def test_find_depth_1_plus():
     obs = utils.find_depth(TEST_VARS, level='1+')
     assert obs == [False, True, True]
+
+
+def test_concat_with_pipe_all():
+    obs = utils.concat_with_pipe(TEST_CONCAT_SERIES)
+    assert obs == 'foo|bar|baz'
+
+
+def test_concat_with_pipe_exclude_none():
+    s = TEST_CONCAT_SERIES.copy()
+    s['b'] = None
+    obs = utils.concat_with_pipe(s)
+    assert obs == 'foo|baz'
+
+
+def test_concat_with_pipe_by_name():
+    obs = utils.concat_with_pipe(TEST_CONCAT_SERIES, ['f', 'z'])
+    assert obs == 'foo|baz'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,3 +170,19 @@ def test_concat_with_pipe_exclude_nan():
 def test_concat_with_pipe_by_name():
     obs = utils.concat_with_pipe(TEST_CONCAT_SERIES, ['f', 'z'])
     assert obs == 'foo|baz'
+
+
+def test_reduce_hierarchy_0():
+    assert utils.reduce_hierarchy('foo|bar|baz', 0) == 'foo'
+
+
+def test_reduce_hierarchy_1():
+    assert utils.reduce_hierarchy('foo|bar|baz', 1) == 'foo|bar'
+
+
+def test_reduce_hierarchy_neg1():
+    assert utils.reduce_hierarchy('foo|bar|baz', -1) == 'foo|bar'
+
+
+def test_reduce_hierarchy_neg2():
+    assert utils.reduce_hierarchy('foo|bar|baz', -2) == 'foo'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,6 +160,13 @@ def test_concat_with_pipe_exclude_none():
     assert obs == 'foo|baz'
 
 
+def test_concat_with_pipe_exclude_nan():
+    s = TEST_CONCAT_SERIES.copy()
+    s['b'] = np.nan
+    obs = utils.concat_with_pipe(s)
+    assert obs == 'foo|baz'
+
+
 def test_concat_with_pipe_by_name():
     obs = utils.concat_with_pipe(TEST_CONCAT_SERIES, ['f', 'z'])
     assert obs == 'foo|baz'


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR allows initialising an `IamDataFrame` from a file or `pd.DataFrame` and filling out missing required columns efficiently.

See the unit tests in `tests/test_cast_to_iamc.py` for possible use cases.