### PR TITLE
Rearrange tests, skip IIASA-API tests if unavailable

### DIFF
--- a/.github/workflows/pytest_38.yml
+++ b/.github/workflows/pytest_38.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[tests,optional-io-formats]
+        pip install pandoc nbformat
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/pytest_38.yml
+++ b/.github/workflows/pytest_38.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[tests,optional-io-formats]
+        pip install -e .[tests,deploy,optional-io-formats]
         pip install pandoc nbformat
 
     - name: Test with pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,20 @@ import matplotlib
 matplotlib.use('agg')
 
 import os
+from requests.exceptions import SSLError
 import pytest
 import pandas as pd
 
-
 from datetime import datetime
-from pyam import IamDataFrame, IAMC_IDX
+from pyam import IamDataFrame, IAMC_IDX, iiasa
+
+
+# verify whether IIASA database API can be reached, skip tests otherwise
+try:
+    iiasa.Connection('ixmp-integration')
+    IIASA_UNAVAILABLE = False
+except SSLError:
+    IIASA_UNAVAILABLE = True
 
 
 here = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,7 +3,7 @@ to print configuration information of the loaded package(s) to users!"""
 import sys
 
 from test_plotting import MPL_KWARGS
-
+from conftest import IIASA_UNAVAILABLE
 
 def test_config(capsys):
     modules = {}
@@ -14,12 +14,13 @@ def test_config(capsys):
                 modules[m.__name__] = version
 
     with capsys.disabled():
-        print()
-        print('Plotting function decorator kwargs:')
+        print('\nPlotting function decorator kwargs:')
         for k, v in MPL_KWARGS.items():
             print('{}: {}'.format(k, v))
 
-        print()
-        print('Module versions:')
+        print('\nModule versions:')
         for key in sorted(list(modules.keys())):
             print('{}: {}'.format(key, modules[key]))
+
+        if IIASA_UNAVAILABLE:
+            print('\nIIASA-API unavailable, skipping related tests\n')

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -23,4 +23,7 @@ def test_config(capsys):
             print('{}: {}'.format(key, modules[key]))
 
         if IIASA_UNAVAILABLE:
-            print('\nIIASA-API unavailable, skipping related tests\n')
+            print('\nWARNING: IIASA-API unavailable, skipping related tests\n')
+
+        # add empty spaces equivalent to length of file name
+        print('                    ')

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -26,4 +26,4 @@ def test_config(capsys):
             print('\nWARNING: IIASA-API unavailable, skipping related tests\n')
 
         # add empty spaces equivalent to length of file name
-        print('                    ')
+        print('tests/test_admin.py ', end='')

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -1,11 +1,17 @@
-import copy
-import pytest
 import os
+from requests.exceptions import SSLError
+import copy
 import yaml
-
+import pytest
 import numpy.testing as npt
-
 from pyam import iiasa
+
+# verify whether IIASA database API can be reached
+try:
+    iiasa.Connection('ixmp-integration')
+    IIASA_AVAILABLE = True
+except SSLError:
+    pytest.skip('IIASA database API unavailable', allow_module_level=True)
 
 # check to see if we can do online testing of db authentication
 TEST_ENV_USER = 'IIASA_CONN_TEST_USER'

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -6,10 +6,9 @@ import pytest
 import numpy.testing as npt
 from pyam import iiasa
 
-# verify whether IIASA database API can be reached
+# verify whether IIASA database API can be reached, skip tests otherwise
 try:
     iiasa.Connection('ixmp-integration')
-    IIASA_AVAILABLE = True
 except SSLError:
     pytest.skip('IIASA database API unavailable', allow_module_level=True)
 

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -1,15 +1,12 @@
 import os
-from requests.exceptions import SSLError
 import copy
 import yaml
 import pytest
 import numpy.testing as npt
 from pyam import iiasa
+from conftest import IIASA_UNAVAILABLE
 
-# verify whether IIASA database API can be reached, skip tests otherwise
-try:
-    iiasa.Connection('ixmp-integration')
-except SSLError:
+if IIASA_UNAVAILABLE:
     pytest.skip('IIASA database API unavailable', allow_module_level=True)
 
 # check to see if we can do online testing of db authentication

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import pytest
 
-from conftest import here
+from conftest import here, IIASA_UNAVAILABLE
 
 try:
     import nbformat
@@ -111,6 +111,7 @@ def test_pyam_logo():
 
 @pytest.mark.skipif(not jupyter_installed, reason=jupyter_reason)
 @pytest.mark.skipif(not pandoc_installed, reason=pandoc_reason)
+@pytest.mark.skipif(IIASA_UNAVAILABLE, reason='IIASA database API unavailable')
 def test_iiasa_dbs():
     fname = os.path.join(tut_path, 'iiasa_dbs.ipynb')
     nb, errors = _notebook_run(fname, timeout=600)


### PR DESCRIPTION
# Description of PR

This PR adds a module-wide pytest-skip (plus writing a message to the log) when the IIASA database API is unavailable.
