### PR TITLE
Add a validation check to `rename()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#202](https://github.com/IAMconsortium/pyam/pull/202) Extend the `df.rename()` function with a `check_duplicates (default True)` validation option
 - [#199](https://github.com/IAMconsortium/pyam/pull/199) Initializing an `IamDataFrame` accepts kwargs to fill or create from the data any missing required columns
 - [#197](https://github.com/IAMconsortium/pyam/pull/197) Added a `normalize` function that normalizes all data in a data frame to a specific time period.
 - [#195](https://github.com/IAMconsortium/pyam/pull/195) Fix filtering for `time`, `day` and `hour` to use generic `pattern_match()` (if such a column exists) in 'year'-formmatted IamDataFrames

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -611,8 +611,9 @@ class IamDataFrame(object):
                         _data.loc[~rows, self._LONG_IDX].drop_duplicates())
             )
             if any(merged.duplicated()):
-                msg = 'duplicates between original and renamed data!'
-                raise ValueError(msg)
+                msg = 'Duplicated rows between original and renamed data!\n{}'
+                conflict_rows = merged.loc[merged.duplicated(), self._LONG_IDX]
+                raise ValueError(msg.format(conflict_rows.drop_duplicates()))
 
         # merge using `groupby().sum()`
         ret.data = _data.groupby(ret._LONG_IDX).sum().reset_index()

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -608,7 +608,7 @@ class IamDataFrame(object):
         if check_duplicates:
             merged = (
                 _data.loc[rows, self._LONG_IDX].drop_duplicates().append(
-                        _data.loc[~rows, self._LONG_IDX].drop_duplicates())
+                    _data.loc[~rows, self._LONG_IDX].drop_duplicates())
             )
             if any(merged.duplicated()):
                 msg = 'Duplicated rows between original and renamed data!\n{}'

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -589,7 +589,9 @@ class IamDataFrame(object):
         # renaming is only applied where a filter matches for all given columns
         rows = ret._apply_filters(filters)
         idx = ret.meta.index.isin(_make_index(ret.data[rows]))
-        _data = ret.data.copy()
+
+        # if `check_duplicates`, do the rename on a copy until after the check
+        _data = ret.data.copy() if check_duplicates else ret.data
 
         # apply renaming changes
         for col, _mapping in mapping.items():

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -645,8 +645,8 @@ class IamDataFrame(object):
             return ret
 
     def normalize(self, inplace=False, **kwargs):
-        """Normalize data to a given value. Currently only supports normalizing to a
-        specific time
+        """Normalize data to a given value. Currently only supports normalizing
+        to a specific time.
 
         Parameters
         ----------

--- a/tests/test_feature_append_rename_convert.py
+++ b/tests/test_feature_append_rename_convert.py
@@ -6,7 +6,7 @@ import pandas as pd
 from numpy import testing as npt
 
 
-from pyam import IamDataFrame, META_IDX, IAMC_IDX
+from pyam import IamDataFrame, META_IDX, IAMC_IDX, compare
 
 
 RENAME_DF = IamDataFrame(pd.DataFrame([
@@ -179,6 +179,24 @@ def test_rename_append(meta_df):
     ], columns=['model', 'scenario', 'exclude']
     ).set_index(META_IDX)
     pd.testing.assert_frame_equal(obs.meta, exp)
+
+
+def test_rename_duplicates():
+    mapping = {'variable': {'test_1': 'test_3'}}
+    pytest.raises(ValueError, RENAME_DF.rename, **mapping)
+
+    obs = RENAME_DF.rename(check_duplicates=False, **mapping)
+
+    exp = IamDataFrame(pd.DataFrame([
+       ['model', 'scen', 'region_a', 'test_2', 'unit', 2, 6],
+       ['model', 'scen', 'region_a', 'test_3', 'unit', 4, 12],
+       ['model', 'scen', 'region_b', 'test_3', 'unit', 4, 8],
+    ], columns=['model', 'scenario', 'region',
+                'variable', 'unit', 2005, 2010],
+    ))
+
+    assert compare(obs, exp).empty
+    pd.testing.assert_frame_equal(obs.data, exp.data)
 
 
 def test_convert_unit():

--- a/tests/test_feature_append_rename_convert.py
+++ b/tests/test_feature_append_rename_convert.py
@@ -188,9 +188,9 @@ def test_rename_duplicates():
     obs = RENAME_DF.rename(check_duplicates=False, **mapping)
 
     exp = IamDataFrame(pd.DataFrame([
-       ['model', 'scen', 'region_a', 'test_2', 'unit', 2, 6],
-       ['model', 'scen', 'region_a', 'test_3', 'unit', 4, 12],
-       ['model', 'scen', 'region_b', 'test_3', 'unit', 4, 8],
+        ['model', 'scen', 'region_a', 'test_2', 'unit', 2, 6],
+        ['model', 'scen', 'region_a', 'test_3', 'unit', 4, 12],
+        ['model', 'scen', 'region_b', 'test_3', 'unit', 4, 8],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
     ))


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a validation check to `df.rename()` to prevent accidentally renaming and aggregating existing and renamed variables.

In terms of the new unit test `test_rename_duplicates()`, the user may not be (actively) aware that a variable `test_3` exists in the `IamDataFrame` and not actually want to aggregate `test_1` and `test_3`. With the new feature, the user will receive an error message as default behaviour and has to actively override the validation step.

closes #182