### PR TITLE
add aggregate tutorial to docs

### DIFF
--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -8,6 +8,7 @@ Tutorials
    :maxdepth: 1
 
    tutorials/pyam_first_steps.ipynb
+   tutorials/aggregating_variables_and_plotting_with_negative_values.ipynb
    tutorials/ipcc_colors.ipynb
    tutorials/pyam_logo.ipynb
    tutorials/iiasa_dbs.ipynb


### PR DESCRIPTION
Saw that the tutorial wasn't actually added to `tutorials.rst` @rossursino and @znicholls. It is now added!