### PR TITLE
[WIP] fix error not finding shared file `lipoppler.so.76` when building the docs on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - make test
   # only test docs once to make sure everything works on most recent python
   - cd doc
-  - if [[ "${PYENV}" == "py37" && "${TRAVIS_OS_NAME}" != 'windows' ]]; then make html; fi
+  - if [[ "${PYENV}" == "py37" && "${TRAVIS_OS_NAME}" != 'windows' ]]; then conda install --yes kealib==1.4.7; make html; fi
   - cd ..
 
 after_success:

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -6,5 +6,6 @@ gdal
 fiona
 "geopandas<0.5.0"
 "poppler<0.66"
+kealib==1.4.7
 cython
 cartopy

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -4,7 +4,7 @@ matplotlib-base==3.0.3
 seaborn==0.9.0
 gdal
 fiona
-"geopandas<0.5.0" # note that this has follow-up dependencies in `.travis.yml`
+"geopandas<0.5.0"
 "poppler<0.66"
 cython
 cartopy

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -4,8 +4,7 @@ matplotlib-base==3.0.3
 seaborn==0.9.0
 gdal
 fiona
-"geopandas<0.5.0"
+"geopandas<0.5.0" # note that this has follow-up dependencies in `.travis.yml`
 "poppler<0.66"
-"kealib<1.4.8"
 cython
 cartopy

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -6,6 +6,6 @@ gdal
 fiona
 "geopandas<0.5.0"
 "poppler<0.66"
-kealib==1.4.7
+"kealib<1.4.10"
 cython
 cartopy

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -6,6 +6,6 @@ gdal
 fiona
 "geopandas<0.5.0"
 "poppler<0.66"
-"kealib<1.4.10"
+"kealib<1.4.8"
 cython
 cartopy

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -5,5 +5,6 @@ seaborn==0.9.0
 gdal
 fiona
 "geopandas<0.5.0"
+"poppler<0.66"
 cython
 cartopy


### PR DESCRIPTION
This is a hotfix for a follow-up problem when building the docs on CI because of the current restriction `geopandas<0.5.0`, see #227 

This fix **does not fix** the issues with building the docs on readthedocs.