### PR TITLE
Region aggregation if region missing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 # Next Release
 
 - [#268](https://github.com/IAMconsortium/pyam/pull/268) Update `aggregate_region` so it can find variables below sub-cateogories too
+- [#267](https://github.com/IAMconsortium/pyam/pull/267) Make clear error message if variable-region pair is missing when `check_aggregate_region` is called
 - [#261](https://github.com/IAMconsortium/pyam/pull/261) Add a check that `keep` in `filter()` is a boolean
 - [#254](https://github.com/IAMconsortium/pyam/pull/254) Hotfix for aggregating missing regions and filtering empty dataframes
 - [#243](https://github.com/IAMconsortium/pyam/pull/243) Update `pyam.iiasa.Connection` to support all public and private database connections. DEPRECATED: the argument 'iamc15' has been deprecated in favor of names as queryable directly from the REST API.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -889,11 +889,10 @@ class IamDataFrame(object):
         # filter and groupby data, use `pd.Series.align` for matching index
         rows = self._apply_filters(region=region, variable=variable)
         if not rows.any():
-            msg = 'variable `{}` does not exsit in region `{}`'
+            msg = 'variable `{}` does not exist in region `{}`'
             logger().info(msg.format(variable, region))
-
             return
-        
+
         df_region, df_subregions = (
             _aggregate(self.data[rows], ['region', 'variable'])
             .align(df_subregions)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -888,6 +888,12 @@ class IamDataFrame(object):
 
         # filter and groupby data, use `pd.Series.align` for matching index
         rows = self._apply_filters(region=region, variable=variable)
+        if not rows.any():
+            msg = 'variable `{}` does not exsit in region `{}`'
+            logger().info(msg.format(variable, region))
+
+            return
+        
         df_region, df_subregions = (
             _aggregate(self.data[rows], ['region', 'variable'])
             .align(df_subregions)

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 import numpy as np
 import pandas as pd
@@ -82,13 +83,16 @@ def test_check_aggregate_pass(check_aggregate_df):
     assert obs is None
 
 
-def test_check_internal_consistency_no_world_for_variable_error(check_aggregate_df):
+def test_check_internal_consistency_no_world_for_variable(check_aggregate_df, caplog):
     assert check_aggregate_df.check_internal_consistency() is None
     test_df = check_aggregate_df.filter(
         variable='Emissions|CH4', region='World', keep=False
     )
-    # TODO: check warning is raised about Emissions|CH4 not existing in World
+    caplog.set_level(logging.INFO)
     test_df.check_internal_consistency()
+    warn_idx = caplog.messages.index("variable `Emissions|CH4` does not exist "
+                                     "in region `World`")
+    assert caplog.records[warn_idx].levelname == "INFO"
 
 
 def test_check_aggregate_fail(meta_df):
@@ -298,7 +302,9 @@ def test_aggregate_region_components_handling(check_aggregate_regional_df,
     pd.testing.assert_series_equal(res, exp)
 
 
-def test_check_aggregate_region_no_world(check_aggregate_regional_df):
+def test_check_aggregate_region_no_world(check_aggregate_regional_df, caplog):
     test_df = check_aggregate_regional_df.filter(region='World', keep=False)
-    # TODO: check warning is raised about Emissions|N2O not existing in World
     test_df.check_aggregate_region('Emissions|N2O', region='World')
+    warn_idx = caplog.messages.index("variable `Emissions|N2O` does not exist "
+                                     "in region `World`")
+    assert caplog.records[warn_idx].levelname == "INFO"

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -87,7 +87,7 @@ def test_check_internal_consistency_no_world_for_variable_error(check_aggregate_
     test_df = check_aggregate_df.filter(
         variable='Emissions|CH4', region='World', keep=False
     )
-    # what should happen here? at the moment it's a cryptic error..
+    # TODO: check warning is raised about Emissions|CH4 not existing in World
     test_df.check_internal_consistency()
 
 
@@ -300,5 +300,5 @@ def test_aggregate_region_components_handling(check_aggregate_regional_df,
 
 def test_check_aggregate_region_no_world(check_aggregate_regional_df):
     test_df = check_aggregate_regional_df.filter(region='World', keep=False)
-    # what do we want to happen here, at the moment the error is cryptic?
+    # TODO: check warning is raised about Emissions|N2O not existing in World
     test_df.check_aggregate_region('Emissions|N2O', region='World')

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -83,7 +83,9 @@ def test_check_aggregate_pass(check_aggregate_df):
     assert obs is None
 
 
-def test_check_internal_consistency_no_world_for_variable(check_aggregate_df, caplog):
+def test_check_internal_consistency_no_world_for_variable(
+    check_aggregate_df, caplog
+):
     assert check_aggregate_df.check_internal_consistency() is None
     test_df = check_aggregate_df.filter(
         variable='Emissions|CH4', region='World', keep=False

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -82,6 +82,15 @@ def test_check_aggregate_pass(check_aggregate_df):
     assert obs is None
 
 
+def test_check_internal_consistency_no_world_for_variable_error(check_aggregate_df):
+    assert check_aggregate_df.check_internal_consistency() is None
+    test_df = check_aggregate_df.filter(
+        variable='Emissions|CH4', region='World', keep=False
+    )
+    # what should happen here? at the moment it's a cryptic error..
+    test_df.check_internal_consistency()
+
+
 def test_check_aggregate_fail(meta_df):
     obs = meta_df.check_aggregate('Primary Energy', exclude_on_fail=True)
     assert len(obs.columns) == 2
@@ -287,3 +296,9 @@ def test_aggregate_region_components_handling(check_aggregate_regional_df,
     exp.name = "value"
 
     pd.testing.assert_series_equal(res, exp)
+
+
+def test_check_aggregate_region_no_world(check_aggregate_regional_df):
+    test_df = check_aggregate_regional_df.filter(region='World', keep=False)
+    # what do we want to happen here, at the moment the error is cryptic?
+    test_df.check_aggregate_region('Emissions|N2O', region='World')


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Updates pyam so behaviour of `check_aggregate_region` is sensible even if the region your checking is missing.
