### PR TITLE
Bugfix for writing `to_excel` with `pd.ExcelWriter`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#301](https://github.com/IAMconsortium/pyam/pull/301) Bugfix when using `to_excel()` with a `pd.ExcelWriter`
 - [#297](https://github.com/IAMconsortium/pyam/pull/297) Add `empty` attribute, better error for `timeseries()` on empty dataframe 
 - [#295](https://github.com/IAMconsortium/pyam/pull/295) Include `meta` table when writing to or reading from `xlsx` files
 - [#292](https://github.com/IAMconsortium/pyam/pull/292) Add warning message if `data` is empty at initialization (after formatting)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1161,6 +1161,7 @@ class IamDataFrame(object):
             if True, write :code:`meta` to an Excel sheet 'meta' (default);
             if this is a string, use it as sheet name
         """
+        close = False
         if not isinstance(excel_writer, pd.ExcelWriter):
             close = True
             excel_writer = pd.ExcelWriter(excel_writer)
@@ -1171,6 +1172,8 @@ class IamDataFrame(object):
         include_meta = 'meta' if include_meta is True else include_meta
         if isstr(include_meta):
             write_sheet(excel_writer, include_meta, self.meta, index=True)
+
+        # close the file if `excel_writer` arg was a file name
         if close:
             excel_writer.close()
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -29,18 +29,20 @@ def test_io_xlsx(meta_df, meta_args):
     # add column to `meta`
     meta_df.set_meta(['a', 'b'], 'string')
 
-    # write to xlsx
+    # write to xlsx (direct file name and ExcelWriter, see bug report #300)
     file = 'testing_io_write_read.xlsx'
-    meta_df.to_excel(file, **meta_args[0])
+    for f in [file, pd.ExcelWriter(file)]:
+        meta_df.to_excel(f, **meta_args[0])
+        if isinstance(f, pd.ExcelWriter):
+            f.close()
 
-    # read from xlsx
-    import_df = IamDataFrame(file, **meta_args[1])
+        # read from xlsx
+        import_df = IamDataFrame(file, **meta_args[1])
 
-    # assert that `data` and `meta` tables are equal and delete file
-    pd.testing.assert_frame_equal(meta_df.data, import_df.data)
-    pd.testing.assert_frame_equal(meta_df.meta, import_df.meta)
-
-    os.remove(file)
+        # assert that `data` and `meta` tables are equal and delete file
+        pd.testing.assert_frame_equal(meta_df.data, import_df.data)
+        pd.testing.assert_frame_equal(meta_df.meta, import_df.meta)
+        os.remove(file)
 
 
 @pytest.mark.parametrize("args", [{}, dict(sheet_name='meta')])


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Bugfix when using `to_excel()` with a `pd.ExcelWriter` instance, including an extension of the unit test.

Closes #300
