### PR TITLE
add tests and tutorials to `data_package`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,11 @@ def main():
     package_data = {
         'pyam': ['region_mappings/*',
                  '../units/definitions.txt', '../units/modules/**/*.txt',
-                 'tests/**'],
+                 '../tests/*.*',
+                 '../tests/**/*.*',
+                 '../doc/source/tutorials/*.*',
+                 '../doc/source/tutorials/_static/*.*'
+         ],
     }
     install_requirements = REQUIREMENTS
     extra_requirements = EXTRA_REQUIREMENTS

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,9 @@ def main():
         ],
     }
     package_data = {
-        'pyam': ['region_mappings/*', '../units/definitions.txt',
-                 '../units/modules/**/*.txt'],
+        'pyam': ['region_mappings/*',
+                 '../units/definitions.txt', '../units/modules/**/*.txt',
+                 'tests/**'],
     }
     install_requirements = REQUIREMENTS
     extra_requirements = EXTRA_REQUIREMENTS


### PR DESCRIPTION
# Description of PR

This PR adds the tests and tutorials folders (and subfolders) to `package_data` in `setup.py`, so that they are copied as part of the installation. This is a step towards enabling #284.