### PR TITLE
add io-support for frictionless `datapackage`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *png
 *jpg
 *pdf
+*zip
+*json
 
 # Apple file system
 *.DS_STORE

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $(VENV_DIR):  $(CI_ENVIRONMENT_CONDA_DEFAULT_FILE) $(CI_ENVIRONMENT_CONDA_FORGE_
 	$(CONDA_EXE) config --add channels conda-forge # sets conda-forge as highest priority
 	$(CONDA_EXE) install --yes $(shell cat $(CI_ENVIRONMENT_CONDA_DEFAULT_FILE) $(CI_ENVIRONMENT_CONDA_FORGE_FILE) | tr '\n' ' ')
 	# Install development setup
-	$(VENV_DIR)/bin/pip install -e .[tests,deploy]
+	$(VENV_DIR)/bin/pip install -e .[tests,deploy,optional-io-formats]
 	# install docs requirements
 	# --name $(CONDA_DEFAULT_ENV) ensures we install in active environment (check at
 	# top of Makefile ensures that environment is not the base one)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Next release
 
+- [#323](https://github.com/IAMconsortium/pyam/pull/323) Support import/export of frictionless `datapackage` format
+
 # Release v0.4.0
 
 ## Highlights

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ build: false
 
 test_script:
   - conda list
-  - pip install -e .[tests,deploy]
+  - pip install -e .[tests,deploy,optional-io-formats]
   - pytest -v --mpl tests --mpl-results-path=test-artifacts
 
 artifacts:

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -6,4 +6,3 @@ gdal
 fiona
 "poppler<0.66"
 cython
-datapackage

--- a/ci/environment-conda-forge.txt
+++ b/ci/environment-conda-forge.txt
@@ -4,7 +4,6 @@ matplotlib-base==3.0.3
 seaborn==0.9.0
 gdal
 fiona
-"geopandas<0.5.0"
 "poppler<0.66"
 cython
-cartopy
+datapackage

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1288,7 +1288,7 @@ class IamDataFrame(object):
             excel_writer.close()
 
     def to_datapackage(self, path, tmp='tmp'):
-        """Write object to a frictionless datapackage
+        """Write object to a frictionless Data Package
 
         More information: https://frictionlessdata.io
 
@@ -1298,7 +1298,7 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        path: string
+        path: string or pathlib.Path
             file path
         tmp: string, default 'tmp'
             name for temporary folder to export csv files
@@ -1819,11 +1819,11 @@ def concat(dfs):
 
 
 def read_datapackage(path, data='data', meta='meta'):
-    """Read timeseries data (and meta-indicators) from frictionless datapackage
+    """Read timeseries data (and meta-indicators) from frictionless Data Package
 
     Parameters
     ----------
-    path: path to datapackage
+    path: path to Data Package
         passed to ``datapackage.Package()``
     data: str, default `data`
         resource containing timeseries data in IAMC-compatible format

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -10,7 +10,12 @@ import pandas as pd
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from datapackage import Package
+
+try:
+    from datapackage import Package
+    HAS_DATAPACKAGE = True
+except IoError:
+    HAS_DATAPACKAGE = False
 
 try:
     import ixmp
@@ -1303,6 +1308,9 @@ class IamDataFrame(object):
             file path
         """
 
+        if not HAS_DATAPACKAGE:
+            raise ImportError('required package `datapackage` not found!')
+
         with TemporaryDirectory(dir='.') as tmp:
             # save data and meta tables to a temporary folder
             self.data.to_csv(Path(tmp) / 'data.csv', index=False)
@@ -1808,7 +1816,7 @@ def concat(dfs):
 
 
 def read_datapackage(path, data='data', meta='meta'):
-    """Read timeseries data (and meta-indicators) from frictionless Data Package
+    """Read timeseries data and meta-indicators from frictionless Data Package
 
     Parameters
     ----------
@@ -1820,6 +1828,9 @@ def read_datapackage(path, data='data', meta='meta'):
         (optional) resource containing a table of categorization and
         quantitative indicators
     """
+
+    if not HAS_DATAPACKAGE:
+        raise ImportError('required package `datapackage` not found!')
 
     package = Package(path)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1287,14 +1287,14 @@ class IamDataFrame(object):
         if close:
             excel_writer.close()
 
-    def to_datapackage(self, path='datapackage.zip', tmp='tmp'):
+    def to_datapackage(self, path, tmp='tmp'):
         """Write object to a frictionless datapackage
 
         More information: https://frictionlessdata.io
 
         Parameters
         ----------
-        path: file, default 'datapackage.zip'
+        path: string
             file path
         tmp: string, default 'tmp'
             name for temporary folder to export csv files

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1292,6 +1292,10 @@ class IamDataFrame(object):
 
         More information: https://frictionlessdata.io
 
+        Returns the saved :class:`datapackage.Package`. When adding metadata
+        (descriptors), please follow the `template` defined by
+        https://github.com/OpenEnergyPlatform/metadata
+
         Parameters
         ----------
         path: string
@@ -1322,6 +1326,9 @@ class IamDataFrame(object):
         for f in tmp.iterdir():
             f.unlink()
         tmp.rmdir()
+
+        # return the package (needs to reloaded because `tmp` was deleted)
+        return Package(path)
 
     def load_metadata(self, path, *args, **kwargs):
         """Deprecated, see :method:`load_meta()`"""

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -14,7 +14,7 @@ from tempfile import TemporaryDirectory
 try:
     from datapackage import Package
     HAS_DATAPACKAGE = True
-except IoError:
+except ImportError:
     HAS_DATAPACKAGE = False
 
 try:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1288,8 +1288,17 @@ class IamDataFrame(object):
             excel_writer.close()
 
     def to_datapackage(self, path='datapackage.zip', tmp='tmp'):
-        """Export object to a
+        """Write object to a frictionless datapackage
 
+        More information: https://frictionlessdata.io
+
+        Parameters
+        ----------
+        path: file, default 'datapackage.zip'
+            file path
+        tmp: string, default 'tmp'
+            name for temporary folder to export csv files
+            (deleted after saving datapackage)
         """
 
         path, tmp = Path(path), Path(tmp)
@@ -1813,7 +1822,8 @@ def read_datapackage(path, data='data', meta='meta'):
     data: str, default `data`
         resource containing timeseries data in IAMC-compatible format
     meta: str, default `meta`
-        resource containing table of categorization and quantitative indicators
+        (optional) resource containing a table of categorization and
+        quantitative indicators
     """
 
     package = Package(path)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1323,8 +1323,7 @@ class IamDataFrame(object):
         package.save(path)
 
         # remove the temporary folder
-        for f in tmp.iterdir():
-            f.unlink()
+        [f.unlink() for f in tmp.iterdir()]
         tmp.rmdir()
 
         # return the package (needs to reloaded because `tmp` was deleted)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1828,7 +1828,7 @@ def read_datapackage(path, data='data', meta='meta'):
     df = IamDataFrame(_data)
 
     # read `meta` table
-    if meta in package.get_resource_names():
+    if meta in package.resource_names:
         resource_meta = package.get_resource(meta)
         _meta = pd.DataFrame(resource_meta.read())
         _meta.columns = _get_column_names(resource_meta)

--- a/pyam/testing.py
+++ b/pyam/testing.py
@@ -2,7 +2,7 @@ from . import compare
 import pandas.testing as pdt
 
 
-def assert_frame_equal(a, b, **assert_kwargs):
+def assert_iamframe_equal(a, b, **assert_kwargs):
     diff = compare(a, b)
     if not diff.empty:
         msg = 'IamDataFrame.data are different: \n {}'

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ REQUIREMENTS = [
     'matplotlib<=3.0.2',
     'seaborn',
     'six',
+    'pathlib',
+    'datapackage'
 ]
 
 EXTRA_REQUIREMENTS = {

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,11 @@ REQUIREMENTS = [
     'matplotlib<=3.0.2',
     'seaborn',
     'six',
-    'datapackage'
 ]
 
 EXTRA_REQUIREMENTS = {
     'tests': ['coverage', 'coveralls', 'pytest', 'pytest-cov', 'pytest-mpl'],
+    'optional-io-formats': ['datapackage'],
     'deploy': ['twine', 'setuptools', 'wheel'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ REQUIREMENTS = [
     'matplotlib<=3.0.2',
     'seaborn',
     'six',
-    'pathlib',
     'datapackage'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
     'argparse',
     'numpy',
     'requests',
-    'pandas>=0.25.0',
+    'pandas>=0.25.0,<1.0.0',
     'PyYAML',
     'xlrd',
     'xlsxwriter',

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 import pandas as pd
 from pyam import check_aggregate, IamDataFrame, IAMC_IDX
-from pyam.testing import assert_frame_equal
+from pyam.testing import assert_iamframe_equal
 
 from conftest import DTS_MAPPING
 
@@ -48,7 +48,7 @@ PRICE_MAX_DF = pd.DataFrame([
 def test_aggregate(simple_df, variable, data):
     # check that `variable` is a a direct sum and matches given total
     exp = simple_df.filter(variable=variable)
-    assert_frame_equal(simple_df.aggregate(variable), exp)
+    assert_iamframe_equal(simple_df.aggregate(variable), exp)
 
     # use other method (max) both as string and passing the function
     _df = data.copy()
@@ -57,7 +57,7 @@ def test_aggregate(simple_df, variable, data):
         _df.rename({'year': 'time'}, axis='columns', inplace=True)
     exp = IamDataFrame(_df)
     for m in ['max', np.max]:
-        assert_frame_equal(simple_df.aggregate(variable, method=m), exp)
+        assert_iamframe_equal(simple_df.aggregate(variable, method=m), exp)
 
 
 def test_check_aggregate(simple_df):
@@ -103,7 +103,7 @@ def test_aggregate_append(simple_df, variable):
     # remove `variable`, do aggregate and append, check equality to original
     _df = simple_df.filter(variable=variable, keep=False)
     _df.aggregate(variable, append=True)
-    assert_frame_equal(_df, simple_df)
+    assert_iamframe_equal(_df, simple_df)
 
 
 def test_aggregate_with_components(simple_df):
@@ -138,12 +138,12 @@ def test_aggregate_unknown_method(simple_df):
 def test_aggregate_region(simple_df, variable):
     # check that `variable` is a a direct sum across regions
     exp = simple_df.filter(variable=variable, region='World')
-    assert_frame_equal(simple_df.aggregate_region(variable), exp)
+    assert_iamframe_equal(simple_df.aggregate_region(variable), exp)
 
     # check custom `region` (will include `World`, so double-count values)
     foo = exp.rename(region={'World': 'foo'})
     foo.data.value = foo.data.value * 2
-    assert_frame_equal(simple_df.aggregate_region(variable, region='foo'), foo)
+    assert_iamframe_equal(simple_df.aggregate_region(variable, region='foo'), foo)
 
 
 def test_aggregate_region_log(simple_df, caplog):
@@ -191,7 +191,7 @@ def test_aggregate_region_append(simple_df, variable):
     # remove `variable`, do aggregate and append, check equality to original
     _df = simple_df.filter(variable=variable, region='World', keep=False)
     _df.aggregate_region(variable, append=True)
-    assert_frame_equal(_df, simple_df)
+    assert_iamframe_equal(_df, simple_df)
 
 
 @pytest.mark.parametrize("variable", (
@@ -205,13 +205,13 @@ def test_aggregate_region_with_subregions(simple_df, variable):
         .rename(region={'reg_a': 'World'})
     )
     obs = simple_df.aggregate_region(variable, subregions='reg_a')
-    assert_frame_equal(obs, exp)
+    assert_iamframe_equal(obs, exp)
 
     # check that both custom `region` and `subregions` work
     foo = exp.rename(region={'World': 'foo'})
     obs = simple_df.aggregate_region(variable, region='foo',
                                      subregions='reg_a')
-    assert_frame_equal(obs, foo)
+    assert_iamframe_equal(obs, foo)
 
     # check that invalid list of subregions returns empty
     assert simple_df.aggregate_region(variable, subregions=['reg_c']).empty
@@ -229,7 +229,7 @@ def test_aggregate_region_with_other_method(simple_df, variable, data):
         _df.rename({'year': 'time'}, axis='columns', inplace=True)
     exp = IamDataFrame(_df).filter(region='World')
     for m in ['max', np.max]:
-        assert_frame_equal(simple_df.aggregate_region(variable, method=m), exp)
+        assert_iamframe_equal(simple_df.aggregate_region(variable, method=m), exp)
 
 
 def test_aggregate_region_with_components(simple_df):
@@ -251,7 +251,7 @@ def test_aggregate_region_with_weights(simple_df):
     assert simple_df.check_aggregate_region(v, weight=w) is None
 
     exp = simple_df.filter(variable=v, region='World')
-    assert_frame_equal(simple_df.aggregate_region(v, weight=w), exp)
+    assert_iamframe_equal(simple_df.aggregate_region(v, weight=w), exp)
 
     # inconsistent index of variable and weight raises an error
     _df = simple_df.filter(variable=w, region='reg_b', keep=False)

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -143,7 +143,8 @@ def test_aggregate_region(simple_df, variable):
     # check custom `region` (will include `World`, so double-count values)
     foo = exp.rename(region={'World': 'foo'})
     foo.data.value = foo.data.value * 2
-    assert_iamframe_equal(simple_df.aggregate_region(variable, region='foo'), foo)
+    assert_iamframe_equal(simple_df.aggregate_region(variable, region='foo'),
+                          foo)
 
 
 def test_aggregate_region_log(simple_df, caplog):
@@ -229,7 +230,8 @@ def test_aggregate_region_with_other_method(simple_df, variable, data):
         _df.rename({'year': 'time'}, axis='columns', inplace=True)
     exp = IamDataFrame(_df).filter(region='World')
     for m in ['max', np.max]:
-        assert_iamframe_equal(simple_df.aggregate_region(variable, method=m), exp)
+        assert_iamframe_equal(simple_df.aggregate_region(variable, method=m),
+                              exp)
 
 
 def test_aggregate_region_with_components(simple_df):

--- a/tests/test_feature_downscale.py
+++ b/tests/test_feature_downscale.py
@@ -1,5 +1,5 @@
 import pytest
-from pyam.testing import assert_frame_equal
+from pyam.testing import assert_iamframe_equal
 
 
 @pytest.mark.parametrize("variable", (
@@ -13,9 +13,9 @@ def test_downscale_region(simple_df, variable):
     # return as new IamDataFrame
     obs = simple_df.downscale_region(variable, proxy='Population')
     exp = simple_df.filter(variable=variable, region=regions)
-    assert_frame_equal(exp, obs)
+    assert_iamframe_equal(exp, obs)
 
     # append to `self` (after removing to-be-downscaled timeseries)
     inplace = simple_df.filter(variable=variable, region=regions, keep=False)
     inplace.downscale_region(variable, proxy='Population', append=True)
-    assert_frame_equal(inplace, simple_df)
+    assert_iamframe_equal(inplace, simple_df)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,8 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from pyam import IamDataFrame
+from pyam import IamDataFrame, read_datapackage
+from pyam.testing import assert_frame_equal
 
 from conftest import TEST_DATA_DIR
 
@@ -74,3 +75,20 @@ def test_load_rcp_database_downloaded_file(test_df_year):
         TEST_DATA_DIR, 'test_RCP_database_raw_download.xlsx')
     )
     pd.testing.assert_frame_equal(obs_df.as_pandas(), exp)
+
+
+def test_io_datapackage(test_df):
+    file = 'foo.zip'
+
+    # add column to `meta`
+    test_df.set_meta(['a', 'b'], 'string')
+
+    # write to datapackage
+    test_df.to_datapackage(file)
+
+    # read from csv
+    import_df = read_datapackage(file)
+
+    # assert that IamDataFrame instances are equal and delete file
+    assert_frame_equal(test_df, import_df)
+    os.remove(file)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from pyam import IamDataFrame, read_datapackage
-from pyam.testing import assert_frame_equal
+from pyam.testing import assert_iamframe_equal
 
 from conftest import TEST_DATA_DIR
 
@@ -42,9 +42,8 @@ def test_io_xlsx(test_df, meta_args):
         # read from xlsx
         import_df = IamDataFrame(file, **meta_args[1])
 
-        # assert that `data` and `meta` tables are equal and delete file
-        pd.testing.assert_frame_equal(test_df.data, import_df.data)
-        pd.testing.assert_frame_equal(test_df.meta, import_df.meta)
+        # assert that IamDataFrame instances are equal and delete file
+        assert_iamframe_equal(test_df, import_df)
         os.remove(file)
 
 
@@ -90,5 +89,5 @@ def test_io_datapackage(test_df):
     import_df = read_datapackage(file)
 
     # assert that IamDataFrame instances are equal and delete file
-    assert_frame_equal(test_df, import_df)
+    assert_iamframe_equal(test_df, import_df)
     os.remove(file)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds functions (and a unit test) to export and read (zipped) files in the frictionless datapackage format (https://frictionlessdata.io/). It's a first stab exporting/importing only the `data` and `meta` tables, not incorporating metadata (license) or other fancy features like consistency validation.
