### PR TITLE
[WIP] including `meta` table when reading and writing xlsx files

### DIFF
--- a/doc/source/tutorials/pyam_first_steps.ipynb
+++ b/doc/source/tutorials/pyam_first_steps.ipynb
@@ -705,8 +705,10 @@
    "source": [
     "## Exporting timeseries data for further analysis\n",
     "\n",
-    "The IamDataFrame can be directly exported to `xlsx` and `csv` in the standard IAMC format.  \n",
-    "This feature is based on [pd.DataFrame.to_excel()](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html) and can use any keyword arguments of that function."
+    "The `IamDataFrame` can be exported to `xlsx` and `csv` in the IAMC (wide) format. When writing to `xlsx`, both the timeseries data and the `meta` dataframe of categorization and quantitative indicators will be written to the file,\n",
+    "to two sheets named `data` and `meta` respectively.\n",
+    "\n",
+    "This feature is based on [pd.DataFrame.to_excel()](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html) and [pd.DataFrame.to_csv()](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_csv.html). It can use any keyword arguments of that function."
    ]
   },
   {
@@ -715,8 +717,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.to_excel('tutorial_export.xlsx')\n",
-    "df.export_metadata('tutorial_metadata.xlsx')"
+    "df.to_excel('tutorial_export.xlsx')"
    ]
   }
  ],

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1158,6 +1158,7 @@ class IamDataFrame(object):
 
     def export_metadata(self, excel_writer, sheet_name='meta'):
         """Deprecated, see :method:`export_meta()`"""
+        # TODO: deprecate in next release
         deprecation_warning('Use `export_meta() instead`!')
         self.export_meta(excel_writer, sheet_name='meta')
 
@@ -1180,6 +1181,7 @@ class IamDataFrame(object):
 
     def load_metadata(self, path, *args, **kwargs):
         """Deprecated, see :method:`load_meta()`"""
+        # TODO: deprecate in next release
         deprecation_warning('Use `load_meta() instead`!')
         self.load_meta(path, *args, **kwargs)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1184,9 +1184,6 @@ class IamDataFrame(object):
         path: string
             xlsx or csv file path to ``meta`` table
         """
-        if not os.path.exists(path):
-            raise ValueError("no metadata file '" + path + "' found!")
-
         if path.endswith('csv'):
             df = pd.read_csv(path, *args, **kwargs)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1134,25 +1134,42 @@ class IamDataFrame(object):
         if close:
             excel_writer.close()
 
-    def export_metadata(self, path):
-        """Export metadata to Excel
+    def export_metadata(self, excel_writer, sheet_name='meta'):
+        """Deprecated, see :method:`export_meta()`"""
+        msg = 'This function will be removed in future versions. {}'
+        logger().error(msg.format('Use `export_meta() instead`!'))
+        self.load_meta(excel_writer, sheet_name='meta')
+
+    def export_meta(self, excel_writer, sheet_name='meta'):
+        """Write the ``meta`` table of this object to an Excel sheet
 
         Parameters
         ----------
-        path: string
-            path/filename for xlsx file of metadata export
+        excel_writer: string or ExcelWriter object
+            file path or existing ExcelWriter
+        sheet_name: string
+            name of sheet which will contain ``IamDataFrame.meta`` table
         """
-        writer = pd.ExcelWriter(path)
-        write_sheet(writer, 'meta', self.meta, index=True)
-        writer.save()
+        if not isinstance(excel_writer, pd.ExcelWriter):
+            close = True
+            excel_writer = pd.ExcelWriter(excel_writer)
+        write_sheet(excel_writer, sheet_name, self.meta, index=True)
+        if close:
+            excel_writer.close()
 
     def load_metadata(self, path, *args, **kwargs):
-        """Load metadata exported from `pyam.IamDataFrame` instance
+        """Deprecated, see :method:`load_meta()`"""
+        msg = 'This function will be removed in future versions. {}'
+        logger().error(msg.format('Use `load_meta() instead`!'))
+        self.load_meta(path, *args, **kwargs)
+
+    def load_meta(self, path, *args, **kwargs):
+        """Load ``meta`` table  exported from a ``pyam.IamDataFrame`` instance
 
         Parameters
         ----------
         path: string
-            xlsx file with metadata exported from `pyam.IamDataFrame` instance
+            xlsx or csv file path to ``meta`` table
         """
         if not os.path.exists(path):
             raise ValueError("no metadata file '" + path + "' found!")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from pyam import plotting
 
-from pyam.logger import logger, adjust_log_level
+from pyam.logger import logger, adjust_log_level, deprecation_warning
 from pyam.run_control import run_control
 from pyam.utils import (
     write_sheet,
@@ -1158,8 +1158,7 @@ class IamDataFrame(object):
 
     def export_metadata(self, excel_writer, sheet_name='meta'):
         """Deprecated, see :method:`export_meta()`"""
-        msg = 'This function will be removed in future versions. {}'
-        logger().error(msg.format('Use `export_meta() instead`!'))
+        deprecation_warning('Use `export_meta() instead`!')
         self.load_meta(excel_writer, sheet_name='meta')
 
     def export_meta(self, excel_writer, sheet_name='meta'):
@@ -1181,8 +1180,7 @@ class IamDataFrame(object):
 
     def load_metadata(self, path, *args, **kwargs):
         """Deprecated, see :method:`load_meta()`"""
-        msg = 'This function will be removed in future versions. {}'
-        logger().error(msg.format('Use `load_meta() instead`!'))
+        deprecation_warning('Use `load_meta() instead`!')
         self.load_meta(path, *args, **kwargs)
 
     def load_meta(self, path, *args, **kwargs):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -62,6 +62,15 @@ class IamDataFrame(object):
         - one column in `df`
         - multiple columns, which will be concatenated by pipe
         - a string to be used as value for this column
+
+    Notes
+    -----
+    When initializing an :class:`IamDataFrame` from an :code:`xlsx` file,
+    :code:`pyam` will per default look for the sheets 'data' and 'meta' to
+    populate the respective tables. Custom sheet names can be specified with
+    the kwargs :code:`sheet_name` (for :code:`data`) and :code:`meta_sheet_name`
+    (for meta). Calling the class with :code:`meta_sheet_name=False` will skip
+    the import of the :code:`meta` table.
     """
 
     def __init__(self, data, **kwargs):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -68,9 +68,9 @@ class IamDataFrame(object):
     When initializing an :class:`IamDataFrame` from an :code:`xlsx` file,
     :code:`pyam` will per default look for the sheets 'data' and 'meta' to
     populate the respective tables. Custom sheet names can be specified with
-    the kwargs :code:`sheet_name` (for :code:`data`) and :code:`meta_sheet_name`
-    (for meta). Calling the class with :code:`meta_sheet_name=False` will skip
-    the import of the :code:`meta` table.
+    the kwargs :code:`sheet_name` (:code:`data`) and :code:`meta_sheet_name`
+    (:code:`meta`). Calling the class with :code:`meta_sheet_name=False` will
+    skip the import of the :code:`meta` table.
     """
 
     def __init__(self, data, **kwargs):
@@ -92,11 +92,11 @@ class IamDataFrame(object):
 
         self._LONG_IDX = IAMC_IDX + [self.time_col] + self.extra_cols
 
-        # define a dataframe for categorization and other metadata indicators
+        # define `meta` dataframe for categorization & quantitative indicators
         self.meta = self.data[META_IDX].drop_duplicates().set_index(META_IDX)
         self.reset_exclude()
 
-        # if initialized from xlsx, try to load `meta` table from file
+        # if initializing from xlsx, try to load `meta` table from file
         meta_sheet = kwargs.get('meta_sheet_name', 'meta')
         if isstr(data) and data.endswith('.xlsx') and meta_sheet is not False\
                 and meta_sheet in pd.ExcelFile(data).sheet_names:
@@ -1137,10 +1137,10 @@ class IamDataFrame(object):
         sheet_name: string
             name of sheet which will contain ``IamDataFrame.timeseries()`` data
         iamc_index: bool, default False
-            if True, use ``['model', 'scenario', 'region', 'variable', 'unit']`;
-            else, use all ``data`` columns
+            if True, use :code:`['model', 'scenario', 'region', 'variable',
+            'unit']`; else, use all :code:`data` columns
         include_meta: boolean or string
-            if True, write ``meta`` to an Excel sheet 'meta' (default);
+            if True, write :code:`meta` to an Excel sheet 'meta' (default);
             if this is a string, use it as sheet name
         """
         if not isinstance(excel_writer, pd.ExcelWriter):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1099,7 +1099,7 @@ class IamDataFrame(object):
         return df
 
     def to_csv(self, path, iamc_index=False, **kwargs):
-        """Write timeseries data to a csv file
+        """Write timeseries data of this object to a csv file
 
         Parameters
         ----------

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1159,7 +1159,7 @@ class IamDataFrame(object):
     def export_metadata(self, excel_writer, sheet_name='meta'):
         """Deprecated, see :method:`export_meta()`"""
         deprecation_warning('Use `export_meta() instead`!')
-        self.load_meta(excel_writer, sheet_name='meta')
+        self.export_meta(excel_writer, sheet_name='meta')
 
     def export_meta(self, excel_writer, sheet_name='meta'):
         """Write the ``meta`` table of this object to an Excel sheet

--- a/pyam/logger.py
+++ b/pyam/logger.py
@@ -28,4 +28,4 @@ def adjust_log_level(level='ERROR'):
 def deprecation_warning(msg):
     """Write deprecation warning to log"""
     warn = 'This method is deprecated and will be removed in future versions.'
-    logger().warning('{} {}'.format(warn, msg)
+    logger().warning('{} {}'.format(warn, msg))

--- a/pyam/logger.py
+++ b/pyam/logger.py
@@ -23,3 +23,9 @@ def adjust_log_level(level='ERROR'):
     _logger.setLevel(level)
     yield
     _logger.setLevel(old_level)
+
+
+def deprecation_warning(msg):
+    """Write deprecation warning to log"""
+    warn = 'This method is deprecated and will be removed in future versions.'
+    logger().warning('{} {}'.format(warn, msg)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -98,8 +98,6 @@ def write_sheet(writer, name, df, index=False):
 
 def read_pandas(fname, *args, **kwargs):
     """Read a file and return a pd.DataFrame"""
-    if not os.path.exists(fname):
-        raise ValueError('no data file `{}` found!'.format(fname))
     if fname.endswith('csv'):
         df = pd.read_csv(fname, *args, **kwargs)
     else:

--- a/tests/data/testing_data_2.csv
+++ b/tests/data/testing_data_2.csv
@@ -1,2 +1,0 @@
-model,scenario,region,variable,unit,2005
-a_model,append_scenario,World,Primary Energy,EJ/y,2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,20 +136,6 @@ def test_init_datetime_subclass_long_timespan(test_pd_df):
     assert df["time"].min() == tmin
 
 
-def test_to_excel(test_df):
-    fname = 'foo_testing.xlsx'
-    test_df.to_excel(fname)
-    assert os.path.exists(fname)
-    os.remove(fname)
-
-
-def test_to_csv(test_df):
-    fname = 'foo_testing.csv'
-    test_df.to_csv(fname)
-    assert os.path.exists(fname)
-    os.remove(fname)
-
-
 def test_get_item(test_df):
     assert test_df['model'].unique() == ['model_a']
 
@@ -475,11 +461,6 @@ def test_timeseries(test_df):
     npt.assert_array_equal(obs, exp)
 
 
-def test_read_pandas():
-    df = IamDataFrame(os.path.join(TEST_DATA_DIR, 'testing_data_2.csv'))
-    assert list(df.variables()) == ['Primary Energy']
-
-
 def test_filter_meta_index(meta_df):
     obs = meta_df.filter(scenario='scen_b').meta.index
     exp = pd.MultiIndex(levels=[['model_a'], ['scen_b']],
@@ -622,32 +603,6 @@ def test_category_top_level(meta_df):
                variable='Primary Energy')
     obs = meta_df['category']
     pd.testing.assert_series_equal(obs, exp)
-
-
-def test_load_metadata(meta_df):
-    meta_df.load_metadata(os.path.join(
-        TEST_DATA_DIR, 'testing_metadata.xlsx'), sheet_name='meta')
-    obs = meta_df.meta
-
-    dct = {'model': ['model_a'] * 2, 'scenario': ['scen_a', 'scen_b'],
-           'category': ['imported', np.nan], 'exclude': [False, False]}
-    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])
-    pd.testing.assert_series_equal(obs['exclude'], exp['exclude'])
-    pd.testing.assert_series_equal(obs['category'], exp['category'])
-
-
-def test_load_SSP_database_downloaded_file(test_df_year):
-    obs_df = IamDataFrame(os.path.join(
-        TEST_DATA_DIR, 'test_SSP_database_raw_download.xlsx')
-    )
-    pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df_year.as_pandas())
-
-
-def test_load_RCP_database_downloaded_file(test_df_year):
-    obs_df = IamDataFrame(os.path.join(
-        TEST_DATA_DIR, 'test_RCP_database_raw_download.xlsx')
-    )
-    pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df_year.as_pandas())
 
 
 def test_interpolate(test_df_year):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,11 +19,20 @@ def test_io_csv(meta_df):
     # assert that `data` tables are equal and delete file
     pd.testing.assert_frame_equal(meta_df.data, import_df.data)
     os.remove(file)
-    import_df = IamDataFrame(fname)
 
-    # assert that `data` tables are equal and delete file
+
+def test_io_xlsx(meta_df):
+    # write to xlsx
+    file = 'testing_io_write_read.xlsx'
+    meta_df.to_excel(file)
+
+    # read from xlsx
+    import_df = IamDataFrame(file)
+
+    # assert that `data` and `meta` tables are equal and delete file
     pd.testing.assert_frame_equal(meta_df.data, import_df.data)
-    os.remove(fname)
+
+    os.remove(file)
 
 
 @pytest.mark.parametrize("args", [{}, dict(sheet_name='meta')])
@@ -51,10 +60,3 @@ def test_load_rcp_database_downloaded_file(test_df_year):
         TEST_DATA_DIR, 'test_RCP_database_raw_download.xlsx')
     )
     pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df_year.as_pandas())
-
-
-def test_to_excel(test_df):
-    fname = 'foo_testing.xlsx'
-    test_df.to_excel(fname)
-    assert os.path.exists(fname)
-    os.remove(fname)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -10,10 +10,15 @@ from conftest import TEST_DATA_DIR
 
 def test_io_csv(meta_df):
     # write to csv
-    fname = 'foo_testing.csv'
-    meta_df.to_csv(fname)
+    file = 'foo_testing.csv'
+    meta_df.to_csv(file)
 
     # read from csv
+    import_df = IamDataFrame(file)
+
+    # assert that `data` tables are equal and delete file
+    pd.testing.assert_frame_equal(meta_df.data, import_df.data)
+    os.remove(file)
     import_df = IamDataFrame(fname)
 
     # assert that `data` tables are equal and delete file

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,6 +22,9 @@ def test_io_csv(meta_df):
 
 
 def test_io_xlsx(meta_df):
+    # add column to `meta`
+    meta_df.set_meta(['a', 'b'], 'string')
+
     # write to xlsx
     file = 'testing_io_write_read.xlsx'
     meta_df.to_excel(file)
@@ -31,6 +34,7 @@ def test_io_xlsx(meta_df):
 
     # assert that `data` and `meta` tables are equal and delete file
     pd.testing.assert_frame_equal(meta_df.data, import_df.data)
+    pd.testing.assert_frame_equal(meta_df.meta, import_df.meta)
 
     os.remove(file)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -21,16 +21,20 @@ def test_io_csv(meta_df):
     os.remove(file)
 
 
-def test_io_xlsx(meta_df):
+@pytest.mark.parametrize("meta_args", [
+    [{}, {}],
+    [dict(include_meta='foo'), dict(meta_sheet_name='foo')]
+])
+def test_io_xlsx(meta_df, meta_args):
     # add column to `meta`
     meta_df.set_meta(['a', 'b'], 'string')
 
     # write to xlsx
     file = 'testing_io_write_read.xlsx'
-    meta_df.to_excel(file)
+    meta_df.to_excel(file, **meta_args[0])
 
     # read from xlsx
-    import_df = IamDataFrame(file)
+    import_df = IamDataFrame(file, **meta_args[1])
 
     # assert that `data` and `meta` tables are equal and delete file
     pd.testing.assert_frame_equal(meta_df.data, import_df.data)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,52 @@
+import os
+import pandas as pd
+import numpy as np
+
+from pyam import IamDataFrame
+
+from conftest import TEST_DATA_DIR
+
+
+def test_read_csv():
+    df = IamDataFrame(os.path.join(TEST_DATA_DIR, 'testing_data_2.csv'))
+    assert list(df.variables()) == ['Primary Energy']
+
+
+def test_load_metadata(meta_df):
+    meta_df.load_metadata(os.path.join(
+        TEST_DATA_DIR, 'testing_metadata.xlsx'), sheet_name='meta')
+    obs = meta_df.meta
+
+    dct = {'model': ['model_a'] * 2, 'scenario': ['scen_a', 'scen_b'],
+           'category': ['imported', np.nan], 'exclude': [False, False]}
+    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])
+    pd.testing.assert_series_equal(obs['exclude'], exp['exclude'])
+    pd.testing.assert_series_equal(obs['category'], exp['category'])
+
+
+def test_load_SSP_database_downloaded_file(test_df_year):
+    obs_df = IamDataFrame(os.path.join(
+        TEST_DATA_DIR, 'test_SSP_database_raw_download.xlsx')
+    )
+    pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df_year.as_pandas())
+
+
+def test_load_RCP_database_downloaded_file(test_df_year):
+    obs_df = IamDataFrame(os.path.join(
+        TEST_DATA_DIR, 'test_RCP_database_raw_download.xlsx')
+    )
+    pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df_year.as_pandas())
+
+
+def test_to_excel(test_df):
+    fname = 'foo_testing.xlsx'
+    test_df.to_excel(fname)
+    assert os.path.exists(fname)
+    os.remove(fname)
+
+
+def test_to_csv(test_df):
+    fname = 'foo_testing.csv'
+    test_df.to_csv(fname)
+    assert os.path.exists(fname)
+    os.remove(fname)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -44,7 +44,7 @@ def test_io_xlsx(meta_df, meta_args):
 
 
 @pytest.mark.parametrize("args", [{}, dict(sheet_name='meta')])
-def test_load_metadata(meta_df, args):
+def test_load_meta(meta_df, args):
     file = os.path.join(TEST_DATA_DIR, 'testing_metadata.xlsx')
     meta_df.load_meta(file, **args)
     obs = meta_df.meta

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 import numpy as np
+import pytest
 
 from pyam import IamDataFrame
 
@@ -12,9 +13,10 @@ def test_read_csv():
     assert list(df.variables()) == ['Primary Energy']
 
 
-def test_load_metadata(meta_df):
-    meta_df.load_metadata(os.path.join(
-        TEST_DATA_DIR, 'testing_metadata.xlsx'), sheet_name='meta')
+@pytest.mark.parametrize("args", [{}, dict(sheet_name='meta')])
+def test_load_metadata(meta_df, args):
+    file = os.path.join(TEST_DATA_DIR, 'testing_metadata.xlsx')
+    meta_df.load_meta(file, **args)
     obs = meta_df.meta
 
     dct = {'model': ['model_a'] * 2, 'scenario': ['scen_a', 'scen_b'],

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -10,7 +10,7 @@ from conftest import TEST_DATA_DIR
 
 def test_io_csv(meta_df):
     # write to csv
-    file = 'foo_testing.csv'
+    file = 'testing_io_write_read.csv'
     meta_df.to_csv(file)
 
     # read from csv

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -26,14 +26,14 @@ def test_load_metadata(meta_df, args):
     pd.testing.assert_series_equal(obs['category'], exp['category'])
 
 
-def test_load_SSP_database_downloaded_file(test_df_year):
+def test_load_ssp_database_downloaded_file(test_df_year):
     obs_df = IamDataFrame(os.path.join(
         TEST_DATA_DIR, 'test_SSP_database_raw_download.xlsx')
     )
     pd.testing.assert_frame_equal(obs_df.as_pandas(), test_df_year.as_pandas())
 
 
-def test_load_RCP_database_downloaded_file(test_df_year):
+def test_load_rcp_database_downloaded_file(test_df_year):
     obs_df = IamDataFrame(os.path.join(
         TEST_DATA_DIR, 'test_RCP_database_raw_download.xlsx')
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,9 +8,17 @@ from pyam import IamDataFrame
 from conftest import TEST_DATA_DIR
 
 
-def test_read_csv():
-    df = IamDataFrame(os.path.join(TEST_DATA_DIR, 'testing_data_2.csv'))
-    assert list(df.variables()) == ['Primary Energy']
+def test_io_csv(meta_df):
+    # write to csv
+    fname = 'foo_testing.csv'
+    meta_df.to_csv(fname)
+
+    # read from csv
+    import_df = IamDataFrame(fname)
+
+    # assert that `data` tables are equal and delete file
+    pd.testing.assert_frame_equal(meta_df.data, import_df.data)
+    os.remove(fname)
 
 
 @pytest.mark.parametrize("args", [{}, dict(sheet_name='meta')])
@@ -43,12 +51,5 @@ def test_load_rcp_database_downloaded_file(test_df_year):
 def test_to_excel(test_df):
     fname = 'foo_testing.xlsx'
     test_df.to_excel(fname)
-    assert os.path.exists(fname)
-    os.remove(fname)
-
-
-def test_to_csv(test_df):
-    fname = 'foo_testing.csv'
-    test_df.to_csv(fname)
     assert os.path.exists(fname)
     os.remove(fname)

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -64,7 +64,6 @@ def test_pyam_first_steps(capsys):
     nb, errors = _notebook_run(fname, capsys=capsys)
     assert errors == []
     assert os.path.exists(os.path.join(tut_path, 'tutorial_export.xlsx'))
-    assert os.path.exists(os.path.join(tut_path, 'tutorial_metadata.xlsx'))
 
 
 @pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Following #286 and some offline discussions about supporting more data formats, this PR implements also writing the `meta` table (by default, option to switch off) as part of `to_excel()`. Similarly, when initialising from `xlsx`, it will look for a `meta` sheet and use it to populate that table.

As an aside, the PR also streamlines the IO-tests and moves them into an own test file.
