### PR TITLE
[WIP] initial inclusion of operations on dataframes

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -115,6 +115,29 @@ class IamDataFrame(object):
     def __len__(self):
         return self.data.__len__()
 
+    def __sub__(self, other):
+        # confirm data formulated as expected
+        single_var_self = len(self.variables()) == 1
+        single_var_other = len(other.variables()) == 1
+        if  not single_var_self and not single_var_other:
+            raise ValueError('Can only subtract if one operand has a '
+                             'single variable type')
+
+        # get new variable column data
+        left = self.variables()[0] if single_var_self else self['variable']
+        right = other['variable'] if single_var_self else other.variables()[0]
+        varcol = left + ' - ' + right
+
+        # perform subtraction and return
+        df = self.copy()
+        x = df.data.set_index(GROUP_IDX).drop('variable', axis=1)
+        y = other.data.set_index(GROUP_IDX).drop('variable', axis=1)
+
+        df.data.value = (x.value - y.value).values
+        df.data.variable = varcol.values
+        return df
+        
+    
     def _execute_run_control(self):
         for module_block in run_control()['exec']:
             fname = module_block['file']

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+def test_subtract(meta_df):
+    x = meta_df.filter(variable='Primary Energy', scenario='scen_a')
+    y = meta_df.filter(variable='Primary Energy|Coal', scenario='scen_a')
+    obs = (x-y).data
+
+    exp = x.copy().data
+    exp['variable'] = 'Primary Energy - Primary Energy|Coal'
+    exp['value'] = [0.5, 3.0]
+
+    pd.testing.assert_frame_equal(obs, exp)
+


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR provides one example of how to do operations on dataframes. It is quite limited in scope, but still perhaps useful. I'd like to use it as a basis for discussion, so @danielhuppmann and @znicholls please chime in!!

The basic idea here is to be able to do basic operations, i.e., addition, subtraction, multiplication such as:

```
df = df1 - df2 # all dfs are pyam.IamDataFrames
```

I have thus far implemented a `__sub__` method. At the moment, it assumes that both dataframes included in the operation have the same model/scenario/etc. data. One operand **must** have a single variable. This is one of the pain points - we probably want to actually *intuit* which is the value being "subtracted". At the moment, I assume it is some number of variables minus some other variable. But it could also be models, or scenarios, etc.

So, as I said, this is simply a starting point for implementation and discussion. Let me know what you think!