### PR TITLE
add tutorial notebook for table-format io

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,14 @@
 
 ## API changes
 
-PR [#334](https://github.com/IAMconsortium/pyam/pull/334) Changes the arguments of `IamDataFrame.interpolate()` and `pyam.fill_series()` to `time`. It can still be an integer (i.e., year). 
-PR [#337](https://github.com/IAMconsortium/pyam/pull/337) IamDataFrame to throw an error when initialized with n/a entries in columns other than `value`
+PR [#334](https://github.com/IAMconsortium/pyam/pull/334) changes the arguments
+of `IamDataFrame.interpolate()` and `pyam.fill_series()` to `time`.
+It can still be an integer (i.e., year). 
 
 ## Individual Updates
 
+- [#339](https://github.com/IAMconsortium/pyam/pull/339) Add tutorial for dataframe format io
+- [#337](https://github.com/IAMconsortium/pyam/pull/337) IamDataFrame to throw an error when initialized with n/a entries in columns other than `value`
 - [#334](https://github.com/IAMconsortium/pyam/pull/334) Enable interpolate to work on datetimes.
 
 # Release v0.4.1

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -4,6 +4,10 @@
 Tutorials
 *********
 
+The source code of the tutorials is available in the folder
+[doc/source/tutorials](https://github.com/IAMconsortium/pyam/tree/master/doc/source/tutorials)
+of the GitHub repository.
+
 .. toctree::
    :maxdepth: 1
 

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -8,6 +8,7 @@ Tutorials
    :maxdepth: 1
 
    tutorials/pyam_first_steps.ipynb
+   tutorials/data_table_formats.ipynb
    tutorials/aggregating_downscaling_consistency.ipynb
    tutorials/ipcc_colors.ipynb
    tutorials/iiasa_dbs.ipynb

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -5,8 +5,10 @@ Tutorials
 *********
 
 The source code of the tutorials is available in the folder
-[doc/source/tutorials](https://github.com/IAMconsortium/pyam/tree/master/doc/source/tutorials)
-of the GitHub repository.
+`doc/source/tutorials`_ of the GitHub repository.
+
+.. _`doc/source/tutorials`:
+   https://github.com/IAMconsortium/pyam/tree/master/doc/source/tutorials
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/tutorials/data_table_formats.ipynb
+++ b/doc/source/tutorials/data_table_formats.ipynb
@@ -29,7 +29,15 @@
     "\n",
     "It does not matter whether an `IamDataFrame` is initialized from a [pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html)\n",
     "or a path to a `xslsx`/`csv` file with the data in the given format.\n",
-    "For simplicity, this tutorial only uses dataframes."
+    "For simplicity, this tutorial only uses dataframes.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "The default columns (a.k.a. index or dimensions) of the IAMC data format are  \n",
+    "`pyam.IAMC_IDX = ['model', 'scenario', 'region', 'variable', 'unit']`.  \n",
+    "The last section of this tutorial illustrates the use of additional, custom columns.\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -384,6 +392,59 @@
    "outputs": [],
    "source": [
     "df_complicated.equals(df_simple)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Postscriptum: custom data columns in an `IamDataFrame`\n",
+    "\n",
+    "This final section illustrates the behaviour of **pyam** when working with non-standard columns.\n",
+    "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "The *custom data column* feature is currently only on experimental support.\n",
+    "Not all **pyam** functions currently support custom columns in a `data` table.\n",
+    "If you encounter any problems, please remove any non-standard columns\n",
+    "from the input dataframe (or [contribute](https://pyam-iamc.readthedocs.io/en/stable/contributing.html) to fix the problem!).\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CUSTOM_COL_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/y', 2.1, 1, 6.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/y', 2.1, 0.5, 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/y', 2.1, 2, 7],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + ['version', 2005, 2010],\n",
+    ")\n",
+    "\n",
+    "CUSTOM_COL_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_custom_col = pyam.IamDataFrame(CUSTOM_COL_DF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_custom_col.timeseries()"
    ]
   }
  ],

--- a/doc/source/tutorials/data_table_formats.ipynb
+++ b/doc/source/tutorials/data_table_formats.ipynb
@@ -398,7 +398,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Postscriptum: custom data columns in an `IamDataFrame`\n",
+    "## Postscriptum: custom data columns in an `IamDataFrame`\n",
     "\n",
     "This final section illustrates the behaviour of **pyam** when working with non-standard columns.\n",
     "\n",

--- a/doc/source/tutorials/data_table_formats.ipynb
+++ b/doc/source/tutorials/data_table_formats.ipynb
@@ -1,0 +1,410 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importing various data table formats\n",
+    "\n",
+    "The default input/output (io) format of the **pyam** package is the *tabular, wide data format*,\n",
+    "where the columns represent the time domain.\n",
+    "This follows the standard established by the *Integrated Assessment Modeling Consortium*\n",
+    "([IAMC](http://www.globalchange.umd.edu/iamc/));\n",
+    "[read the docs](https://pyam-iamc.readthedocs.io/en/stable/data.html) for more information.\n",
+    "\n",
+    "Alas, to make using the package as easy as possible, iniatilizing an `IamDataFrame` will accept a variety of different table formats\n",
+    "and allows specifying missing columns via keyword arguments.\n",
+    "This way, a user can import their data into **pyam** as easily as possible without needing to worry (more than necessary) about manipulating the original, raw timeseries data.\n",
+    "\n",
+    "This tutorial illustrates the broad range of possible formats\n",
+    "to facilitate choosing the one that works for *your data*!\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The first section shows the standard [pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html) (a.k.a. table) used in the **pyam** test suite.\n",
+    "The following sections shows modifications of this dataframe\n",
+    "and the necessary (if any) additional specifications to initialize an `IamDataFrame`.\n",
+    "The last cell of each section uses the [equals()](https://pyam-iamc.readthedocs.io/en/stable/api.html#pyam.IamDataFrame.equals) function\n",
+    "to assert that the `IamDataFrame` in that section is identical to the object in the first section.\n",
+    "\n",
+    "It does not matter whether an `IamDataFrame` is initialized from a [pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html)\n",
+    "or a path to a `xslsx`/`csv` file with the data in the given format.\n",
+    "For simplicity, this tutorial only uses dataframes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pyam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Initialize timeseries data from standard IAMC-format table\n",
+    "\n",
+    "The first cell creates a \"simple dataframe\" in the standard *wide* IAMC format.\n",
+    "\n",
+    "It then casts that dataframe to an `IamDataFrame`\n",
+    "and uses the [timeseries()](https://pyam-iamc.readthedocs.io/en/stable/api.html#pyam.IamDataFrame.timeseries) function\n",
+    "to again show the data in the standard format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SIMPLE_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/y', 1, 6.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/y', 0.5, 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/y', 2, 7],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + [2005, 2010],\n",
+    ")\n",
+    "\n",
+    "SIMPLE_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_simple = pyam.IamDataFrame(SIMPLE_DF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_simple.timeseries()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Adding missing columns\n",
+    "\n",
+    "The IAMC data format expects the columns `model`, `scenario`, `region`, `variable` and `unit`.\n",
+    "If the input dataframe does not have any of these columns, the value for that column\n",
+    "can be given as a keyword argument of the type `col=value`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MISSING_COLS_DF = pd.DataFrame([\n",
+    "    ['scen_a', 'World', 'Primary Energy', 'EJ/y', 1, 6.],\n",
+    "    ['scen_a', 'World', 'Primary Energy|Coal', 'EJ/y', 0.5, 3],\n",
+    "    ['scen_b', 'World', 'Primary Energy', 'EJ/y', 2, 7],\n",
+    "],\n",
+    "    columns=['scenario', 'region', 'variable', 'unit', 2005, 2010],\n",
+    ")\n",
+    "\n",
+    "MISSING_COLS_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_missing_cols = pyam.IamDataFrame(MISSING_COLS_DF, model='model_a')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_missing_cols.equals(df_simple)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Using a *long* data format\n",
+    "\n",
+    "The next illustration is a dataframe where the years and values are given in a *long format*,\n",
+    "i.e., in two columns named `year` and `value`.\n",
+    "This is the format internally used by **pyam**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LONG_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/y', 2005, 1.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/y', 2010, 6],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/y', 2005, 0.5],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/y', 2010, 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/y', 2005, 2],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/y', 2010, 7],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + ['year', 'value'],\n",
+    ")\n",
+    "\n",
+    "LONG_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_long = pyam.IamDataFrame(LONG_DF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_long.equals(df_simple)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Using column headers as variable names\n",
+    "\n",
+    "The next example shows a table where the values are given as columns\n",
+    "and the column header specifies the variable name.\n",
+    "In this case, a user needs to specify the columns that should be interpreted as values\n",
+    "using the keyword argument `value=<value_cols>`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VALUE_COLS_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],\n",
+    "    ['model_a', 'scen_a', 'World', 'EJ/y', 2010, 6., 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'EJ/y', 2005, 2, None],\n",
+    "    ['model_a', 'scen_b', 'World', 'EJ/y', 2010, 7, None]\n",
+    "],\n",
+    "    columns=['model', 'scenario', 'region', 'unit', 'year',\n",
+    "             'Primary Energy', 'Primary Energy|Coal'],\n",
+    ")\n",
+    "\n",
+    "VALUE_COLS_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_value_cols = pyam.IamDataFrame(VALUE_COLS_DF,\n",
+    "                                  value=['Primary Energy', 'Primary Energy|Coal'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_value_cols.equals(df_simple)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Using non-standard column names\n",
+    "\n",
+    "As stated above, the IAMC data format expects a specific set of column names.\n",
+    "If the input dataframe has columns with non-standard headers,\n",
+    "the *column renaming* can be done on the fly by **pyam** using the keyword argument `default_col=input_col`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OTHER_HEADER_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/y', 1, 6.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/y', 0.5, 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/y', 2, 7],\n",
+    "],\n",
+    "    columns=['model', 'foo', 'region', 'variable', 'unit', 2005, 2010],\n",
+    ")\n",
+    "\n",
+    "OTHER_HEADER_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_other_header = pyam.IamDataFrame(OTHER_HEADER_DF, scenario='foo')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_other_header.equals(df_simple)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Concatenating multiple columns as variable names\n",
+    "\n",
+    "In the IAMC data format, the `variable` implements a semi-hierarchical structure using the `|` (pipe) character.\n",
+    "If the input dataframe has the hierarchy represented as separate columns,\n",
+    "the concatenation can be performed during the initialization\n",
+    "using the keyword argument `variable=<list_of_cols>`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONCAT_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', None, 'EJ/y', 1, 6.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'Coal', 'EJ/y', 0.5, 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', None, 'EJ/y', 2, 7],\n",
+    "],\n",
+    "    columns=['model', 'scenario', 'region', 'var_1', 'var_2', 'unit', 2005, 2010],\n",
+    ")\n",
+    "\n",
+    "CONCAT_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_concat = pyam.IamDataFrame(CONCAT_DF, variable=['var_1', 'var_2'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_concat.equals(df_simple)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Combining multiple \n",
+    "\n",
+    "The last example in this tutorial illustrates that the features above can be used in combination (if nessary). The input dataframe has the following issues:\n",
+    "\n",
+    " - missing `model` column\n",
+    " - non-standard name of the `region` column\n",
+    " - values in columns with `variable` as name\n",
+    "\n",
+    "Notice that the value-columns do not have the same headers as the variables in the dataframe in Section 0.\n",
+    "Therefore, we use the [rename()](https://pyam-iamc.readthedocs.io/en/stable/api.html#pyam.IamDataFrame.rename) function\n",
+    "to change the variables after initialization to the expected names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COMPLICATED_DF = pd.DataFrame([\n",
+    "    ['scen_a', 'World', 'EJ/y', 2005, 1, 0.5],\n",
+    "    ['scen_a', 'World', 'EJ/y', 2010, 6., 3],\n",
+    "    ['scen_b', 'World', 'EJ/y', 2005, 2, None],\n",
+    "    ['scen_b', 'World', 'EJ/y', 2010, 7, None]\n",
+    "],\n",
+    "    columns=['scenario', 'iso', 'unit', 'year', 'primary', 'coal'],\n",
+    ")\n",
+    "\n",
+    "COMPLICATED_DF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_complicated = (\n",
+    "    pyam.IamDataFrame(COMPLICATED_DF, model='model_a', region='iso',\n",
+    "                      value=['primary', 'coal'])\n",
+    "    .rename(variable={'primary': 'Primary Energy', 'coal': 'Primary Energy|Coal'})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_complicated.equals(df_simple)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/doc/source/tutorials/data_table_formats.ipynb
+++ b/doc/source/tutorials/data_table_formats.ipynb
@@ -97,7 +97,7 @@
     "## 1. Adding missing columns\n",
     "\n",
     "The IAMC data format expects the columns `model`, `scenario`, `region`, `variable` and `unit`.\n",
-    "If the input dataframe does not have any of these columns, the value for that column\n",
+    "If the input dataframe does not have one or several of these columns, the value for that column\n",
     "can be given as a keyword argument of the type `col=value`."
    ]
   },
@@ -288,7 +288,7 @@
     "## 5. Concatenating multiple columns as variable names\n",
     "\n",
     "In the IAMC data format, the `variable` implements a semi-hierarchical structure using the `|` (pipe) character.\n",
-    "If the input dataframe has the hierarchy represented as separate columns,\n",
+    "If the input dataframe has the hierarchy (or dimensions of an index) represented as separate columns,\n",
     "the concatenation can be performed during the initialization\n",
     "using the keyword argument `variable=<list_of_cols>`."
    ]
@@ -332,15 +332,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Combining multiple \n",
+    "## 6. Combining multiple format issues\n",
     "\n",
-    "The last example in this tutorial illustrates that the features above can be used in combination (if nessary). The input dataframe has the following issues:\n",
+    "The last example in this tutorial illustrates that the features above can be used in combination.\n",
+    "The input dataframe has the following issues:\n",
     "\n",
     " - missing `model` column\n",
     " - non-standard name of the `region` column\n",
     " - values in columns with `variable` as name\n",
     "\n",
-    "Notice that the value-columns do not have the same headers as the variables in the dataframe in Section 0.\n",
+    "Also, notice that the value-columns do not have the same headers as the variables in the dataframe in **Section 0**.\n",
     "Therefore, we use the [rename()](https://pyam-iamc.readthedocs.io/en/stable/api.html#pyam.IamDataFrame.rename) function\n",
     "to change the variables after initialization to the expected names."
    ]

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -5,6 +5,10 @@ from pyam import IamDataFrame, compare
 from conftest import TEST_DTS
 
 
+# when making any updates to this file,
+# please also update the `data_table_formats` tutorial notebook!
+
+
 def test_cast_from_value_col(test_df_year):
     df_with_value_cols = pd.DataFrame([
         ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -99,3 +99,14 @@ def test_aggregating_variables_and_plotting_with_negative_values():
     )
     nb, errors = _notebook_run(fname)
     assert errors == []
+
+
+@pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
+@pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
+def test_data_table_formats():
+    fname = os.path.join(
+        tut_path,
+        'data_table_formats.ipynb'
+    )
+    nb, errors = _notebook_run(fname)
+    assert errors == []


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a tutorial notebook (based on `tests/cast_to_iamc.py`) to show how different data tables can be cast to an `IamDataFrame` using keyword arguments.

The rendered tutorial notebook can be (currently) seen on [ReadTheDocs](https://pyam-iamc.readthedocs.io/en/tutorial-io/)
