### PR TITLE
Enable casting to IamDataFrame multiple times

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#396](https://github.com/IAMconsortium/pyam/pull/396) Enable casting to `IamDataFrame` multiple times
 - [#394](https://github.com/IAMconsortium/pyam/pull/394) Switch CI to Github Actions.
 - [#393](https://github.com/IAMconsortium/pyam/pull/393) Import ABC from collections.abc for Python 3.10 compatibility.
 - [#380](https://github.com/IAMconsortium/pyam/pull/380) Add compatibility with latest matplotlib and py3.8

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -90,6 +90,11 @@ class IamDataFrame(object):
     kwargs :code:`sheet_name` ('data') and :code:`meta_sheet_name` ('meta')
     Calling the class with :code:`meta_sheet_name=False` will
     skip the import of the 'meta' table.
+
+    When initializing an :class:`IamDataFrame` from an object that is already
+    an :class:`IamDataFrame` instance, the new object will be hard-linked to
+    all attributes of the original object - so any changes on one object
+    (e.g., with :code:`inplace=True`) may also modify the other object!
     """
     def __init__(self, data, **kwargs):
         """Initialize an instance of an IamDataFrame"""

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -93,6 +93,14 @@ class IamDataFrame(object):
     """
     def __init__(self, data, **kwargs):
         """Initialize an instance of an IamDataFrame"""
+        if isinstance(data, IamDataFrame) and not kwargs:
+            for attr, value in data.__dict__.items():
+                setattr(self, attr, value)
+        else:
+            self._init(data, **kwargs)
+
+    def _init(self, data, **kwargs):
+        """Process data and set attributes for new instance"""
         # import data from pd.DataFrame or read from source
         if isinstance(data, pd.DataFrame) or isinstance(data, pd.Series):
             _data = format_data(data.copy(), **kwargs)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -100,7 +100,10 @@ class IamDataFrame(object):
     """
     def __init__(self, data, **kwargs):
         """Initialize an instance of an IamDataFrame"""
-        if isinstance(data, IamDataFrame) and not kwargs:
+        if isinstance(data, IamDataFrame):
+            if kwargs:
+                msg = 'Invalid arguments `{}` for initializing an IamDataFrame'
+                raise ValueError(msg.format(kwargs))
             for attr, value in data.__dict__.items():
                 setattr(self, attr, value)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -95,6 +95,8 @@ class IamDataFrame(object):
     an :class:`IamDataFrame` instance, the new object will be hard-linked to
     all attributes of the original object - so any changes on one object
     (e.g., with :code:`inplace=True`) may also modify the other object!
+    This is intended behaviour and consistent with pandas but may be confusing
+    for those who are not used to the pandas/Python universe.
     """
     def __init__(self, data, **kwargs):
         """Initialize an instance of an IamDataFrame"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -46,6 +46,10 @@ def test_init_df_with_index(test_pd_df):
     pd.testing.assert_frame_equal(df.timeseries().reset_index(), test_pd_df)
 
 
+def test_init_from_iamdf(test_df_year):
+    assert not IamDataFrame(test_df_year).empty
+
+
 def test_init_df_with_float_cols_raises(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005.5, 2010: 2010.})
     pytest.raises(ValueError, IamDataFrame, data=_test_df)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -59,6 +59,12 @@ def test_init_from_iamdf(test_df_year):
     assert all(df.scenarios().values == ['scen_b', 'scen_bar'])
     assert all(test_df_year.scenarios().values == ['scen_b', 'scen_foo'])
 
+
+def test_init_from_iamdf_raises(test_df_year):
+    # casting an IamDataFrame instance again with extra args fails
+    pytest.raises(ValueError, IamDataFrame, test_df_year, model='foo')
+
+
 def test_init_df_with_float_cols_raises(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005.5, 2010: 2010.})
     pytest.raises(ValueError, IamDataFrame, data=_test_df)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,7 +62,10 @@ def test_init_from_iamdf(test_df_year):
 
 def test_init_from_iamdf_raises(test_df_year):
     # casting an IamDataFrame instance again with extra args fails
-    pytest.raises(ValueError, IamDataFrame, test_df_year, model='foo')
+    args = dict(model='foo')
+    match = f'Invalid arguments `{args}` for initializing an IamDataFrame'
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame(test_df_year, **args)
 
 
 def test_init_df_with_float_cols_raises(test_pd_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,8 +47,17 @@ def test_init_df_with_index(test_pd_df):
 
 
 def test_init_from_iamdf(test_df_year):
-    assert not IamDataFrame(test_df_year).empty
+    # casting an IamDataFrame instance again works
+    df = IamDataFrame(test_df_year)
 
+    # inplace-operations on the new object have effects on the original object
+    df.rename(scenario={'scen_a': 'scen_foo'}, inplace=True)
+    assert all(test_df_year.scenarios().values == ['scen_b', 'scen_foo'])
+
+    # overwrites on the new object do not have effects on the original object
+    df = df.rename(scenario={'scen_foo': 'scen_bar'})
+    assert all(df.scenarios().values == ['scen_b', 'scen_bar'])
+    assert all(test_df_year.scenarios().values == ['scen_b', 'scen_foo'])
 
 def test_init_df_with_float_cols_raises(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005.5, 2010: 2010.})


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

I recently noticed that casting an IamDataFrame again (i.e., `IamDataFrame(IamDataFrame(<file>))` raises a non-intuitive error message.

This PR implements a simple approach to circumvent this problem, with all attributes of the first and second casting of the IamDataFrame instance pointing to the same objects. This follows the logic for pandas.DataFrames (as far as I understand it) where performing an operation on one instance has an impact also on the second (see the new test to show how this works in pyam).

An alternative approach may be to do a full copy during the double-casting.

## Use case

I wrote a script recently that cast an object to an `IamDataFrame` ([see here](https://github.com/openENTRANCE/nomenclature/blob/69703d073a6367332aab1d9d648dc01a9ec483c6/nomenclature/__init__.py#L82)) before performing a few checks and operations - this failed when the object was already an `IamDataFrame`. That function has been extended to first check before casting, but this may be a problem that other users run into.