### PR TITLE
reinsert cython as dependency on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - conda --version
   - activate testing
   - conda install -y numpy pandas pyyaml xlrd xlsxwriter seaborn==0.9.0 six requests jupyter nbconvert proj4==5.2.0 pywin32
-  - conda install -y -c conda-forge matplotlib==3.0.3 pyproj==1.9.6
+  - conda install -y -c conda-forge matplotlib==3.0.3 cython pyproj==1.9.6
 
 build: false
 


### PR DESCRIPTION
This PR tries to fix an issue on Appveyor (ie Windows) only occurring with Python 3.7. 

```
> pyam\utils.py:21: in <module>
>     logger = logging.getLogger(__name__)
> E   AttributeError: 'module' object has no attribute 'getLogger'
```