### PR TITLE
update docs and readme to point to `groups.io` and `RTD`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,7 +27,7 @@ including a detailed description of the new feature and unit tests
 to illustrate the intended functionality.
 Code submitted via pull requests must adhere to the `pep8`_ style formats.
 
-We do not require anyone to sign a *Contributor License Agreement*, because we
+We do not require users to sign a *Contributor License Agreement*, because we
 believe that when posting ideas or submitting code to an open-source project,
 it should be obvious and self-evident that any such contributions
 are made in the spirit of open collaborative development.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,11 +2,11 @@
 Have a question? Get in touch!
 ------------------------------
 
-- Report bugs, suggest features or view the source code `on GitHub`_.
-- For less well defined questions or ideas, use the `mailing list`_.
+- Send bug reports, suggest new features or view the source code `on GitHub`_,
+- Reach out via our community mailing list hosted by `groups.io`_,
 
-.. _mailing list: https://groups.google.com/forum/#!forum/pyam
 .. _on GitHub: http://github.com/IAMconsortium/pyam
+.. _`groups.io`: https://groups.io/g/pyam
 
 
 Interested in Contributing? Welcome to the team!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,9 +4,11 @@ Have a question? Get in touch!
 
 - Send bug reports, suggest new features or view the source code `on GitHub`_,
 - Reach out via our community mailing list hosted by `groups.io`_,
+- Or send an email to pyam+owner@groups.io to join our Slack_ workspace!
 
 .. _on GitHub: http://github.com/IAMconsortium/pyam
 .. _`groups.io`: https://groups.io/g/pyam
+.. _Slack: https://slack.com
 
 
 Interested in Contributing? Welcome to the team!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,10 +4,11 @@ Have a question? Get in touch!
 
 - Send bug reports, suggest new features or view the source code `on GitHub`_,
 - Reach out via our community mailing list hosted by `groups.io`_,
-- Or send an email to pyam+owner@groups.io to join our Slack_ workspace!
+- Or send us an `email`_ to join our Slack_ workspace!
 
 .. _on GitHub: http://github.com/IAMconsortium/pyam
 .. _`groups.io`: https://groups.io/g/pyam
+.. _`email`: mailto:pyam+owner@groups.io?subject=[pyam]%20Please%20add%20me%20to%20the%20Slack%20workspace
 .. _Slack: https://slack.com
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 pyam: a Python toolkit for Integrated Assessment Modeling
 =========================================================
 
-**Documentation: http://software.ene.iiasa.ac.at/pyam**
+**Documentation on [Read the Docs](https://pyam-iamc.readthedocs.io)**
+
 **Questions? Start a discussion on our [mailing list](https://groups.io/g/pyam)**
 
 Overview and scope
@@ -64,8 +65,8 @@ see [LICENSE](LICENSE) and [NOTICE](NOTICE.md) for details.
 Install
 -------
 
-For basic instructions see our
-[website](http://software.ene.iiasa.ac.at/pyam/install.html).
+For basic instructions,
+[read the docs](https://pyam-iamc.readthedocs.io/en/stable/install.html).
 
 To install from source after cloning this repository, simply run
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ pyam: a Python toolkit for Integrated Assessment Modeling
 =========================================================
 
 **Documentation: http://software.ene.iiasa.ac.at/pyam**
-**Questions? Start a discussion on our [listserv](https://groups.google.com/forum/#!forum/pyam)**
+**Questions? Start a discussion on our [mailing list](https://groups.io/g/pyam)**
 
 Overview and scope
 ------------------

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -30,7 +30,7 @@
 1. Update on conda-forge:
    - A PR should automatically be opened by the bot after the Github release
    - confirm that any new depedencies are added there
-1. Announce it on our mailing list: https://groups.google.com/forum/#!forum/pyam
+1. Announce it on our mailing list: https://groups.io/g/pyam
    - Again, just copy the now rendered HTML from the Github release directly in
      the email
 1. Confirm that the doc page is updated to the latest release: https://pyam-iamc.readthedocs.io/

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,15 +7,11 @@
 
 Release v\ |version|.
 
-|rtd| |pypi| |conda| |license| |latest|
+|pypi| |conda| |license| |latest|
 
-|travis| |appveyor| |coveralls|
+|rtd| |travis| |appveyor| |coveralls|
 
 |joss| |doi|
-
-.. |rtd| image:: https://readthedocs.org/projects/pyam-iamc/badge/?version=latest
-   :target: https://pyam-iamc.readthedocs.io/en/latest/?badge=latest
-   :alt: Documentation Status
 
 .. |pypi| image:: https://img.shields.io/pypi/v/pyam-iamc.svg
    :target: https://pypi.python.org/pypi/pyam-iamc/
@@ -28,6 +24,10 @@ Release v\ |version|.
 
 .. |latest| image:: https://anaconda.org/conda-forge/pyam/badges/latest_release_date.svg
    :target: https://anaconda.org/conda-forge/pyam
+
+.. |rtd| image:: https://readthedocs.org/projects/pyam-iamc/badge/?version=latest
+   :target: https://pyam-iamc.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
 
 .. |travis| image:: https://travis-ci.org/IAMconsortium/pyam.svg?branch=master
    :target: https://travis-ci.org/IAMconsortium/pyam

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -53,9 +53,6 @@ The source code for **pyam** is available on `Github`_.
 .. _`Github`:
    https://github.com/IAMconsortium/pyam
 
-.. _`groups.google.com/d/forum/pyam` :
-   https://groups.google.com/d/forum/pyam
-
 Overview
 --------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,5 +1,5 @@
-**pyam**: analysis and visualization of assessment models
-=========================================================
+**pyam**: analysis and visualization of integrated-assessment scenarios
+=======================================================================
 
 .. |br| raw:: html
 
@@ -44,8 +44,9 @@ Release v\ |version|.
 .. |doi| image:: https://zenodo.org/badge/113359260.svg
    :target: https://zenodo.org/badge/latestdoi/113359260
 
-The **pyam** Python package provides a range of diagnostic tools and functions
-for analyzing and visualizing data from your favorite assessment model(s).
+The **pyam** Python package provides a suite of diagnostic tools and functions
+for analyzing and visualizing input data and scenario results
+of your favorite integrated-assessment model(s).
 
 The source code for **pyam** is available on `Github`_.
 

--- a/doc/source/tutorials/pyam_first_steps.ipynb
+++ b/doc/source/tutorials/pyam_first_steps.ipynb
@@ -16,7 +16,7 @@
     "The ``pyam`` package provides a range of diagnostic tools and functions  \n",
     "for analyzing and working with scenario data following the IAMC template format.\n",
     "A comprehensive documentation of the package is available\n",
-    "at [software.ene.iiasa.ac.at/pyam/](http://software.ene.iiasa.ac.at/pyam/)\n",
+    "at [pyam-iamc.readthedocs.io](http://pyam-iamc.readthedocs.io)\n",
     "\n",
     "An illustrative example of the IAMC template is shown below;\n",
     "see [data.ene.iiasa.ac.at/database/](http://data.ene.iiasa.ac.at/database/) for more information.\n",


### PR DESCRIPTION
# Description of PR

This PR updates the README and docs to point to `groups.io` and `RTD` (rather than googlegroups and https://software.ene.iiasa.ac.at/pyam).

It also rephrases to "scenario" rather than "model" in the `pyam` docs teaser (because this is closer to what the package does). This change is not inconsistent with the published manuscript.