### PR TITLE
fix link to license page

### DIFF
--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -21,7 +21,7 @@ _BASE_URL = 'https://db1.ene.iiasa.ac.at/EneAuth/config/v1'
 _CITE_MSG = """
 You are connected to the {} scenario explorer hosted by IIASA.
  If you use this data in any published format, please cite the
- data as provided in the explorer guidelines: {}.
+ data as provided in the explorer guidelines: {}
 """.replace('\n', '')
 
 


### PR DESCRIPTION
# Description of PR

The `.` in the cite-message messes up the link-formatting in Jupyter notebooks, see screenshot below.

<img width="860" alt="image" src="https://user-images.githubusercontent.com/16931589/74023885-fd362300-49a0-11ea-9150-fdd6ad55bde9.png">
