### PR TITLE
Read data from World Bank Open Data Catalogue as IamDataFrame

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Next release
 
-- [#416](https://github.com/IAMconsortium/pyam/pull/416) Include `meta` in new IamDataFrames returned by aggregation functions
+- [#418](https://github.com/IAMconsortium/pyam/pull/418) Read data from World Bank Open Data Catalogue as IamDataFrame.
+- [#416](https://github.com/IAMconsortium/pyam/pull/416) Include `meta` in new IamDataFrames returned by aggregation functions.
 
 # Release v0.7.0
 

--- a/doc/source/api/io.rst
+++ b/doc/source/api/io.rst
@@ -46,3 +46,15 @@ The data is returned as an :class:`IamDataFrame`.
 See `this tutorial <../tutorials/iiasa_dbs.html>`_ for more information.
 
 .. autofunction:: read_iiasa
+
+Connecting to other data resources
+----------------------------------
+
+The package :class:`pandas-datareader`
+(`read the docs <https://pandas-datareader.readthedocs.io>`_)
+implements a number of connections to publicly accessible data resources,
+e.g., the `World Bank Open Data Catalog <https://datacatalog.worldbank.org>`_.
+|pyam| provides a simple utility function to cast the queried timeseries data
+directly as an :class:`IamDataFrame`.
+
+.. autofunction:: read_worldbank

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -325,7 +325,9 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'pint': ('https://pint.readthedocs.io/en/stable', None),
-    'ixmp': ('https://message.iiasa.ac.at/projects/ixmp/en/stable/', None)
+    'ixmp': ('https://message.iiasa.ac.at/projects/ixmp/en/stable/', None),
+    'pandas_datareader':
+        ('https://pandas-datareader.readthedocs.io/en/stable', None)
 }
 
 # extend the timeout limit for running notebooks

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -6,7 +6,7 @@ from pyam.read_ixmp import *
 from pyam.logging import *
 from pyam.run_control import *
 from pyam.iiasa import read_iiasa  # noqa: F401
-from pyam.datareader import wb, read_worldbank  # noqa: F401
+from pyam.datareader import read_worldbank  # noqa: F401
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 from pyam.core import *
 from pyam.utils import *
 from pyam.statistics import *
@@ -8,6 +6,7 @@ from pyam.read_ixmp import *
 from pyam.logging import *
 from pyam.run_control import *
 from pyam.iiasa import read_iiasa  # noqa: F401
+from pyam.datareader import wb, read_worldbank  # noqa: F401
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1994,7 +1994,7 @@ def read_datapackage(path, data='data', meta='meta'):
         (optional) resource containing a table of categorization and
         quantitative indicators
     """
-    if not HAS_DATAPACKAGE:
+    if not HAS_DATAPACKAGE:  # pragma: no cover
         raise ImportError('required package `datapackage` not found!')
 
     package = Package(path)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -792,6 +792,8 @@ class IamDataFrame(object):
         `iam-units <https://github.com/IAMconsortium/units>`_ package.
         This registry can also be accessed directly, using::
 
+        .. code-block:: python
+
             from iam_units import registry
 
         When using this registry, *current* and *to* may contain the symbols of

--- a/pyam/datareader.py
+++ b/pyam/datareader.py
@@ -3,7 +3,7 @@ from pyam import IamDataFrame
 try:
     import pandas_datareader.wb as wb
     HAS_DATAREADER = True
-except ImportError:
+except ImportError:  # pragma: no cover
     wb = None
     HAS_DATAREADER = False
 
@@ -46,7 +46,7 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
     -------
     IamDataFrame
     """
-    if not HAS_DATAREADER:
+    if not HAS_DATAREADER:  # pragma: no cover
         raise ImportError('Required package `pandas-datareader` not found!')
 
     data = wb.download(**kwargs)

--- a/pyam/datareader.py
+++ b/pyam/datareader.py
@@ -13,9 +13,12 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
 
     This function is a simple wrapper for the class
     :class:`pandas_datareader.wb.WorldBankReader` and the function
-    :func:`pandas_datareader.wb.download`. You can access any function
-    of that module via :func:`pyam.wb.<function>` to retrieve/search
+    :func:`pandas_datareader.wb.download`. Import the module to retrieve/search
     the list of indicators (and their id's), countries, etc.
+
+    .. code-block:: python
+
+        from pandas_datareader import wb
 
     Parameters
     ----------
@@ -30,8 +33,8 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
     -----
     The function :func:`pandas_datareader.wb.download` takes an `indicator`
     argument, which can be a string or list of strings. If the `indicator`
-    passed to :func:`read_worldbank` is a dictionary mapping a World Bank id to
-    a variable name, the variables in the returned IamDataFrame will be renamed.
+    passed to :func:`read_worldbank` is a dictionary of a World Bank id mapped
+    to a string, the variables in the returned IamDataFrame will be renamed.
 
     The function :func:`pandas_datareader.wb.download` does not return a unit,
     but it can be collected for some indicators using the function

--- a/pyam/datareader.py
+++ b/pyam/datareader.py
@@ -1,0 +1,52 @@
+from pyam import IamDataFrame
+
+try:
+    import pandas_datareader.wb as wb
+    HAS_DATAREADER = True
+except ImportError:
+    wb = None
+    HAS_DATAREADER = False
+
+
+def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
+    """Read data from the World Bank Data Catalogue and return as IamDataFrame
+
+    This function is a simple wrapper for the class
+    :class:`pandas_datareader.wb.WorldBankReader` and the function
+    :func:`pandas_datareader.wb.download`. You can access any function
+    of the package via :func:`pyam.wb.<function>` to retrieve/search
+    the list of indicators (and their id's), countries, etc.
+
+    Parameters
+    ----------
+    model : str, optional
+        The `model` name to be used for the returned timeseries data.
+    scenario : str, optional
+        The `scenario` name to be used for the returned timeseries data.
+    kwargs
+        passed to :func:`pandas_datareader.wb.download`
+
+    Notes
+    -----
+    The function :func:`pandas_datareader.wb.download` takes an `indicator`
+    argument, which can be a string or list of strings. If the `indicator`
+    passed to :func:`read_worldbank` is a dictionary mapping a World Bank id to
+    a variable name, the variables in the returned IamDataFrame will be renamed.
+
+    Returns
+    -------
+    IamDataFrame
+    """
+    if not HAS_DATAREADER:
+        raise ImportError('Required package `pandas-datareader` not found!')
+
+    data = wb.download(**kwargs)
+    df = IamDataFrame(data.reset_index(), model=model, scenario=scenario,
+                      value=data.columns, unit='n/a', region='country')
+
+    # if `indicator` is a mapping, use it for renaming
+    if 'indicator' in kwargs and isinstance(kwargs['indicator'], dict):
+        df.rename(variable=kwargs['indicator'], inplace=True)
+
+    return df
+

--- a/pyam/datareader.py
+++ b/pyam/datareader.py
@@ -59,4 +59,3 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
         df.rename(variable=kwargs['indicator'], inplace=True)
 
     return df
-

--- a/pyam/datareader.py
+++ b/pyam/datareader.py
@@ -14,7 +14,7 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
     This function is a simple wrapper for the class
     :class:`pandas_datareader.wb.WorldBankReader` and the function
     :func:`pandas_datareader.wb.download`. You can access any function
-    of the package via :func:`pyam.wb.<function>` to retrieve/search
+    of that module via :func:`pyam.wb.<function>` to retrieve/search
     the list of indicators (and their id's), countries, etc.
 
     Parameters
@@ -33,6 +33,12 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
     passed to :func:`read_worldbank` is a dictionary mapping a World Bank id to
     a variable name, the variables in the returned IamDataFrame will be renamed.
 
+    The function :func:`pandas_datareader.wb.download` does not return a unit,
+    but it can be collected for some indicators using the function
+    :func:`pandas_datareader.wb.get_indicators`.
+    In the current implementation, unit is defined as `n/a` for all data;
+    this can be enhanced later (if there is interest from users).
+
     Returns
     -------
     IamDataFrame
@@ -43,6 +49,7 @@ def read_worldbank(model='World Bank', scenario='WDI', **kwargs):
     data = wb.download(**kwargs)
     df = IamDataFrame(data.reset_index(), model=model, scenario=scenario,
                       value=data.columns, unit='n/a', region='country')
+    # TODO use wb.get_indicators to retrieve corrent units (where available)
 
     # if `indicator` is a mapping, use it for renaming
     if 'indicator' in kwargs and isinstance(kwargs['indicator'], dict):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
 
 EXTRA_REQUIREMENTS = {
     'tests': ['coverage', 'coveralls', 'pytest', 'pytest-cov', 'pytest-mpl'],
-    'optional-io-formats': ['datapackage'],
+    'optional-io-formats': ['datapackage', 'pandas-datareader'],
     'deploy': ['twine', 'setuptools', 'wheel'],
     'tutorials': ['pypandoc', 'nbformat', 'nbconvert', 'jupyter_client',
                   'ipykernel'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from pyam import IamDataFrame, META_IDX, IAMC_IDX, iiasa
 try:
     iiasa.Connection()
     IIASA_UNAVAILABLE = False
-except ConnectionError:
+except ConnectionError:  # pragma: no cover
     IIASA_UNAVAILABLE = True
 
 TEST_API = 'integration-test'

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -3,8 +3,8 @@ import pytest
 import pandas as pd
 
 from pyam import IamDataFrame, IAMC_IDX, read_worldbank
-from pyam import wb
 from pyam.testing import assert_iamframe_equal
+from pandas_datareader import wb
 
 try:
     wb.get_indicators()

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -15,7 +15,7 @@ except ConnectionError:
 WB_REASON = 'World Bank API unavailable'
 
 WB_DF = pd.DataFrame([
-    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39473.4,	40637.4, 42266.5],
+    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39473.4, 40637.4, 42266.5],
     ['foo', 'WDI', 'Mexico', 'GDP', 'n/a', 17231.7, 17661.6, 17815.2],
     ['foo', 'WDI', 'United States', 'GDP', 'n/a', 51643.7, 53111.8, 54473.4]
 ], columns=IAMC_IDX + [2003, 2004, 2005])

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -1,0 +1,28 @@
+from requests.exceptions import ConnectionError
+import pytest
+import pandas as pd
+
+from pyam import IamDataFrame, IAMC_IDX, read_worldbank
+from pyam import wb
+from pyam.testing import assert_iamframe_equal
+
+try:
+    wb.get_indicators()
+    WB_UNAVAILABLE = False
+except ConnectionError:
+    WB_UNAVAILABLE = True
+
+WB_REASON = 'World Bank API unavailable'
+
+WB_DF = pd.DataFrame([
+    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39473.4,	40637.4, 42266.5],
+    ['foo', 'WDI', 'Mexico', 'GDP', 'n/a', 17231.7, 17661.6, 17815.2],
+    ['foo', 'WDI', 'United States', 'GDP', 'n/a', 51643.7, 53111.8, 54473.4]
+], columns=IAMC_IDX + [2003, 2004, 2005])
+
+
+@pytest.mark.skipif(WB_UNAVAILABLE, reason=WB_REASON)
+def test_worldbank():
+    obs = read_worldbank(model='foo', indicator={'NY.GDP.PCAP.PP.KD': 'GDP'})
+    exp = IamDataFrame(WB_DF)
+    assert_iamframe_equal(obs, exp)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added
# Description of PR

Based on initial work by @maartenbrinkerink, this PR adds a `read_worldbank` function to retrieve data directly from the World Bank Open Data Catalogue and cast the returned timeseries as `IamDataFrame`. This initial implementation does not add the units (which would need to retrieve additional information via `wb.get_indicators()` and then merge it into the timeseries dataframe), instead adding `n/a` as unit. This could be added as a future improvement.
