### PR TITLE
Region ag hotfix

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -844,8 +844,11 @@ class IamDataFrame(object):
         # level below `variable` that are only present in `region`
         region_df = self.filter(region=region)
         components = components or (
-            set(region_df._variable_components(variable)).difference(
-                subregion_df._variable_components(variable)))
+            set(region_df._variable_components(variable))
+            .difference(
+                subregion_df._variable_components(variable)
+            )
+        )
 
         if len(components):
             rows = region_df._apply_filters(variable=components)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -309,9 +309,14 @@ def pattern_match(data, values, level=None, regexp=False, has_nan=True):
     matching of model/scenario names, variables, regions, and meta columns to
     pseudo-regex (if `regexp == False`) for filtering (str, int, bool)
     """
-    matches = np.array([False] * len(data))
+    # coerce values to a list
     if not isinstance(values, collections.Iterable) or isstr(values):
         values = [values]
+
+    if len(data) == 0 or len(values) == 0:
+        return []
+
+    matches = np.array([False] * len(data))
 
     # issue (#40) with string-to-nan comparison, replace nan by empty string
     _data = data.copy()

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from pyam import check_aggregate, IAMC_IDX
+from pyam import check_aggregate, IAMC_IDX, IamDataFrame
 
 from conftest import TEST_DTS
 
@@ -73,6 +73,27 @@ def test_df_check_aggregate_region_pass(check_aggregate_df):
         obs = check_aggregate_df.check_aggregate_region(variable)
         assert obs is None
 
+def test_aggregate_region():
+    data = pd.DataFrame([
+        ['TEST', 'scen', 'China', 'Primary Energy', 'EJ/y', 1, 6],
+        ['TEST', 'scen', 'Vietnam', 'Primary Energy', 'EJ/y', 0.75, 5]],
+        columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+    df = IamDataFrame(data=data)
+    obs = df.aggregate_region(variable='Primary Energy',
+                              region='R5ASIA',
+                              subregions=['China', 'Vietnam', 'Japan'],
+                              components=[], append=False)
+    assert len(obs) == 2
+
+def test_aggregate_region_missing_all_subregions():
+    data = pd.DataFrame([],
+        columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+    df = IamDataFrame(data=data)
+    obs = df.aggregate_region(variable='Primary Energy',
+                              region='R5ASIA',
+                              subregions=['China', 'Vietnam', 'Japan'],
+                              components=[], append=False)
+    assert len(obs) == 2
 
 def run_check_agg_fail(pyam_df, tweak_dict, test_type):
     mr = pyam_df.data.model == tweak_dict['model']

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -4,6 +4,13 @@ from pyam import check_aggregate, IAMC_IDX
 
 from conftest import TEST_DTS
 
+
+def test_missing_region(check_aggregate_df):
+    print(check_aggregate_df['region'])
+    obs = check_aggregate_df.aggregate_region('Primary Energy', region='foo')
+    print(obs['region'])  # there is no region column in returned df
+
+
 def test_do_aggregate_append(meta_df):
     meta_df.rename({'variable': {'Primary Energy': 'Primary Energy|Gas'}},
                    inplace=True)


### PR DESCRIPTION
This is a hotfix for region aggregation as observed by @zikolach. It 

a) checks that regions actually exist, throwing an error if not
b) checks that `pattern_match` is provided actual data, throwing an error if not

@zikolach can you please test this and make sure it catches your use case? We can iterate on this branch as needed.