### PR TITLE
Make log warning "if-filter()-returns-empty" optional

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -842,7 +842,7 @@ class IamDataFrame(object):
 
         # add components at the `region` level, defaults to all variables one
         # level below `variable` that are only present in `region`
-        region_df = self.filter(region=region)
+        region_df = self.filter(region=region, warn_if_empty=False)
         components = components or (
             set(region_df._variable_components(variable)).difference(
                 subregion_df._variable_components(variable)))
@@ -951,15 +951,17 @@ class IamDataFrame(object):
         logger().info('{} non-valid scenario{} will be excluded'
                       .format(len(idx), '' if len(idx) == 1 else 's'))
 
-    def filter(self, keep=True, inplace=False, **kwargs):
+    def filter(self, keep=True, inplace=False, warn_if_empty=True, **kwargs):
         """Return a filtered IamDataFrame (i.e., a subset of current data)
 
         Parameters
         ----------
-        keep: bool, default True
+        keep: bool
             keep all scenarios satisfying the filters (if True) or the inverse
-        inplace: bool, default False
+        inplace: bool
             if True, do operation inplace and return None
+        warn_if_empty: bool
+            warn in the log ifthe returned `IamDataFrame` is empty
         filters by kwargs:
             The following columns are available for filtering:
              - metadata columns: filter by category assignment
@@ -980,7 +982,7 @@ class IamDataFrame(object):
         ret.data = ret.data[_keep]
 
         idx = _make_index(ret.data)
-        if len(idx) == 0:
+        if warn_if_empty and len(idx) == 0:
             logger().warning('Filtered IamDataFrame is empty!')
         ret.meta = ret.meta.loc[idx]
         if not inplace:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -956,12 +956,12 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        keep: bool
+        keep: boolean, default True
             keep all scenarios satisfying the filters (if True) or the inverse
-        inplace: bool
+        inplace: boolean, default False
             if True, do operation inplace and return None
-        warn_if_empty: bool
-            warn in the log ifthe returned `IamDataFrame` is empty
+        warn_if_empty: boolean, default True
+            print warning in the log output if returned `IamDataFrame` is empty
         filters by kwargs:
             The following columns are available for filtering:
              - metadata columns: filter by category assignment


### PR DESCRIPTION
# Description of PR

The function `filter()` prints a warning to the log if a returned `IamDataFrame` is empty. This makes sense in most instance (and should remain the default behaviour), but it produces verbose and potentially misleading output in some cases and larger scripts.

One such case (fixed in this PR) is the `aggregate_region()` function when the new `region` does not have any data yet - which is not a problem and should not raise a warning.

# Alternative implementations

An alternative to circumvent the warning would be:
```
new = IamDataFrame(df.data[df._apply_filters(**filter_kwargs)])
```
This is more verbose but computationally more efficient (first downselect, then cast as `IamDataFrame`, ignore meta) compared to `filter()` (make a full copy including `meta`, then downselect). Still, in our limited-size use cases, concise code wins over speed, I would think...?