### PR TITLE
Update badges on the docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-pyam: analysis & visualization of integrated-assessment scenarios
-===================================================================
+pyam: analysis & visualization <br /> of integrated-assessment scenarios
+========================================================================
 
 [![license](https://anaconda.org/conda-forge/pyam/badges/license.svg)](https://anaconda.org/conda-forge/pyam)
 [![pypi](https://img.shields.io/pypi/v/pyam-iamc.svg)](https://pypi.python.org/pypi/pyam-iamc/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
-pyam: analysis and visualization of integrated-assessment scenarios
+pyam: analysis & visualization of integrated-assessment scenarios
 ===================================================================
+
+[![license](https://anaconda.org/conda-forge/pyam/badges/license.svg)](https://anaconda.org/conda-forge/pyam)
+[![pypi](https://img.shields.io/pypi/v/pyam-iamc.svg)](https://pypi.python.org/pypi/pyam-iamc/)
+[![conda](https://anaconda.org/conda-forge/pyam/badges/version.svg)](https://anaconda.org/conda-forge/pyam)
+[![latest](https://anaconda.org/conda-forge/pyam/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/pyam)
+
+[![pytest-38](https://github.com/IAMconsortium/pyam/workflows/pytest%20(3.8)/badge.svg?branch=master)](https://github.com/IAMconsortium/pyam/actions?query=workflow%3A%22pytest+%283.8%29%22+branch%3Amaster)
+[![pytest-37](https://github.com/IAMconsortium/pyam/workflows/pytest%20(3.7)/badge.svg?branch=master)](https://github.com/IAMconsortium/pyam/actions?query=workflow%3A%22pytest+%283.7%29%22+branch%3Amaster)
+[![codecov](https://codecov.io/gh/IAMconsortium/pyam/branch/master/graph/badge.svg)](https://codecov.io/gh/IAMconsortium/pyam)
+[![ReadTheDocs](https://readthedocs.org/projects/pyam-iamc/badge/?version=latest)](https://pyam-iamc.readthedocs.io/en/latest/?badge=latest)
+
+[![doi](https://zenodo.org/badge/113359260.svg)](https://zenodo.org/badge/latestdoi/113359260)
+[![joss](https://joss.theoj.org/papers/10.21105/joss.01095/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01095)
+
+****
 
 **Documentation on [Read the Docs](https://pyam-iamc.readthedocs.io)**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Next Release
 
-- [#408](https://github.com/IAMconsortium/pyam/pull/408) Update badges on the docs page.
+- [#408](https://github.com/IAMconsortium/pyam/pull/408) Update badges on the docs page and readme.
 - [#407](https://github.com/IAMconsortium/pyam/pull/407) Add Codecov to Github Actions CI.
 - [#394](https://github.com/IAMconsortium/pyam/pull/394) Switch CI to Github Actions.
 - [#393](https://github.com/IAMconsortium/pyam/pull/393) Import ABC from collections.abc for Python 3.10 compatibility.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#408](https://github.com/IAMconsortium/pyam/pull/408) Update badges on the docs page.
 - [#407](https://github.com/IAMconsortium/pyam/pull/407) Add Codecov to Github Actions CI.
 - [#394](https://github.com/IAMconsortium/pyam/pull/394) Switch CI to Github Actions.
 - [#393](https://github.com/IAMconsortium/pyam/pull/393) Import ABC from collections.abc for Python 3.10 compatibility.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,7 +5,7 @@ Release v\ |version|.
 
 |pypi| |conda| |license| |latest|
 
-|rtd| |travis| |appveyor| |coveralls|
+|pytest-38| |pytest-37| |codecov| |rtd|
 
 |joss| |doi|
 
@@ -21,18 +21,18 @@ Release v\ |version|.
 .. |latest| image:: https://anaconda.org/conda-forge/pyam/badges/latest_release_date.svg
    :target: https://anaconda.org/conda-forge/pyam
 
+.. |pytest-38| image:: https://github.com/IAMconsortium/pyam/workflows/pytest%20(3.8)/badge.svg?branch=master
+   :target: https://github.com/IAMconsortium/pyam/actions?query=workflow%3A%22pytest+%283.8%29%22+branch%3Amaster
+
+.. |pytest-37| image:: https://github.com/IAMconsortium/pyam/workflows/pytest%20(3.7)/badge.svg?branch=master
+   :target: https://github.com/IAMconsortium/pyam/actions?query=workflow%3A%22pytest+%283.7%29%22+branch%3Amaster
+
+.. |codecov| image:: https://codecov.io/gh/IAMconsortium/pyam/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/IAMconsortium/pyam
+
 .. |rtd| image:: https://readthedocs.org/projects/pyam-iamc/badge/?version=latest
    :target: https://pyam-iamc.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
-
-.. |travis| image:: https://travis-ci.com/IAMconsortium/pyam.svg?branch=master
-   :target: https://travis-ci.com/IAMconsortium/pyam
-
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/qd4taojd2vkqoab4/branch/master?svg=true&passingText=passing&failingText=failing&pendingText=pending
-   :target: https://ci.appveyor.com/project/gidden/pyam/branch/master
-
-.. |coveralls| image:: https://coveralls.io/repos/github/IAMconsortium/pyam/badge.svg?branch=master
-   :target: https://coveralls.io/github/IAMconsortium/pyam?branch=master
 
 .. |joss| image:: https://joss.theoj.org/papers/10.21105/joss.01095/status.svg
    :target: https://joss.theoj.org/papers/10.21105/joss.01095

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,19 +3,19 @@
 
 Release v\ |version|.
 
-|pypi| |conda| |license| |latest|
+|license| |pypi| |conda| |latest|
 
 |pytest-38| |pytest-37| |codecov| |rtd|
 
 |joss| |doi|
 
+.. |license| image:: https://anaconda.org/conda-forge/pyam/badges/license.svg
+   :target: https://anaconda.org/conda-forge/pyam
+
 .. |pypi| image:: https://img.shields.io/pypi/v/pyam-iamc.svg
    :target: https://pypi.python.org/pypi/pyam-iamc/
 
 .. |conda| image:: https://anaconda.org/conda-forge/pyam/badges/version.svg
-   :target: https://anaconda.org/conda-forge/pyam
-
-.. |license| image:: https://anaconda.org/conda-forge/pyam/badges/license.svg
    :target: https://anaconda.org/conda-forge/pyam
 
 .. |latest| image:: https://anaconda.org/conda-forge/pyam/badges/latest_release_date.svg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from pyam import IamDataFrame, IAMC_IDX, iiasa
 
 # verify whether IIASA database API can be reached, skip tests otherwise
 try:
-    iiasa.Connection('ixmp-integration')
+    iiasa.Connection()
     IIASA_UNAVAILABLE = False
 except SSLError:
     IIASA_UNAVAILABLE = True


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR updates the badges on the docs pages to use GitHub actions and codecov instead of travis, appveyor and coveralls. It also adds the badges on the README.
