### PR TITLE
support custom `pint.UnitRegistry` and contexts in unit conversion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ an IamDataFrame with `n/a` entries in columns other than `value` raises an error
 
 ## Individual Updates
 
+- [#347](https://github.com/IAMconsortium/pyam/pull/347) Enable contexts and custom UnitRegistry with unit conversion.
 - [#341](https://github.com/IAMconsortium/pyam/pull/341) Use `pint` and IIASA-ene-units repo for unit conversion.
 - [#339](https://github.com/IAMconsortium/pyam/pull/339) Add tutorial for dataframe format io
 - [#337](https://github.com/IAMconsortium/pyam/pull/337) IamDataFrame to throw an error when initialized with n/a entries in columns other than `value`

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -15,6 +15,7 @@ The source code of the tutorials is available in the folder
 
    tutorials/pyam_first_steps.ipynb
    tutorials/data_table_formats.ipynb
+   tutorials/unit_conversion.ipynb
    tutorials/aggregating_downscaling_consistency.ipynb
    tutorials/ipcc_colors.ipynb
    tutorials/iiasa_dbs.ipynb

--- a/doc/source/tutorials/unit_conversion.ipynb
+++ b/doc/source/tutorials/unit_conversion.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction to unit conversion with `pyam`\n",
+    "\n",
+    "Conversion of timeseries data units is one of the most tedious aspects of modelling and scenario analysis -\n",
+    "and it is a frequent source for errors!\n",
+    "The **pyam** function [convert_unit()](https://pyam-iamc.readthedocs.io/en/stable/api.html#pyam.IamDataFrame.convert_unit) can support and simplify this task.\n",
+    "\n",
+    "The function uses the Python package [pint](https://pint.readthedocs.io),\n",
+    "which natively handles conversion of standard (SI) units (e.g., exajoule to terawatt-hours, `EJ -> TWh`).\n",
+    "The **pint** package can also parse combined units (e.g., exajoule per year, `EJ/yr`).\n",
+    "\n",
+    "To better support common use cases when working with energy systems analysis and integrated-assessment scenarios,\n",
+    "the default [pint.UnitRegistry](https://pint.readthedocs.io/en/stable/developers_reference.html#pint.UnitRegistry)\n",
+    "used by **pyam** loads the unit definitions collected at [IAMconsortium/units](https://github.com/IAMconsortium/units).\n",
+    "This repository provides a wide range of conversion factors in a **pint**-compatible format\n",
+    "so that they can easily be used across multiple applications (**pyam** just being one of them).\n",
+    "If you have suggestions for additional units to be added to the repository,\n",
+    "please [start an issue](https://github.com/IAMconsortium/units/issues) - or make a pull request!\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "This notebook illustrates the following features:\n",
+    "\n",
+    "0. Load timeseries data from first-steps snapshot file and downselect to illustrative data\n",
+    "1. Use the default **pint** unit conversion\n",
+    "2. Use a unit conversion from the [IAMconsortium/units](https://github.com/IAMconsortium/units) repository.\n",
+    "3. Use a custom conversion factor\n",
+    "4. Use contexts to specify more elaborate conversions\n",
+    "5. Access the application registry for more advanced use cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Load timeseries data from first-steps snapshot file and downselect to illustrative data\n",
+    "\n",
+    "We use the scenario ensemble from the **first-steps tutorial** (here on\n",
+    "[GitHub](https://github.com/IAMconsortium/pyam/blob/master/doc/source/tutorials/pyam_first_steps.ipynb)\n",
+    "and on [read the docs](https://pyam-iamc.readthedocs.io/en/stable/tutorials/pyam_first_steps.html))\n",
+    "and filter it to one model/scenario and two variables for illustration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = (\n",
+    "    pyam.IamDataFrame(data='tutorial_data.csv')\n",
+    "    .filter(model='MESSAGE*', scenario='CD-LINKS_NPi',\n",
+    "            region='World', variable=['Primary Energy', 'Emissions|CO2'])\n",
+    ")\n",
+    "\n",
+    "df.timeseries()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/doc/source/tutorials/unit_conversion.ipynb
+++ b/doc/source/tutorials/unit_conversion.ipynb
@@ -73,6 +73,168 @@
     "df = pyam.IamDataFrame(UNIT_DF)\n",
     "df.timeseries()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Use the default pint unit conversion\n",
+    "\n",
+    "As a first step, we illustrate unit conversion between \"standard formats\",\n",
+    "i.e., units that **pint** knows by default.\n",
+    "\n",
+    "In this particular case, we convert exajoule to petawatthours, `EJ/yr -> PWh/yr`.\n",
+    "Note that the timeseries data for other units (CO2 emissions in this case) are not changed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.convert_unit('EJ/yr', to='PWh/yr').timeseries()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The **pint** package usually does a good job at parsing orders of magnitude (peta, giga, mega, milli, ...)\n",
+    "and their abbreviations (`P`, `G`, `M`, `m`, ...)\n",
+    "as well as common units (centimeter, inch, kilometer, mile).\n",
+    "It also handles combined units like exajoule per year with various spellings:\n",
+    "`PWh/yr`, `PWh / yr` and `petawatthour / year` will all be treated as synomyms by the conversion.\n",
+    "The only difference is the format in the resulting `IamDataFrame`.\n",
+    "\n",
+    "[Read the docs](https://pint.readthedocs.io) for more information!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.convert_unit('EJ/yr', to='petawatthour / year').timeseries()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Use a unit & conversion factor from the `IAMconsortium/unit` repository\n",
+    "\n",
+    "The **pint** package includes many standard units, but many units often encountered in the context of energy systems analysis and integrated assessment scenarios are not defined by default.\n",
+    "\n",
+    "Therefore, the [IAMconsortium/units](https://github.com/IAMconsortium/units) repository\n",
+    "provides a common location to define such units.\n",
+    "The **pyam** package loads these definitions and uses them by default in any unit conversion.\n",
+    "\n",
+    "One entry defined there is 'tons of coal equivalent' (`tce`) as a measure of energy (content).\n",
+    "This is used in the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.convert_unit('EJ/yr', to='Gtce/yr').timeseries()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Use a custom conversion factor\n",
+    "\n",
+    "In some cases, a user needs to specify a custom unit.\n",
+    "The `convert_unit()` function supports that by specifying a `factor` as a keyword argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.convert_unit('EJ/yr', to='my_unit', factor=2.3).timeseries()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Use contexts to specify conversion metrics\n",
+    "\n",
+    "There are unit conversions where no \"default\" factor exists.\n",
+    "One such case is calculating the CO2-equivalent of CH4 emissions (or other greenhouse gases),\n",
+    "because the conversion depends on the species' \"global warming potential\"\n",
+    "and estimates for that potential are updated regularly in the literature.\n",
+    "\n",
+    "To facilitate such use cases, **pint** provides \"contexts\" to allow specifying the appropriate metric.\n",
+    "The [IAMconsortium/units](https://github.com/IAMconsortium/units) parametrizes multiple contexts\n",
+    "for the comversion of greenhouse gases;\n",
+    "see the [emissions module](https://github.com/IAMconsortium/units/blob/master/modules/emissions) for details.\n",
+    "\n",
+    "Performing a unit conversion with context is illustrated below using the IPCC AR5-GWP100 factor;\n",
+    "in this situation, not specifying a context would result in a `pint.DimensionalityError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.convert_unit('Mt CH4/yr', to='Mt CO2e/yr', context='gwp_AR5GWP100').timeseries()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. More advanced use cases with a unit registry\n",
+    "\n",
+    "For more advanced use cases, **pyam** supports two further features: first, it can sometimes be useful\n",
+    "to work with the `UnitRegistry` used by default directly. This registry can be accessed\n",
+    "via [pint.get_application_registry()](https://pint.readthedocs.io/en/latest/developers_reference.html#pint.get_application_registry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pint\n",
+    "pint.get_application_registry()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In other use cases, it can be helpful to use one (or several) specific registries\n",
+    "instead of the default application registry.\n",
+    "The `convert_unit()` function therefore allows passing a `registry` as a keyword argument.\n",
+    "\n",
+    "The specifications below are the same as the example in section 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ureg = pint.UnitRegistry()\n",
+    "ureg.define('my_unit = 1 / 2.3 * EJ/yr')\n",
+    "\n",
+    "df.convert_unit('EJ/yr', to='my_unit', registry=ureg).timeseries()"
+   ]
   }
  ],
  "metadata": {

--- a/doc/source/tutorials/unit_conversion.ipynb
+++ b/doc/source/tutorials/unit_conversion.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Introduction to unit conversion with `pyam`\n",
+    "# Introduction to unit conversion with pyam\n",
     "\n",
     "Conversion of timeseries data units is one of the most tedious aspects of modelling and scenario analysis -\n",
     "and it is a frequent source for errors!\n",
@@ -18,20 +18,21 @@
     "the default [pint.UnitRegistry](https://pint.readthedocs.io/en/stable/developers_reference.html#pint.UnitRegistry)\n",
     "used by **pyam** loads the unit definitions collected at [IAMconsortium/units](https://github.com/IAMconsortium/units).\n",
     "This repository provides a wide range of conversion factors in a **pint**-compatible format\n",
-    "so that they can easily be used across multiple applications (**pyam** just being one of them).\n",
-    "If you have suggestions for additional units to be added to the repository,\n",
-    "please [start an issue](https://github.com/IAMconsortium/units/issues) - or make a pull request!\n",
+    "so that they can easily be used across multiple applications (**pyam** is just one of them).\n",
+    "\n",
+    "*If you have suggestions for additional units to be added to that repository,\n",
+    "please [start an issue](https://github.com/IAMconsortium/units/issues) - or make a pull request!*\n",
     "\n",
     "## Overview\n",
     "\n",
     "This notebook illustrates the following features:\n",
     "\n",
-    "0. Load timeseries data from first-steps snapshot file and downselect to illustrative data\n",
+    "0. Define timeseries data and initialize an `IamDataFrame`\n",
     "1. Use the default **pint** unit conversion\n",
-    "2. Use a unit conversion from the [IAMconsortium/units](https://github.com/IAMconsortium/units) repository.\n",
+    "2. Use a unit & conversion factor from the [IAMconsortium/units](https://github.com/IAMconsortium/units) repository\n",
     "3. Use a custom conversion factor\n",
-    "4. Use contexts to specify more elaborate conversions\n",
-    "5. Access the application registry for more advanced use cases"
+    "4. Use contexts to specify conversion metrics\n",
+    "5. More advanced use cases with a unit registry"
    ]
   },
   {
@@ -47,12 +48,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 0. Load timeseries data from first-steps snapshot file and downselect to illustrative data\n",
+    "## 0. Define timeseries data and initialize an `IamDataFrame`\n",
     "\n",
-    "We use the scenario ensemble from the **first-steps tutorial** (here on\n",
+    "This tutorial uses a scenario similar to the data in the **first-steps tutorial** (here on\n",
     "[GitHub](https://github.com/IAMconsortium/pyam/blob/master/doc/source/tutorials/pyam_first_steps.ipynb)\n",
-    "and on [read the docs](https://pyam-iamc.readthedocs.io/en/stable/tutorials/pyam_first_steps.html))\n",
-    "and filter it to one model/scenario and two variables for illustration."
+    "and on [read the docs](https://pyam-iamc.readthedocs.io/en/stable/tutorials/pyam_first_steps.html)).\n",
+    "Please read that tutorial for the reference and further information."
    ]
   },
   {

--- a/doc/source/tutorials/unit_conversion.ipynb
+++ b/doc/source/tutorials/unit_conversion.ipynb
@@ -196,6 +196,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "When working with contexts, it is important to track the information which metric was used.\n",
+    "This can be done either in the metadata of the resulting data (file)\n",
+    "or directly in the unit (or variable) of the timeseries.\n",
+    "See an illustration below for a simple workflow.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gwp = 'AR5GWP100'\n",
+    "target = 'Mt CO2e/yr'\n",
+    "(\n",
+    "    df.convert_unit('Mt CH4/yr', to=target, context=f'gwp_{gwp}')\n",
+    "    .rename(unit={target: f'{target} ({gwp})'})\n",
+    "    .timeseries()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 5. More advanced use cases with a unit registry\n",
     "\n",
     "For more advanced use cases, **pyam** supports two further features: first, it can sometimes be useful\n",

--- a/doc/source/tutorials/unit_conversion.ipynb
+++ b/doc/source/tutorials/unit_conversion.ipynb
@@ -41,6 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
     "import pyam"
    ]
   },
@@ -62,12 +63,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = (\n",
-    "    pyam.IamDataFrame(data='tutorial_data.csv')\n",
-    "    .filter(model='MESSAGE*', scenario='CD-LINKS_NPi',\n",
-    "            region='World', variable=['Primary Energy', 'Emissions|CO2'])\n",
+    "UNIT_DF = pd.DataFrame([\n",
+    "    ['MESSAGEix-GLOBIOM 1.0', 'CD-LINKS_NPi', 'World', 'Primary Energy', 'EJ/yr', 500.74, 636.79, 809.93, 1284.78],\n",
+    "    ['MESSAGEix-GLOBIOM 1.0', 'CD-LINKS_NPi', 'World', 'Emissions|CH4', 'Mt CH4/yr', 327.92, 354.35, 377.88, 403.98],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + [2010, 2030, 2050, 2100],\n",
     ")\n",
     "\n",
+    "df = pyam.IamDataFrame(UNIT_DF)\n",
     "df.timeseries()"
    ]
   }

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -758,7 +758,8 @@ class IamDataFrame(object):
         if not inplace:
             return ret
 
-    def convert_unit(self, current, to=None, factor=None, inplace=False):
+    def convert_unit(self, current, to=None, factor=None, registry=None,
+                     context=None, inplace=False):
         """Converts a unit using a given factor or the pint package
 
         The `pint package <https://pint.readthedocs.io>`_ natively handles
@@ -771,8 +772,8 @@ class IamDataFrame(object):
         systems analysis from the `IAMconsortium/units
         <https://github.com/IAMconsortium/units>`_ repository.
 
-        You can access the :py:class:`pint.UnitRegistry` used by :class:`pyam`
-        via :func:`pint.get_application_registry`.
+        You can access the :py:class:`pint.UnitRegistry` used as default
+        by :class:`pyam` via :func:`pint.get_application_registry`.
 
         Parameters
         ----------
@@ -783,6 +784,12 @@ class IamDataFrame(object):
         factor: value, optional
             conversion factor if given, otherwise defaults to the application
             :py:class:`pint.UnitRegistry`
+        registry: pint.UnitRegistry, optional
+            use a specific UnitRegistry; if `None`, use default application
+            registry with definitions imported from the `IAMconsortium/units
+            <https://github.com/IAMconsortium/units>`_ repository
+        context: str, optional
+            passed to the pint.UnitRegistry
         inplace: bool, default False
             if True, do operation inplace and return None
         """
@@ -793,7 +800,8 @@ class IamDataFrame(object):
                                 type='Using a dictionary to convert units')
             return convert_unit_with_mapping(self, current, inplace)
         # new standard method, remove this comment when deprecating above
-        return convert_unit(self, current, to, factor, inplace)
+        return convert_unit(self, current, to, factor, registry, context,
+                            inplace)
 
     def normalize(self, inplace=False, **kwargs):
         """Normalize data to a specific data point

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -30,7 +30,8 @@ def convert_unit(df, current, to, factor=None, registry=None, context=None,
     # if factor is not given, get it from custom or application registry
     if factor is None:
         _reg = registry or _REGISTRY
-        factor = _reg[current].to(_reg[to], context=context).magnitude
+        args = [_reg[to]] if context is None else [_reg[to], context]
+        factor = _reg[current].to(*args).magnitude
 
     # do the conversion
     where = ret.data['unit'] == current

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def main():
         ],
     }
     package_data = {
-        'pyam': ['region_mappings/*', '../units/definitions.txt'],
+        'pyam': ['region_mappings/*', '../units/**/*'],
     }
     install_requirements = REQUIREMENTS
     extra_requirements = EXTRA_REQUIREMENTS

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ def main():
         ],
     }
     package_data = {
-        'pyam': ['region_mappings/*', '../units/**/*'],
+        'pyam': ['region_mappings/*', '../units/definitions.txt',
+                 '../units/modules/**/*.txt'],
     }
     install_requirements = REQUIREMENTS
     extra_requirements = EXTRA_REQUIREMENTS

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -68,6 +68,14 @@ def test_pyam_first_steps(capsys):
 
 @pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
 @pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
+def test_unit_conversion():
+    fname = os.path.join(tut_path, 'unit_conversion.ipynb')
+    nb, errors = _notebook_run(fname)
+    assert errors == []
+
+
+@pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
+@pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
 def test_aggregating_downscaling_consistency():
     fname = os.path.join(tut_path, 'aggregating_downscaling_consistency.ipynb')
     nb, errors = _notebook_run(fname)

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -68,6 +68,17 @@ def test_pyam_first_steps(capsys):
 
 @pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
 @pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
+def test_data_table_formats():
+    fname = os.path.join(
+        tut_path,
+        'data_table_formats.ipynb'
+    )
+    nb, errors = _notebook_run(fname)
+    assert errors == []
+
+
+@pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
+@pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
 def test_unit_conversion():
     fname = os.path.join(tut_path, 'unit_conversion.ipynb')
     nb, errors = _notebook_run(fname)
@@ -104,17 +115,6 @@ def test_aggregating_variables_and_plotting_with_negative_values():
     fname = os.path.join(
         tut_path,
         'aggregating_variables_and_plotting_with_negative_values.ipynb'
-    )
-    nb, errors = _notebook_run(fname)
-    assert errors == []
-
-
-@pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
-@pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
-def test_data_table_formats():
-    fname = os.path.join(
-        tut_path,
-        'data_table_formats.ipynb'
     )
     nb, errors = _notebook_run(fname)
     assert errors == []

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -7,15 +7,20 @@ from pyam import IamDataFrame
 PRECISE_ARG = dict(check_less_precise=True)
 
 
+def get_units_test_df(test_df):
+    # modify units in standard test dataframe
+    df = test_df.copy()
+    df.data.loc[0:1, 'unit'] = 'custom_unit'
+    return df
+
+
 @pytest.mark.parametrize("current,to", [
     ('EJ/yr', 'TWh/yr'),
     ('EJ', 'TWh')
 ])
 def test_convert_unit_with_pint(test_df, current, to):
-    print(current, to)
     # unit conversion with standard pint
-    df = test_df.copy()
-    df.data.loc[0:1, 'unit'] = 'custom_unit'
+    df = get_units_test_df(test_df)
 
     # replace EJ/yr by EJ to test pint with single unit
     if current == 'EJ':
@@ -34,9 +39,7 @@ def test_convert_unit_with_pint(test_df, current, to):
 
 def test_convert_unit_from_repo(test_df):
     # unit conversion with definition loaded from common units repo
-    df = test_df.copy()
-    df.data.loc[0:1, 'unit'] = 'custom_unit'
-
+    df = get_units_test_df(test_df)
     exp = pd.Series([1., 6., 17.06, 102.361, 68.241, 238.843], name='value')
 
     # testing for `inplace=False`
@@ -50,9 +53,7 @@ def test_convert_unit_from_repo(test_df):
 
 def test_convert_unit_with_custom_factor(test_df):
     # unit conversion with custom factor
-    df = test_df.copy()
-    df.data.loc[0:1, 'unit'] = 'custom_unit'
-
+    df = get_units_test_df(test_df)
     exp = pd.Series([1., 6., 1., 6., 4., 14.], name='value')
 
     # testing for `inplace=False`

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -53,8 +53,8 @@ def test_convert_unit_with_custom_registry(test_df):
     df = get_units_test_df(test_df).rename(unit={'EJ/yr': 'foo'})
 
     # check that conversion fails with application registry
-    pytest.raises(pint.UndefinedUnitError,
-                  df.convert_unit, 'foo', 'baz')
+    with pytest.raises(pint.UndefinedUnitError):
+        df.convert_unit('foo', 'baz')
 
     # define a custom unit registry
     ureg = pint.UnitRegistry()
@@ -63,6 +63,26 @@ def test_convert_unit_with_custom_registry(test_df):
 
     exp = pd.Series([1., 6., 1.5, 9, 6, 21], name='value')
     assert_converted_units(df, 'foo', 'baz', exp, registry=ureg)
+
+
+@pytest.mark.parametrize('unit', ['{}', 'Mt {}', 'Mt {} / yr', '{} / yr'])
+def test_convert_unit_with_context(test_df, unit):
+    # unit conversion with contexts in application registry
+    df = test_df.copy()
+    df['variable'] = [i.replace('Primary Energy', 'Emissions|CH4')
+                      for i in df['variable']]
+    current = unit.format('CH4')
+    to = unit.format('CO2e')
+    df['unit'] = current
+
+    # assert that conversion fails without context
+    with pytest.raises(pint.DimensionalityError):
+        df.convert_unit(current, to)
+
+    # test conversion for multiple contexts
+    for (c, v) in [('AR5GWP100', 28), ('AR4GWP100', 25), ('SARGWP100', 21)]:
+        exp = test_df.data.value * v
+        assert_converted_units(df.copy(), current, to, exp, context=f'gwp_{c}')
 
 
 def test_convert_unit_with_custom_factor(test_df):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -16,13 +16,15 @@ def get_units_test_df(test_df):
 
 
 def assert_converted_units(df, current, to, exp, **kwargs):
-    # testing for `inplace=False`
+    # testing for `inplace=False` - converted values and expected unit
     _df = df.convert_unit(current, to, **kwargs, inplace=False)
     pd.testing.assert_series_equal(_df.data.value, exp, **PRECISE_ARG)
+    assert _df.data.unit[5] == to
 
-    # testing for `inplace=True`
+    # testing for `inplace=True` - converted values and expected unit
     df.convert_unit(current, to, **kwargs, inplace=True)
     pd.testing.assert_series_equal(df.data.value, exp, **PRECISE_ARG)
+    assert df.data.unit[5] == to
 
 
 @pytest.mark.parametrize("current,to", [

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -19,7 +19,7 @@ def get_units_test_df(test_df):
     ('EJ', 'TWh')
 ])
 def test_convert_unit_with_pint(test_df, current, to):
-    # unit conversion with standard pint
+    # unit conversion with default UnitRegistry (i.e, application_registry)
     df = get_units_test_df(test_df)
 
     # replace EJ/yr by EJ to test pint with single unit
@@ -32,13 +32,13 @@ def test_convert_unit_with_pint(test_df, current, to):
     _df = df.convert_unit(current, to, inplace=False)
     pd.testing.assert_series_equal(_df.data.value, exp, **PRECISE_ARG)
 
-    # testing for `inplace=False`
+    # testing for `inplace=True`
     df.convert_unit(current, to, inplace=True)
     pd.testing.assert_series_equal(df.data.value, exp, **PRECISE_ARG)
 
 
 def test_convert_unit_from_repo(test_df):
-    # unit conversion with definition loaded from common units repo
+    # unit conversion with definition loaded from `IAMconsortium/units` repo
     df = get_units_test_df(test_df)
     exp = pd.Series([1., 6., 17.06, 102.361, 68.241, 238.843], name='value')
 
@@ -46,7 +46,7 @@ def test_convert_unit_from_repo(test_df):
     _df = df.convert_unit('EJ/yr', 'Mtce/yr', inplace=False)
     pd.testing.assert_series_equal(_df.data.value, exp, **PRECISE_ARG)
 
-    # testing for `inplace=False`
+    # testing for `inplace=True`
     df.convert_unit('EJ/yr', 'Mtce/yr', inplace=True)
     pd.testing.assert_series_equal(df.data.value, exp, **PRECISE_ARG)
 
@@ -60,7 +60,7 @@ def test_convert_unit_with_custom_factor(test_df):
     _df = df.convert_unit('EJ/yr', 'foo', factor=2, inplace=False)
     pd.testing.assert_series_equal(_df.data.value, exp)
 
-    # testing for `inplace=False`
+    # testing for `inplace=True`
     df.convert_unit('EJ/yr', 'foo', factor=2, inplace=True)
     pd.testing.assert_series_equal(df.data.value, exp)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -14,6 +14,16 @@ def get_units_test_df(test_df):
     return df
 
 
+def assert_converted_units(df, current, to, exp, **kwargs):
+    # testing for `inplace=False`
+    _df = df.convert_unit(current, to, **kwargs, inplace=False)
+    pd.testing.assert_series_equal(_df.data.value, exp, **PRECISE_ARG)
+
+    # testing for `inplace=True`
+    df.convert_unit(current, to, **kwargs, inplace=True)
+    pd.testing.assert_series_equal(df.data.value, exp, **PRECISE_ARG)
+
+
 @pytest.mark.parametrize("current,to", [
     ('EJ/yr', 'TWh/yr'),
     ('EJ', 'TWh')
@@ -27,42 +37,21 @@ def test_convert_unit_with_pint(test_df, current, to):
         df.rename(unit={'EJ/yr': 'EJ'}, inplace=True)
 
     exp = pd.Series([1., 6., 138.88, 833.33, 555.55, 1944.44], name='value')
-
-    # testing for `inplace=False`
-    _df = df.convert_unit(current, to, inplace=False)
-    pd.testing.assert_series_equal(_df.data.value, exp, **PRECISE_ARG)
-
-    # testing for `inplace=True`
-    df.convert_unit(current, to, inplace=True)
-    pd.testing.assert_series_equal(df.data.value, exp, **PRECISE_ARG)
+    assert_converted_units(df, current, to, exp)
 
 
 def test_convert_unit_from_repo(test_df):
     # unit conversion with definition loaded from `IAMconsortium/units` repo
     df = get_units_test_df(test_df)
     exp = pd.Series([1., 6., 17.06, 102.361, 68.241, 238.843], name='value')
-
-    # testing for `inplace=False`
-    _df = df.convert_unit('EJ/yr', 'Mtce/yr', inplace=False)
-    pd.testing.assert_series_equal(_df.data.value, exp, **PRECISE_ARG)
-
-    # testing for `inplace=True`
-    df.convert_unit('EJ/yr', 'Mtce/yr', inplace=True)
-    pd.testing.assert_series_equal(df.data.value, exp, **PRECISE_ARG)
+    assert_converted_units(df, 'EJ/yr', 'Mtce/yr', exp)
 
 
 def test_convert_unit_with_custom_factor(test_df):
     # unit conversion with custom factor
     df = get_units_test_df(test_df)
     exp = pd.Series([1., 6., 1., 6., 4., 14.], name='value')
-
-    # testing for `inplace=False`
-    _df = df.convert_unit('EJ/yr', 'foo', factor=2, inplace=False)
-    pd.testing.assert_series_equal(_df.data.value, exp)
-
-    # testing for `inplace=True`
-    df.convert_unit('EJ/yr', 'foo', factor=2, inplace=True)
-    pd.testing.assert_series_equal(df.data.value, exp)
+    assert_converted_units(df, 'EJ/yr', 'foo', exp, factor=2)
 
 
 def test_convert_unit_with_mapping():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Tutorial Notebook Added
- [x] Interim Submodule Checkout Of Custom Branch Removed
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR introduces the option to pass a custom `pint.UnitRegistry` and/or contexts to the `IamDataFrame.convert_unit()` function. It uses the contexts for converting greenhouse with various gwp-metrics introduced in PR https://github.com/IAMconsortium/units/pull/10 for the tests.

The PR also adds a tutorial notebook to illustrate the full breadth of features of the new `convert_unit()` function.