### PR TITLE
bugfix for interpolation with extra columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ an IamDataFrame with `n/a` entries in columns other than `value` raises an error
 
 ## Individual Updates
 
+- [#352](https://github.com/IAMconsortium/pyam/pull/352) Bugfix when using `interpolate()` on data with extra columns
 - [#349](https://github.com/IAMconsortium/pyam/pull/349) Fixes an issue with checking that time columns are equal when appending IamDataFrames
 - [#348](https://github.com/IAMconsortium/pyam/pull/348) Extend pages for API docs, clean up docstrings, and harmonize formatting
 - [#347](https://github.com/IAMconsortium/pyam/pull/347) Enable contexts and custom UnitRegistry with unit conversion

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -355,7 +355,8 @@ class IamDataFrame(object):
             raise ValueError(
                 'The `time` argument `{}` is not an integer'.format(time)
             )
-        df = self.pivot_table(index=IAMC_IDX, columns=[self.time_col],
+        index = [i for i in self._LONG_IDX if i not in [self.time_col]]
+        df = self.pivot_table(index=index, columns=[self.time_col],
                               values='value', aggfunc=np.sum)
         # drop time-rows where values are already defined
         if time in df.columns:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ from pyam import IamDataFrame, validate, categorize, \
     require_variable, filter_by_meta, META_IDX, IAMC_IDX, sort_data, compare
 from pyam.core import _meta_idx, concat
 from pyam.utils import isstr
+from pyam.testing import assert_iamframe_equal
 
 from conftest import TEST_DTS
 
@@ -703,6 +704,25 @@ def test_interpolate(test_pd_df):
 
     # assert that extra_col does not have nan's (check for #351)
     assert all([True if isstr(i) else ~np.isnan(i) for i in df.data.foo])
+
+
+def test_interpolate_extra_cols():
+    # check hat interpolation with non-matching extra_cols has no effect (#351)
+    EXTRA_COL_DF = pd.DataFrame([
+        ['foo', 2005, 1],
+        ['bar', 2010, 3],
+    ],
+        columns=['extra_col', 'year', 'value'],
+    )
+    df = IamDataFrame(EXTRA_COL_DF, model='model_a', scenario='scen_a',
+                      region='World', variable='Primary Energy', unit='EJ/yr')
+
+    # create a copy, interpolate
+    df2 = df.copy()
+    df2.interpolate(2007)
+
+    # assert that interpolation didn't change any data
+    assert_iamframe_equal(df, df2)
 
 
 def test_interpolate_datetimes(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR fixes the issue raised by @Rlamboll in #351: the `interpolate()` function now does not return 'data' with `nan` when having an IamDataFrame with extra columns.

Data with non-matching values in extra columns are treated as separate timeseries - see the new test `test_interpolate_extra_cols`.

#closes 351