### PR TITLE
Show head of duplicate rows in error message

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Next Release
 
 ## Individual Updates
+- [#373](https://github.com/IAMconsortium/pyam/pull/373) Extends the error message when initializing with duplicate rows.
 - [#370](https://github.com/IAMconsortium/pyam/pull/370) Allowed filter to work with np.int64 years and np.datetime64 dates.  
 - [#369](https://github.com/IAMconsortium/pyam/pull/369) `convert_unit()` supports GWP conversion of same GHG species without context, lower-case aliases for species symbols.
 - [#361](https://github.com/IAMconsortium/pyam/pull/361) iam-units refactored from a Git submodule to a Python dependency of pyam.

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -251,10 +251,15 @@ def format_data(df, **kwargs):
     if df.isnull().values.any():
         raise ValueError('a column of `data` contains nan!')
 
-    # check for duplicates and return sorted data
+    # check for duplicates and empty data
     idx_cols = IAMC_IDX + [time_col] + extra_cols
-    if any(df[idx_cols].duplicated()):
-        raise ValueError('duplicate rows in `data`!')
+    duplicated_rows = df[idx_cols].duplicated()
+    if any(duplicated_rows):
+        duplicates = df.loc[duplicated_rows, idx_cols].drop_duplicates()
+        msg = f'duplicate rows in `data`:\n{duplicates.head()}'
+        if len(duplicates) > 5:
+            msg += '\n...'
+        raise ValueError(msg)
 
     if df.empty:
         logger.warning('Formatted data is empty!')

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -263,6 +263,7 @@ def format_data(df, **kwargs):
 
     return sort_data(df, idx_cols), time_col, extra_cols
 
+
 def _raise_data_error(msg, data):
     """Utils function to format error message from data formatting"""
     data = data.drop_duplicates()

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -259,6 +259,7 @@ def format_data(df, **kwargs):
         msg = f'duplicate rows in `data`:\n{duplicates.head()}'
         if len(duplicates) > 5:
             msg += '\n...'
+        logger.error(msg)
         raise ValueError(msg)
 
     if df.empty:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,7 +54,9 @@ def test_init_df_with_float_cols_raises(test_pd_df):
 def test_init_df_with_duplicates_raises(test_df):
     _df = test_df.timeseries()
     _df = _df.append(_df.iloc[0]).reset_index()
-    pytest.raises(ValueError, IamDataFrame, data=_df)
+    match = '3  model_a   scen_a  World  Primary Energy  EJ/yr'
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame(_df)
 
 
 def test_init_df_with_na_unit(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- [x] Description in RELEASE_NOTES.md Added
# Description of PR

Initializing an IamDataFrame with duplicate rows already raised an error. This PR extends the error message to include the head of the duplicate rows.

This came up as part of @zikolach and @vruijven working on the ixmp-server-integration pipeline and will hopefully simplify identifying the source of problematic data uploads.