### PR TITLE
Rewrite and extend the instructions for publishing a new release

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -1,5 +1,13 @@
 
-# Steps required for a release
+# Release procedure
+
+## Required accounts and admin privileges
+
+- pip: https://pypi.org/project/pyam-iamc/ and https://test.pypi.org/project/pyam-iamc/
+- conda: https://github.com/conda-forge/pyam-feedstock/
+- rtd: https://readthedocs.org/projects/pyam-iamc/
+
+## Steps for publishing a new release
 
 1. Make a release candidate branch and pull request it into master with the following updates:
    1. Deprecate any stated portion of the API (you can find them by searching the code base for "deprecate")

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -22,18 +22,17 @@
      - **THIS IS NOT THE TAGGED COMMIT WE WILL DISTRIBUTE, IT IS ONLY FOR TESTING**
 	 - **DO NOT PUSH THIS TAG TO UPSTREAM**
   1. Run `make publish-on-testpypi`
-     - this should "just work" if it does not, fix any issues, retag (`git tag
-       -d` then `git tag`), and try again
-	 - note, you need an account on https://test.pypi.org
-  1. Once successful, delete the tag, and merge the candidate PR into master on Github
-1. Switch to now updated master branch: `git checkout master` and `git pull upstream master`
+     - this should "just work" - if it does not, fix any issues,
+       retag (`git tag -d` then `git tag`), and try again
+  1. Once successful, delete the tag, and merge the candidate PR into `master` on Github
+1. Switch to the now-updated master branch: `git checkout master` and `git pull upstream master`
 1. Tag the release number: `git tag v<release version>`, e.g., `git tag v1.2.0`
    - `versioneer` automatically updates the version number based on the tag
    - this is now the official tagged commit
 1. Push the tag upstream: `git push upstream --tags`
 1. Run `make publish-on-pypi`
-   - note, you need an account on https://pypi.org
-   - this will make wheels that all us to be installed via `pip install`
+   - this will make wheels that allow `pyam` to be installed via `pip install`
+   - check that the new version is available at https://pypi.org/project/pyam-iamc/
 1. Make a new release on Github
    - Make sure that you choose the same tag name as was used earlier
    - Copy the markdown from `RELEASE_NOTES.md` into the release description box

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -41,9 +41,11 @@
    - confirm that any new depedencies are added there
    - merge the PR
    - check that the new version is available at https://anaconda.org/conda-forge/pyam
+1. Confirm that the doc pages are updated on https://pyam-iamc.readthedocs.io/
+   - both the **latest** and the **stable** versions point to the new release
+   - the new release has been added to the list of available versions
+1. Add a new line "# Next Release" at the top of `RELEASE_NOTES.md` and commit to `master`
 1. Announce it on our mailing list: https://groups.io/g/pyam
-   - Again, just copy the now rendered HTML from the Github release directly in
-     the email
-1. Confirm that the doc page is updated to the latest release: https://pyam-iamc.readthedocs.io/
+   - again, copy the rendered HTML from the Github release directly in the email
 
 And that's it! Whew...

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -34,11 +34,13 @@
    - this will make wheels that allow `pyam` to be installed via `pip install`
    - check that the new version is available at https://pypi.org/project/pyam-iamc/
 1. Make a new release on Github
-   - Make sure that you choose the same tag name as was used earlier
-   - Copy the markdown from `RELEASE_NOTES.md` into the release description box
-1. Update on conda-forge:
-   - A PR should automatically be opened by the bot after the Github release
+   - make sure that you choose the tag name defined above
+   - copy the release summary from `RELEASE_NOTES.md` into the description box
+1. Update on `conda-forge`
+   - a PR should automatically be opened by the bot after the Github release
    - confirm that any new depedencies are added there
+   - merge the PR
+   - check that the new version is available at https://anaconda.org/conda-forge/pyam
 1. Announce it on our mailing list: https://groups.io/g/pyam
    - Again, just copy the now rendered HTML from the Github release directly in
      the email

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -9,12 +9,14 @@
 
 ## Steps for publishing a new release
 
-1. Make a release candidate branch and pull request it into master with the following updates:
-   1. Deprecate any stated portion of the API (you can find them by searching the code base for "deprecate")
-   1. Update `RELEASE_NOTES.md` (see the examples of other releases)
-	  - create new section under "# Next Release" with "# Release v<release version>"
-	  - For this new release, add a "Highlights section" with some of the most important updates
-      - Make a new heading "## Individual Updates" before the PR listing
+1. Make a release candidate branch (e.g., `rc_v<release version>`)
+   and pull request it into `master` with the following updates:
+   1. Deprecate any stated portion of the API
+      (you can find them by searching the code base for "deprecate")
+   1. Update `RELEASE_NOTES.md` (see the examples of previous releases)
+	  - replace "# Next Release" with "# Release v<release version>"
+	  - for this new release, add a "## Highlights" section with the most important updates & changes
+      - add a new heading "## Individual Updates" before the PR listing
   1. Confirm that the PR passes all tests and checks
   1. Tag the release number: `git tag v<release version>`, e.g., `git tag v1.2.0`
      - **THIS IS NOT THE TAGGED COMMIT WE WILL DISTRIBUTE, IT IS ONLY FOR TESTING**


### PR DESCRIPTION
# Description of PR

This PR rewrites and adds some detail to the steos for publishing a release based on my experience with [release v0.3.0](https://github.com/IAMconsortium/pyam/releases/tag/v0.3.0).
