### PR TITLE
Log message nan data in init

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#290](https://github.com/IAMconsortium/pyam/pull/290) Add warning message if nan rows are detected in init data
 - [#288](https://github.com/IAMconsortium/pyam/pull/288) Put `pyam` logger in its own namespace (see [here](https://docs.python-guide.org/writing/logging/#logging-in-a-library>))
 
 # Release v0.3.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 
 # Next Release
 
-- [#290](https://github.com/IAMconsortium/pyam/pull/290) Add warning message if `data` is empty at initialization (after formatting)
+- [#292](https://github.com/IAMconsortium/pyam/pull/292) Add warning message if `data` is empty at initialization (after formatting)
 - [#288](https://github.com/IAMconsortium/pyam/pull/288) Put `pyam` logger in its own namespace (see [here](https://docs.python-guide.org/writing/logging/#logging-in-a-library>))
 
 # Release v0.3.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 
 # Next Release
 
-- [#290](https://github.com/IAMconsortium/pyam/pull/290) Add warning message if nan rows are detected in init data
+- [#290](https://github.com/IAMconsortium/pyam/pull/290) Add warning message if `data` is empty at initialization (after formatting)
 - [#288](https://github.com/IAMconsortium/pyam/pull/288) Put `pyam` logger in its own namespace (see [here](https://docs.python-guide.org/writing/logging/#logging-in-a-library>))
 
 # Release v0.3.0

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -246,7 +246,9 @@ def format_data(df, **kwargs):
 
     # cast value columns to numeric, drop NaN's, sort data
     df['value'] = df['value'].astype('float64')
-    df.dropna(inplace=True)
+    if df.isnull().any().any():
+        logger.warning("dropping rows containing any na values")
+        df.dropna(inplace=True)
 
     # check for duplicates and return sorted data
     idx_cols = IAMC_IDX + [time_col] + extra_cols

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -255,7 +255,8 @@ def format_data(df, **kwargs):
 
     if df.empty:
         logger.warning(
-            'Formatted data is empty! (perhaps there is a column full of nans?)'
+            'Formatted data is empty! (perhaps there is a column full of '
+            'nans?)'
         )
 
     return sort_data(df, idx_cols), time_col, extra_cols

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -246,14 +246,17 @@ def format_data(df, **kwargs):
 
     # cast value columns to numeric, drop NaN's, sort data
     df['value'] = df['value'].astype('float64')
-    if df.isnull().any().any():
-        logger.warning("dropping rows containing any na values")
-        df.dropna(inplace=True)
+    df.dropna(inplace=True)
 
     # check for duplicates and return sorted data
     idx_cols = IAMC_IDX + [time_col] + extra_cols
     if any(df[idx_cols].duplicated()):
         raise ValueError('duplicate rows in `data`!')
+
+    if df.empty:
+        logger.warning(
+            'Formatted data is empty! (perhaps there is a column full of nans?)'
+        )
 
     return sort_data(df, idx_cols), time_col, extra_cols
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -145,8 +145,8 @@ def test_init_dropping_nans_message(test_pd_df, caplog):
     res = IamDataFrame(tdf)
     assert "Primary Energy|Coal" not in res.variables().tolist()
 
-    drop_message = "dropping na rows"
-    message_idx = caplog.messages.index[drop_message]
+    drop_message = "dropping rows containing any na values"
+    message_idx = caplog.messages.index(drop_message)
     assert caplog.records[message_idx].levelno == logging.WARNING
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,15 +137,17 @@ def test_init_datetime_subclass_long_timespan(test_pd_df):
     assert df["time"].min() == tmin
 
 
-def test_init_dropping_nans_message(test_pd_df, caplog):
+def test_init_empty_message(test_pd_df, caplog):
     tdf = test_pd_df.copy()
     tdf["extra_col"] = "test_val"
-    tdf["extra_col"][tdf["variable"] == "Primary Energy|Coal"] = np.nan
+    tdf["extra_col"] = np.nan
 
     res = IamDataFrame(tdf)
     assert "Primary Energy|Coal" not in res.variables().tolist()
 
-    drop_message = "dropping rows containing any na values"
+    drop_message = (
+        "Formatted data is empty! (perhaps there is a column full of nans?)"
+    )
     message_idx = caplog.messages.index(drop_message)
     assert caplog.records[message_idx].levelno == logging.WARNING
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import pytest
 import re
 import datetime
@@ -134,6 +135,19 @@ def test_init_datetime_subclass_long_timespan(test_pd_df):
 
     assert df["time"].max() == tmax
     assert df["time"].min() == tmin
+
+
+def test_init_dropping_nans_message(test_pd_df, caplog):
+    tdf = test_pd_df.copy()
+    tdf["extra_col"] = "test_val"
+    tdf["extra_col"][tdf["variable"] == "Primary Energy|Coal"] = np.nan
+
+    res = IamDataFrame(tdf)
+    assert "Primary Energy|Coal" not in res.variables().tolist()
+
+    drop_message = "dropping na rows"
+    message_idx = caplog.messages.index[drop_message]
+    assert caplog.records[message_idx].levelno == logging.WARNING
 
 
 def test_to_excel(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added (N/A)
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

A log message is now thrown if any null data is found on initialisation so that users know it's being dropped (I get caught out a lot being like, 'where has all my data gone'). Inspired by #291 and discussions in #286 
