### PR TITLE
Add ability to request regions with synonyms from IXMP web API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 - [#295](https://github.com/IAMconsortium/pyam/pull/295) Include `meta` table when writing to or reading from `xlsx` files
 - [#292](https://github.com/IAMconsortium/pyam/pull/292) Add warning message if `data` is empty at initialization (after formatting)
 - [#288](https://github.com/IAMconsortium/pyam/pull/288) Put `pyam` logger in its own namespace (see [here](https://docs.python-guide.org/writing/logging/#logging-in-a-library>))
-
+- [#285](https://github.com/IAMconsortium/pyam/pull/285) Add ability to fetch regions with synonyms from IXMP API
 # Release v0.3.0
 
 ## Highlights

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -344,7 +344,9 @@ class Connection(object):
         r = requests.post(url, headers=headers, data=data)
         _check_response(r)
         # refactor returned json object to be castable to an IamDataFrame
-        df = pd.read_json(r.content, orient='records')
+        dtype = dict(model=str, scenario=str, variable=str, unit=str,
+                     region=str, year=int, value=float, version=int)
+        df = pd.read_json(r.content, orient='records', dtype=dtype)
         logger.debug('Response size is {0} bytes, '
                        '{1} records'.format(len(r.content), len(df)))
         columns = ['model', 'scenario', 'variable', 'unit',

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -251,7 +251,7 @@ class Connection(object):
             synonyms = df['synonyms'].apply(pd.Series)
             synonyms = synonyms.rename(columns=lambda x: 'synonym_' + str(x))
             # remove synonym_0 if no synonyms retrieved at all
-            synonyms = synonyms.dropna(axis=1)
+            synonyms = synonyms.dropna(axis=1, how='all')
             df = pd.concat([df[:], synonyms[:]], axis=1)
             df = df.drop(columns=['id', 'synonyms', 'parent', 'hierarchy'])
             df = df.rename(columns={'name': 'region'})

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -76,6 +76,12 @@ def test_regions():
     obs = conn.regions().values
     assert 'World' in obs
 
+# API changes to return synonyms not yet deployed to SR15
+# def test_regions_with_synonyms():
+#     conn = iiasa.Connection('IXSE_SR15')
+#     obs = conn.regions(include_synonyms=True)
+#     assert 'World' in obs
+
 
 def test_metadata():
     conn = iiasa.Connection('IXSE_SR15')

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -76,11 +76,13 @@ def test_regions():
     obs = conn.regions().values
     assert 'World' in obs
 
-# API changes to return synonyms not yet deployed to SR15
-# def test_regions_with_synonyms():
-#     conn = iiasa.Connection('IXSE_SR15')
-#     obs = conn.regions(include_synonyms=True)
-#     assert 'World' in obs
+
+def test_regions_with_synonyms():
+    conn = iiasa.Connection('IXSE_SR15')
+    obs = conn.regions(include_synonyms=True)
+    assert 'synonym_0' in obs.columns
+    assert (obs[obs.region == 'R5ROWO']
+            .synonym_0 == 'Rest of the World (R5)').all()
 
 
 def test_metadata():


### PR DESCRIPTION
Changes
- (optionally) fetch region synonyms
- fix fetching timeseries data explicitly specifying column types

---
- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added