### PR TITLE
Region ag hotfix

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -844,8 +844,11 @@ class IamDataFrame(object):
         # level below `variable` that are only present in `region`
         region_df = self.filter(region=region)
         components = components or (
-            set(region_df._variable_components(variable)).difference(
-                subregion_df._variable_components(variable)))
+            set(region_df._variable_components(variable))
+            .difference(
+                subregion_df._variable_components(variable)
+            )
+        )
 
         if len(components):
             rows = region_df._apply_filters(variable=components)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -855,10 +855,11 @@ class IamDataFrame(object):
             _data = _data.add(_aggregate(region_df.data[rows], cols),
                               fill_value=0)
 
+        kwargs = dict(region=region, variable=variable)
         if append is True:
-            self.append(_data, region=region, variable=variable, inplace=True)
+            self.append(_data, inplace=True, **kwargs)
         else:
-            return _data
+            return IamDataFrame(_data, **kwargs)
 
     def check_aggregate_region(self, variable, region='World', subregions=None,
                                components=None, exclude_on_fail=False,

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1063,7 +1063,7 @@ class IamDataFrame(object):
             else:
                 _raise_filter_error(col)
 
-            keep &= keep_col
+            keep = np.logical_and(keep, keep_col)
 
         return keep
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -314,7 +314,7 @@ def pattern_match(data, values, level=None, regexp=False, has_nan=True):
         values = [values]
 
     if len(data) == 0 or len(values) == 0:
-        return []
+        return np.array([])
 
     matches = np.array([False] * len(data))
 
@@ -328,10 +328,10 @@ def pattern_match(data, values, level=None, regexp=False, has_nan=True):
             pattern = re.compile(_escape_regexp(s) + '$' if not regexp else s)
             subset = filter(pattern.match, _data)
             depth = True if level is None else find_depth(_data, s, level)
-            matches |= (_data.isin(subset) & depth)
+            matches = np.logical_or(matches, (_data.isin(subset) & depth))
         else:
-            matches |= data == s
-    return matches
+            matches = np.logical_or(matches, data == s)
+    return np.array(matches)
 
 
 def _escape_regexp(s):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -309,9 +309,14 @@ def pattern_match(data, values, level=None, regexp=False, has_nan=True):
     matching of model/scenario names, variables, regions, and meta columns to
     pseudo-regex (if `regexp == False`) for filtering (str, int, bool)
     """
-    matches = np.array([False] * len(data))
+    # coerce values to a list
     if not isinstance(values, collections.Iterable) or isstr(values):
         values = [values]
+
+    if len(data) == 0 or len(values) == 0:
+        return []
+
+    matches = np.array([False] * len(data))
 
     # issue (#40) with string-to-nan comparison, replace nan by empty string
     _data = data.copy()

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -6,9 +6,16 @@ from conftest import TEST_DTS
 
 
 def test_missing_region(check_aggregate_df):
-    print(check_aggregate_df['region'])
-    obs = check_aggregate_df.aggregate_region('Primary Energy', region='foo')
-    print(obs['region'])  # there is no region column in returned df
+    exp = check_aggregate_df.aggregate_region(
+        'Primary Energy', region='foo', append=False
+    ).data
+    check_aggregate_df.aggregate_region(
+        'Primary Energy', region='foo', append=True
+    )
+    obs = check_aggregate_df.filter(region='foo').data
+    assert len(exp) > 0
+    pd.testing.assert_frame_equal(obs.reset_index(drop=True),
+                                  exp.reset_index(drop=True))
 
 
 def test_do_aggregate_append(meta_df):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from pyam import check_aggregate, IAMC_IDX
+from pyam import check_aggregate, IAMC_IDX, IamDataFrame
 
 from conftest import TEST_DTS
 
@@ -16,6 +16,32 @@ def test_missing_region(check_aggregate_df):
     assert len(exp) > 0
     pd.testing.assert_frame_equal(obs.reset_index(drop=True),
                                   exp.reset_index(drop=True))
+
+
+def test_aggregate_region_extra_subregion():
+    data = pd.DataFrame([
+        ['TEST', 'scen', 'China', 'Primary Energy', 'EJ/y', 1, 6],
+        ['TEST', 'scen', 'Vietnam', 'Primary Energy', 'EJ/y', 0.75, 5]],
+        columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+    df = IamDataFrame(data=data)
+    obs = df.aggregate_region(variable='Primary Energy',
+                              region='R5ASIA',
+                              subregions=['China', 'Vietnam', 'Japan'],
+                              components=[], append=False)
+    assert len(obs) == 2
+
+
+def test_aggregate_region_missing_all_subregions():
+    data = pd.DataFrame([
+        ['TEST', 'scen', 'foo', 'Primary Energy', 'EJ/y', 1, 6],
+        ['TEST', 'scen', 'bar', 'Primary Energy', 'EJ/y', 0.75, 5]],
+        columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+    df = IamDataFrame(data=data)
+    obs = df.aggregate_region(variable='Primary Energy',
+                              region='R5ASIA',
+                              subregions=['China', 'Vietnam', 'Japan']
+                              )
+    assert len(obs) == 0
 
 
 def test_do_aggregate_append(meta_df):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -19,10 +19,11 @@ def test_missing_region(check_aggregate_df):
 
 
 def test_aggregate_region_extra_subregion():
+    cols = ['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
     data = pd.DataFrame([
         ['TEST', 'scen', 'China', 'Primary Energy', 'EJ/y', 1, 6],
         ['TEST', 'scen', 'Vietnam', 'Primary Energy', 'EJ/y', 0.75, 5]],
-        columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+        columns=cols)
     df = IamDataFrame(data=data)
     obs = df.aggregate_region(variable='Primary Energy',
                               region='R5ASIA',
@@ -32,10 +33,11 @@ def test_aggregate_region_extra_subregion():
 
 
 def test_aggregate_region_missing_all_subregions():
+    cols = ['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010]
     data = pd.DataFrame([
         ['TEST', 'scen', 'foo', 'Primary Energy', 'EJ/y', 1, 6],
         ['TEST', 'scen', 'bar', 'Primary Energy', 'EJ/y', 0.75, 5]],
-        columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
+        columns=cols)
     df = IamDataFrame(data=data)
     obs = df.aggregate_region(variable='Primary Energy',
                               region='R5ASIA',

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -4,6 +4,13 @@ from pyam import check_aggregate, IAMC_IDX
 
 from conftest import TEST_DTS
 
+
+def test_missing_region(check_aggregate_df):
+    print(check_aggregate_df['region'])
+    obs = check_aggregate_df.aggregate_region('Primary Energy', region='foo')
+    print(obs['region'])  # there is no region column in returned df
+
+
 def test_do_aggregate_append(meta_df):
     meta_df.rename({'variable': {'Primary Energy': 'Primary Energy|Gas'}},
                    inplace=True)


### PR DESCRIPTION
With @zikolach, we finally got the region aggregation back online. However, to do so we decided to make the API contracts for `aggregate_region` more consistent. Now if you `append=False`, you get back an `IamDataFrame`. @danielhuppmann would you mind helping with the test passage? Sadly, I don't have time to go through them all and convert. In the meantime, @zikolach can use this branch to continue his work.