### PR TITLE
bugfix when casting `pd.DataFrame` to `IamDataFrame` with custom args

### DIFF
--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -136,10 +136,10 @@ def format_data(df, **kwargs):
     # melt value columns and use column name as `variable`
     if 'value' in kwargs and 'variable' not in kwargs:
         value = kwargs.pop('value')
-        idx = set(df.columns) & (set(IAMC_IDX) | set(['year', 'time']))
-        _df = df.set_index(list(idx))
+        value = value if islistable(value) else [value]
+        _df = df.set_index(list(set(df.columns) - set(value)))
         dfs = []
-        for v in value if islistable(value) else [value]:
+        for v in value:
             if v not in df.columns:
                 raise ValueError('column `{}` does not exist!'.format(v))
             vdf = _df[v].to_frame().rename(columns={v: 'value'})

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -147,7 +147,7 @@ def format_data(df, **kwargs):
             dfs.append(vdf.reset_index())
         df = pd.concat(dfs).reset_index(drop=True)
 
-    # otherwise, do a fill-by-value or rename columns or concat to IAMC-style
+    # otherwise, rename columns or concat to IAMC-style or do a fill-by-value
     for col, value in kwargs.items():
         if col in df:
             raise ValueError('conflict of kwarg with column `{}` in dataframe!'

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -20,6 +20,24 @@ def test_cast_from_value_col(meta_df):
     pd.testing.assert_frame_equal(df.data, meta_df.data)
 
 
+def test_cast_from_value_col_and_args(meta_df):
+    # checks for issue [#210](https://github.com/IAMconsortium/pyam/issues/210)
+    df_with_value_cols = pd.DataFrame([
+        ['scen_a', 'World', 'EJ/y', 2005, 1, 0.5],
+        ['scen_a', 'World', 'EJ/y', 2010, 6., 3],
+        ['scen_b', 'World', 'EJ/y', 2005, 2, None],
+        ['scen_b', 'World', 'EJ/y', 2010, 7, None]
+    ],
+        columns=['scenario', 'iso', 'unit', 'year',
+                 'Primary Energy', 'Primary Energy|Coal'],
+    )
+    df = IamDataFrame(df_with_value_cols, model='model_a', region='iso',
+                      value=['Primary Energy', 'Primary Energy|Coal'])
+
+    assert compare(meta_df, df).empty
+    pd.testing.assert_frame_equal(df.data, meta_df.data)
+
+
 def test_cast_with_model_arg_raises():
     df = pd.DataFrame([
         ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added

# Description of PR

This PR fixes a bug when using custom column casting args using both a column rename and a `melt` to `value` from multiple columns using the column name as `variable`.

*Note*: all columns not "melted" or (renamed to) IAMC-standard columns will be used as "extra columns" in the `IamDataFrame`.

closes #210 