### PR TITLE
add a fixture `logger.ignoreWarnings()`, use in `aggregate_region()`

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -3,7 +3,6 @@ import importlib
 import itertools
 import os
 import sys
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,7 @@ except ImportError:
 
 from pyam import plotting
 
-from pyam.logger import logger, ignoreWarnings
+from pyam.logger import logger, adjust_log_level
 from pyam.run_control import run_control
 from pyam.utils import (
     write_sheet,
@@ -842,7 +841,7 @@ class IamDataFrame(object):
 
         # add components at the `region` level, defaults to all variables one
         # level below `variable` that are only present in `region`
-        with ignoreWarnings():
+        with adjust_log_level():
             region_df = self.filter(region=region)
         components = components or (
             set(region_df._variable_components(variable)).difference(

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -16,7 +16,7 @@ except ImportError:
 
 from pyam import plotting
 
-from pyam.logger import logger
+from pyam.logger import logger, ignoreWarnings
 from pyam.run_control import run_control
 from pyam.utils import (
     write_sheet,
@@ -842,7 +842,8 @@ class IamDataFrame(object):
 
         # add components at the `region` level, defaults to all variables one
         # level below `variable` that are only present in `region`
-        region_df = self.filter(region=region)
+        with ignoreWarnings():
+            region_df = self.filter(region=region)
         components = components or (
             set(region_df._variable_components(variable)).difference(
                 subregion_df._variable_components(variable)))

--- a/pyam/logger.py
+++ b/pyam/logger.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import logging
 
 # globally accessible logger
@@ -14,14 +15,10 @@ def logger():
     return _LOGGER
 
 
-class ignoreWarnings():
-    """Fixture to ignore logging messages below `level`"""
-    def __init__(self, level='ERROR'):
-        self.level = _LOGGER.getEffectiveLevel()
-        _LOGGER.setLevel(level)
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exception_type, exception_value, traceback):
-        _LOGGER.setLevel(self.level)
+@contextmanager
+def adjust_log_level(level='ERROR'):
+    """Context manager to change log level"""
+    old_level = _LOGGER.getEffectiveLevel()
+    _LOGGER.setLevel(level)
+    yield
+    _LOGGER.setLevel(old_level)

--- a/pyam/logger.py
+++ b/pyam/logger.py
@@ -12,3 +12,16 @@ def logger():
         _LOGGER = logging.getLogger()
         _LOGGER.setLevel('INFO')
     return _LOGGER
+
+
+class ignoreWarnings():
+    """Fixture to ignore logging messages below `level`"""
+    def __init__(self, level='ERROR'):
+        self.level = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(level)
+  
+    def __enter__(self):
+        pass
+    
+    def __exit__(self, exception_type, exception_value, traceback):
+        _LOGGER.setLevel(self.level)

--- a/pyam/logger.py
+++ b/pyam/logger.py
@@ -19,9 +19,9 @@ class ignoreWarnings():
     def __init__(self, level='ERROR'):
         self.level = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(level)
-  
+
     def __enter__(self):
         pass
-    
+
     def __exit__(self, exception_type, exception_value, traceback):
         _LOGGER.setLevel(self.level)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,9 @@
+from pyam import logger
+from pyam.logger import adjust_log_level
+
+
+def test_context_adjust_log_level():
+    assert logger().getEffectiveLevel() == 20
+    with adjust_log_level():
+        assert logger().getEffectiveLevel() == 40
+    assert logger().getEffectiveLevel() == 20


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Documentation Added
- [x] Tests added

# Description of PR

The function `filter()` prints a warning to the log if a returned `IamDataFrame` is empty. This makes sense in most instance (and should remain the default behaviour), but it produces verbose and potentially misleading output in some cases and larger scripts.

One such case (fixed in this PR) is the `aggregate_region()` function when the new `region` does not have any data yet - which is not a problem and should not raise a warning.

This PR adds a fixture `logger.adjust_log_level()` (see [logging.captureWarnings](https://docs.python.org/2/library/logging.html#logging.captureWarnings) for comparison) as short-hand to change the logging level around a block of code.

# Expected use

```
with logger.adjust_log_level():
    df.filter(model='foo')
```