### PR TITLE
remove testing of Py3.7 on Appveyor because of `lru_cache`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
       - PYTHON_VERSION: "3.6"
         MINICONDA: "C:\\Miniconda36-x64"
         PYTHON_ARCH: "64"
-      - PYTHON_VERSION: "3.7"
-        MINICONDA: "C:\\Miniconda37-x64"
-        PYTHON_ARCH: "64"
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -5,14 +5,10 @@ import os
 import requests
 import warnings
 import yaml
+from functools import lru_cache
 
 import numpy as np
 import pandas as pd
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from functools32 import lru_cache
 
 from pyam.core import IamDataFrame
 from pyam.utils import META_IDX, islistable, isstr, pattern_match


### PR DESCRIPTION
# Description of PR

This is a quick fix for an issue running tests on Appveyor with Python 3.7 - importing `lru_cache` fails, maybe due to https://bugs.python.org/issue36650

```
> pyam\iiasa.py:8: in <module>
>     from functools import lru_cache
>     ImportError: cannot import name lru_cache
```