### PR TITLE
add `empty` attribute, better error for `timeseries()` on empty dataframe

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#297](https://github.com/IAMconsortium/pyam/pull/297) Add `empty` attribute, better error for `timeseries()` on empty dataframe 
 - [#292](https://github.com/IAMconsortium/pyam/pull/292) Add warning message if `data` is empty at initialization (after formatting)
 - [#288](https://github.com/IAMconsortium/pyam/pull/288) Put `pyam` logger in its own namespace (see [here](https://docs.python-guide.org/writing/logging/#logging-in-a-library>))
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -389,7 +389,7 @@ class IamDataFrame(object):
         Raises
         ------
         AttributeError
-            `IamDataFrame` is empty
+            ``IamDataFrame`` is empty
         ValueError
             reducing to IAMC-index yields an index with duplicates
         """

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -388,13 +388,13 @@ class IamDataFrame(object):
 
         Raises
         ------
-        AttributeError
+        ValueError
             ``IamDataFrame`` is empty
         ValueError
             reducing to IAMC-index yields an index with duplicates
         """
         if self.empty:
-            raise AttributeError('this `IamDataFrame` is empty')
+            raise ValueError('this `IamDataFrame` is empty')
 
         index = IAMC_IDX if iamc_index else IAMC_IDX + self.extra_cols
         df = (

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -148,6 +148,11 @@ class IamDataFrame(object):
         """Identical to pd.DataFrame.tail() operating on data"""
         return self.data.tail(*args, **kwargs)
 
+    @property
+    def empty(self):
+        """Indicator whether ``IamDataFrame`` is empty"""
+        return self.data.empty
+
     def models(self):
         """Get a list of models"""
         return pd.Series(self.meta.index.levels[0])

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -378,7 +378,7 @@ class IamDataFrame(object):
         return list(cols)
 
     def timeseries(self, iamc_index=False):
-        """Returns a pd.DataFrame in wide format (years or timedate as columns)
+        """Returns a pd.DataFrame in wide format (years or datetime as columns)
 
         Parameters
         ----------

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -385,7 +385,17 @@ class IamDataFrame(object):
         iamc_index: bool, default False
             if True, use `['model', 'scenario', 'region', 'variable', 'unit']`;
             else, use all `data` columns
+
+        Raises
+        ------
+        AttributeError
+            `IamDataFrame` is empty
+        ValueError
+            reducing to IAMC-index yields an index with duplicates
         """
+        if self.empty:
+            raise AttributeError('this `IamDataFrame` is empty')
+
         index = IAMC_IDX if iamc_index else IAMC_IDX + self.extra_cols
         df = (
             self.data

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -498,7 +498,7 @@ def test_timeseries(test_df):
 
 def test_timeseries_raises(test_df_year):
     _df = test_df_year.filter(model='foo')
-    pytest.raises(AttributeError, _df.timeseries)
+    pytest.raises(ValueError, _df.timeseries)
 
 
 def test_read_pandas():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -152,6 +152,11 @@ def test_init_empty_message(test_pd_df, caplog):
     assert caplog.records[message_idx].levelno == logging.WARNING
 
 
+def test_empty_attribute(test_df_year):
+    assert not test_df_year.empty
+    assert test_df_year.filter(model='foo').empty
+
+
 def test_to_excel(test_df):
     fname = 'foo_testing.xlsx'
     test_df.to_excel(fname)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -496,6 +496,11 @@ def test_timeseries(test_df):
     npt.assert_array_equal(obs, exp)
 
 
+def test_timeseries_raises(test_df_year):
+    _df = test_df_year.filter(model='foo')
+    pytest.raises(AttributeError, _df.timeseries)
+
+
 def test_read_pandas():
     df = IamDataFrame(os.path.join(TEST_DATA_DIR, 'testing_data_2.csv'))
     assert list(df.variables()) == ['Primary Energy']

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -39,8 +39,8 @@ def _notebook_run(path, kernel=None, timeout=60, capsys=None):
     fname = os.path.join(here, 'test.ipynb')
     args = [
         "jupyter", "nbconvert", "--to", "notebook", "--execute",
-        "--ExecutePreprocessor.timeout={}",
-        "--ExecutePreprocessor.kernel_name={}".format(timeout, kernel),
+        "--ExecutePreprocessor.timeout={}".format(timeout),
+        "--ExecutePreprocessor.kernel_name={}".format(kernel),
         "--output", fname, path]
     subprocess.check_call(args)
 

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -28,7 +28,7 @@ tut_path = os.path.join(here, '..', 'doc', 'source', 'tutorials')
 # https://blog.thedataincubator.com/2016/06/testing-jupyter-notebooks/
 
 
-def _notebook_run(path, kernel=None, capsys=None):
+def _notebook_run(path, kernel=None, timeout=60, capsys=None):
     """Execute a notebook via nbconvert and collect output.
     :returns (parsed nb object, execution errors)
     """
@@ -39,8 +39,8 @@ def _notebook_run(path, kernel=None, capsys=None):
     fname = os.path.join(here, 'test.ipynb')
     args = [
         "jupyter", "nbconvert", "--to", "notebook", "--execute",
-        "--ExecutePreprocessor.timeout=60",
-        "--ExecutePreprocessor.kernel_name={}".format(kernel),
+        "--ExecutePreprocessor.timeout={}",
+        "--ExecutePreprocessor.kernel_name={}".format(timeout, kernel),
         "--output", fname, path]
     subprocess.check_call(args)
 
@@ -87,7 +87,7 @@ def test_pyam_logo():
 @pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
 def test_iiasa_dbs():
     fname = os.path.join(tut_path, 'iiasa_dbs.ipynb')
-    nb, errors = _notebook_run(fname)
+    nb, errors = _notebook_run(fname, timeout=600)
     assert errors == []
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR adds an `empty` attribute and adds a better error message when doing `timeseries()` on an empty `IamDataFrame`.

Closes #291 
