### PR TITLE
Read iiasa-creds by default from known location

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#401](https://github.com/IAMconsortium/pyam/pull/401) Read credentials for IIASA-API-Connection by default from known location.
 - [#394](https://github.com/IAMconsortium/pyam/pull/394) Switch CI to Github Actions.
 - [#393](https://github.com/IAMconsortium/pyam/pull/393) Import ABC from collections.abc for Python 3.10 compatibility.
 - [#380](https://github.com/IAMconsortium/pyam/pull/380) Add compatibility with latest matplotlib and py3.8

--- a/doc/source/tutorials/iiasa_dbs.ipynb
+++ b/doc/source/tutorials/iiasa_dbs.ipynb
@@ -44,11 +44,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have additional credentials, you can supply them as well via the `creds` key-word argument:\n",
+    "If you have credentials to connect to a non-public or restricted database,\n",
+    "you can set this (in a separate Python console) using the following command:\n",
     "\n",
     "```\n",
-    "pyam.iiasa.Connection(creds=(<username>, <password>))\n",
-    "```"
+    "import pyam\n",
+    "pyam.iiasa.set_config(<username>, <password>)\n",
+    "```\n",
+    "When initializing a new `Connection` instance, **pyam** will automatically search for the configuration in a known location."
    ]
   },
   {

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -98,29 +98,28 @@ def _get_token(creds, base_url):
 
 
 class Connection(object):
-    """A class to facilitate querying an IIASA scenario explorer database"""
+    """A class to facilitate querying an IIASA scenario explorer database
 
+    Parameters
+    ----------
+    name : str, optional
+        A valid database name. For available options, see
+        valid_connections().
+    creds : str, :class:`pathlib.Path`, list-like, or dict, optional
+        By default, this function will (try to) read user credentials which
+        were set using :meth:`pyam.iiasa.set_config(<user>, <password>)`.
+        Alternatively, you can provide a path to a yaml file
+        with entries of  'username' and 'password'.
+    base_url : str, custom authentication server URL
+
+    Notes
+    -----
+    Providing credentials as an ordered container (tuple, list, etc.)
+    or as a dictionary with keys `user` and `password` is (still) supported
+    for backwards compatibility. However, this option is NOT RECOMMENDED
+    and will be deprecated in future releases of pyam.
+    """
     def __init__(self, name=None, creds=None, base_url=_BASE_URL):
-        """
-        Parameters
-        ----------
-        name : str, optional
-            A valid database name. For available options, see
-            valid_connections().
-        creds : str, :class:`pathlib.Path`, list-like, or dict, optional
-            By default, this function will (try to) read user credentials which
-            were set using :meth:`pyam.iiasa.set_config(<user>, <password>)`.
-            Alternatively, you can provide a path to a yaml file
-            with entries of  'username' and 'password'.
-        base_url : str, custom authentication server URL
-
-        Notes
-        -----
-        Providing credentials as an ordered container (tuple, list, etc.)
-        or as a dictionary with keys `user` and `password` is (still) supported
-        for backwards compatibility. However, this option is NOT RECOMMENDED
-        and will be deprecated in future releases of pyam.
-        """
         self._base_url = base_url
         self._token, self._user = _get_token(creds, base_url=self._base_url)
 

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import json
 import logging
 import os
@@ -22,6 +23,28 @@ You are connected to the {} scenario explorer hosted by IIASA.
  If you use this data in any published format, please cite the
  data as provided in the explorer guidelines: {}
 """.replace('\n', '')
+
+# path to local configuration settings
+DEFAULT_IIASA_CONFIG = Path('~') / '.local' / 'pyam' / 'iiasa-config.json'
+
+
+def set_config(user, password, file=None):
+    """Save username and password for IIASA API connection to file"""
+    file = Path(file) if file is not None else DEFAULT_IIASA_CONFIG
+    if not file.parent.exists():
+        file.parent.mkdir(parents=True)
+
+    with open(file, mode='w') as f:
+        logger.info(f'Setting IIASA-connection configuration file: {file}')
+        json.dump(dict(user=user, password=password), f)
+
+
+def get_config(file=None):
+    """Get username and password for IIASA API connection from file"""
+    file = Path(file) if file is not None else DEFAULT_IIASA_CONFIG
+    if file.exists():
+        with open(file, mode='r') as f:
+            return json.load(f)
 
 
 def _check_response(r, msg='Trouble with request', error=RuntimeError):

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -73,8 +73,7 @@ def _get_token(creds, base_url):
         url = '/'.join([base_url, 'anonym'])
         r = requests.get(url)
         _check_response(r, 'Could not get anonymous token')
-        logger.info('You are connected as an anonymous user')
-        return r.json()
+        return r.json(), None
 
     # parse creds, write warning
     if isinstance(creds, Mapping):
@@ -95,8 +94,7 @@ def _get_token(creds, base_url):
     url = '/'.join([base_url, 'login'])
     r = requests.post(url, headers=headers, data=json.dumps(data))
     _check_response(r, 'Login failed for user: {}'.format(user))
-    logger.info(f'You are connected as user `{user}`')
-    return r.json()
+    return r.json(), user
 
 
 class Connection(object):
@@ -124,12 +122,17 @@ class Connection(object):
         and will be deprecated in future releases of pyam.
         """
         self._base_url = base_url
-        self._token = _get_token(creds, base_url=self._base_url)
+        self._token, self._user = _get_token(creds, base_url=self._base_url)
 
         # connect if provided a name
         self._connected = None
         if name:
             self.connect(name)
+
+        if self._user:
+            logger.info(f'You are connected as user `{self._user}`')
+        else:
+            logger.info(f'You are connected as an anonymous user')
 
     @property
     @lru_cache()

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -26,12 +26,12 @@ You are connected to the {} scenario explorer hosted by IIASA.
 """.replace('\n', '')
 
 # path to local configuration settings
-DEFAULT_IIASA_CONFIG = Path('~').expanduser() / '.local' / 'pyam' / 'iiasa.yaml'
+DEFAULT_IIASA_CREDS = Path('~').expanduser() / '.local' / 'pyam' / 'iiasa.yaml'
 
 
 def set_config(user, password, file=None):
     """Save username and password for IIASA API connection to file"""
-    file = Path(file) if file is not None else DEFAULT_IIASA_CONFIG
+    file = Path(file) if file is not None else DEFAULT_IIASA_CREDS
     if not file.parent.exists():
         file.parent.mkdir(parents=True)
 
@@ -42,7 +42,7 @@ def set_config(user, password, file=None):
 
 def _get_config(file=None):
     """Read username and password for IIASA API connection from file"""
-    file = Path(file) if file is not None else DEFAULT_IIASA_CONFIG
+    file = Path(file) if file is not None else DEFAULT_IIASA_CREDS
     if file.exists():
         with open(file, 'r') as stream:
             return yaml.safe_load(stream)
@@ -84,8 +84,8 @@ def _get_token(creds, base_url):
         logger.warning('You provided credentials in plain text. DO NOT save '
                        'these in a repository or otherwise post them online')
         deprecation_warning('Providing credentials in plain text',
-                            'Please use `pyam.iiasa.set_config(<user>, <pwd>)` '
-                            'to store your credentials in a file!')
+                            'Please use `pyam.iiasa.set_config(<user>, <pwd>)`'
+                            ' to store your credentials in a file!')
 
     # get user token
     headers = {'Accept': 'application/json',

--- a/tests/data/setup_iiasa_integration_test_instance.ipynb
+++ b/tests/data/setup_iiasa_integration_test_instance.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import ixmp\n",
+    "import pyam"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyam.iiasa.Connection().valid_connections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp = ixmp.Platform('ixmp_integration_test')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All default regions in an ixmp instance (R11, countries) otehr than World were manually deleted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp.add_region('region_a', 'World', 'continent_a')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp.add_region_synonym('ISO_a', 'region_a')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "?mp.add_region_synonym"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEST_DF = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/yr', 1, 6.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/yr', 0.5, 3],\n",
+    "    ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/yr', 2, 7],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + [2005, 2010],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pyam.IamDataFrame(TEST_DF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for (model, scenario), data in df.data.groupby(['model', 'scenario']):\n",
+    "    scen = ixmp.Scenario(mp, model, scenario, version= 'new')\n",
+    "    scen.add_timeseries(data)\n",
+    "    scen.commit('importing scenario data from pyam test suite')\n",
+    "    scen.set_as_default()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEST_DF2 = pd.DataFrame([\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/yr', 2, 7.],\n",
+    "    ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/yr', 0.8, 4],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + [2005, 2010],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pyam.IamDataFrame(TEST_DF2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for (model, scenario), data in df.data.groupby(['model', 'scenario']):\n",
+    "    scen = ixmp.Scenario(mp, model, scenario, version= 'new')\n",
+    "    scen.add_timeseries(data)\n",
+    "    scen.commit('importing scenario data from pyam test suite')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp.add_timeslice('Summer', 'Season', 0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEST_DF3 = pd.DataFrame([\n",
+    "    ['model_b', 'scen_a', 'World', 'Primary Energy', 'EJ/yr', 'Year', 3, 8.],\n",
+    "    ['model_b', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/yr', 'Year', 0.9, 5],\n",
+    "    ['model_b', 'scen_a', 'World', 'Primary Energy', 'EJ/yr', 'Summer', 1, 3],\n",
+    "    ['model_b', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/yr', 'Summer', 0.4, 2],\n",
+    "],\n",
+    "    columns=pyam.IAMC_IDX + ['subannual', 2005, 2010],\n",
+    ")\n",
+    "df = pyam.IamDataFrame(TEST_DF3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for (model, scenario), data in df.data.groupby(['model', 'scenario']):\n",
+    "    scen = ixmp.Scenario(mp, model, scenario, version='new')\n",
+    "    scen.add_timeseries(data)\n",
+    "    scen.commit('importing scenario data from pyam test suite')\n",
+    "    scen.set_as_default()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp.scenario_list(default=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -13,7 +13,7 @@ if IIASA_UNAVAILABLE:
 
 # verify whether IIASA database API can be reached, skip tests otherwise
 try:
-    iiasa.Connection('ixmp-integration')
+    iiasa.Connection()
 except SSLError:
     pytest.skip('IIASA database API unavailable', allow_module_level=True)
 

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -1,11 +1,17 @@
-import copy
-import pytest
 import os
+from requests.exceptions import SSLError
+import copy
 import yaml
-
+import pytest
 import numpy.testing as npt
-
 from pyam import iiasa
+
+# verify whether IIASA database API can be reached
+try:
+    iiasa.Connection('ixmp-integration')
+    IIASA_AVAILABLE = True
+except SSLError:
+    pytest.skip('IIASA database API unavailable', allow_module_level=True)
 
 # check to see if we can do online testing of db authentication
 TEST_ENV_USER = 'IIASA_CONN_TEST_USER'

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -6,10 +6,9 @@ import pytest
 import numpy.testing as npt
 from pyam import iiasa
 
-# verify whether IIASA database API can be reached
+# verify whether IIASA database API can be reached, skip tests otherwise
 try:
     iiasa.Connection('ixmp-integration')
-    IIASA_AVAILABLE = True
 except SSLError:
     pytest.skip('IIASA database API unavailable', allow_module_level=True)
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~ (requires more work on GitHub Actions to store secrets, will be added as part of the IIASA-API-tests refactoring
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added
# Description of PR

This PR adds a utility to save the iiasa-api credentials in a known location and provides a utility to store them (`pyam.iiasa.set_config(<user>, <password>)`). This will make it easier for users to not write their password in workflow scripts. Providing credentials as kwargs to `Connection` is marked as deprecated and will be removed in the future.

Documentation and tutorials are updated and built [here](https://pyam-iamc.readthedocs.io/en/iiasa-creds-config/) on readthedocs.
