### PR TITLE
Update `units` submodule after refactoring to package

### DIFF
--- a/pyam/units.py
+++ b/pyam/units.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 
 # get application pint.UnitRegistry and load energy-units
 _REGISTRY = pint.get_application_registry()
-file = Path(__file__).parents[1] / 'units' / 'definitions.txt'
-_REGISTRY.load_definitions(str(file))
+path = Path(__file__).parents[1] / 'units' / 'iam_units' / 'data'
+_REGISTRY.load_definitions(str(path / 'definitions.txt'))
 
 
 def convert_unit(df, current, to, factor=None, registry=None, context=None,

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,9 @@ def main():
         ],
     }
     package_data = {
-        'pyam': ['region_mappings/*', '../units/definitions.txt',
-                 '../units/modules/**/*.txt'],
+        'pyam': ['region_mappings/*',
+                 '../units/iam_units/data/definitions.txt',
+                 '../units/iam_units/data/**/*.txt'],
     }
     install_requirements = REQUIREMENTS
     extra_requirements = EXTRA_REQUIREMENTS


### PR DESCRIPTION
# Description of PR

This PR bumps the [units](https://github.com/IAMconsortium/units) submodule to the latest version, which includes refactoring to a package (thanks @khaeru). The paths for importing `definitions.txt` and `package_data` are updated. (But the registry definitions are still loaded from `definitions.txt` rather than importing the `iam-units` package.)
