### PR TITLE
Add an `info()` function and use in `print(IamDataFrame)`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ via getter and setter functions.
 
 ## Individual updates
 
+- [#427](https://github.com/IAMconsortium/pyam/pull/427) Add an `info()` function and use in `print(IamDataFrame)`
 - [#424](https://github.com/IAMconsortium/pyam/pull/424) Add a tutorial reading results from a GAMS model (via a gdx file).
 - [#420](https://github.com/IAMconsortium/pyam/pull/420) Add a `_data` object (implemented as a pandas.Series) to handle timeseries data internally.
 - [#418](https://github.com/IAMconsortium/pyam/pull/418) Read data from World Bank Open Data Catalogue as IamDataFrame.

--- a/doc/source/tutorials/pyam_first_steps.ipynb
+++ b/doc/source/tutorials/pyam_first_steps.ipynb
@@ -121,7 +121,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a first step, we show lists of all models, scenarios, regions, and the variables (including units) in the snapshot."
+    "As a first step, we show an overview of the `IamDataFrame` content by simply calling `df` (alternatively, you can use `print(df)` or [df.info()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.info)).\n",
+    "\n",
+    "This function returns a concise (abbreviated) overview of the index dimensions and the qualitative/quantitative meta indicators (see an explanation of indicators below)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following cells, we display the lists of all models, scenarios, regions, and the variables (including units) in the snapshot."
    ]
   },
   {

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -1,3 +1,5 @@
+import logging  # noqa: F401
+
 from pyam.core import *
 from pyam.utils import *
 from pyam.statistics import *

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -182,13 +182,13 @@ class IamDataFrame(object):
     def __repr__(self):
         return self.info()
 
-    def info(self, n=5):
+    def info(self, n=80):
         """Print a summary of the object index dimensions and meta indicators
 
         Parameters
         ----------
         n : int
-            The number of index dimension levels and meta indicators to display
+            The maximum line length
         """
         # concatenate list of index dimensions and levels
         repr = f'{type(self)}\nIndex dimensions:\n'

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -44,6 +44,7 @@ from pyam.utils import (
     datetime_match,
     isstr,
     islistable,
+    print_list,
     META_IDX,
     YEAR_IDX,
     IAMC_IDX,
@@ -177,6 +178,39 @@ class IamDataFrame(object):
 
     def __len__(self):
         return self.data.__len__()
+
+    def __repr__(self):
+        return self.info()
+
+    def info(self, n=5):
+        """Print a summary of the object index dimensions and meta indicators
+
+        Parameters
+        ----------
+        n : int
+            The number of index dimension levels and meta indicators to display
+        """
+        # concatenate list of index dimensions and levels
+        repr = f'{type(self)}\nIndex dimensions:\n'
+        _len = max([len(i) for i in self._LONG_IDX]) + 1
+        repr += '\n'.join(
+            [f' * {i:{_len}}: {print_list(get_index_levels(self._data, i))}'
+             for i in self._LONG_IDX])
+
+        # concatenate list of meta indicators and levels/values
+        repr += '\nMeta indicators:\n'
+        _len = max([len(i) for i in self.meta.columns[0:n]])
+        repr += '\n'.join(
+            [f' * {m:{_len}} ({t}): {print_list(self.meta[m].unique())}'
+             for m, t in zip(self.meta.columns[0:n], self.meta.dtypes[0:n])])
+        if len(self.meta.columns) > n:  # print `...` if more than n columns
+            repr += f'\n * ...'
+
+        # add info on size
+        size = self._data.memory_usage() + sum(self.meta.memory_usage())
+        repr += f'\nMemory usage: {size} bytes'
+
+        return repr
 
     def _execute_run_control(self):
         for module_block in run_control()['exec']:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -182,7 +182,7 @@ class IamDataFrame(object):
     def __repr__(self):
         return self.info()
 
-    def info(self, n=80, meta_rows=5):
+    def info(self, n=80, meta_rows=5, memory_usage=False):
         """Print a summary of the object index dimensions and meta indicators
 
         Parameters
@@ -212,9 +212,10 @@ class IamDataFrame(object):
         if len(self.meta.columns) > meta_rows:
             info += f'\n * ...'
 
-        # add info on size
-        size = self._data.memory_usage() + sum(self.meta.memory_usage())
-        info += f'\nMemory usage: {size} bytes'
+        # add info on size (optional)
+        if memory_usage:
+            size = self._data.memory_usage() + sum(self.meta.memory_usage())
+            info += f'\nMemory usage: {size} bytes'
 
         return info
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -200,16 +200,16 @@ class IamDataFrame(object):
             [f' * {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
              for i in self._LONG_IDX])
 
-        # concatenate list of meta indicators and levels/values
+        # concatenate list of (head of) meta indicators and levels/values
         info += '\nMeta indicators:\n'
         info += '\n'.join(
-            [f'   {m} ({t}) ' +
-             print_list(self.meta[m].unique(), n - len(m) - len(t) - 7)
+            [f'   {m} ({t}) '
+             + print_list(self.meta[m].unique(), n - len(m) - len(t) - 7)
              for m, t in zip(self.meta.columns[0:meta_rows],
                              self.meta.dtypes[0:meta_rows])])
         # print `...` if more than `meta_rows` columns
         if len(self.meta.columns) > meta_rows:
-            info += f'\n * ...'
+            info += '\n * ...'
 
         # add info on size (optional)
         if memory_usage:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -201,10 +201,13 @@ class IamDataFrame(object):
              for i in self._LONG_IDX])
 
         # concatenate list of (head of) meta indicators and levels/values
+        def print_meta_row(m, t, lst):
+            _lst = print_list(lst, n - len(m) - len(t) - 7)
+            return f'   {m} ({t}) {_lst}'
+
         info += '\nMeta indicators:\n'
         info += '\n'.join(
-            [f'   {m} ({t}) '
-             + print_list(self.meta[m].unique(), n - len(m) - len(t) - 7)
+            [print_meta_row(m, t, self.meta[m].unique())
              for m, t in zip(self.meta.columns[0:meta_rows],
                              self.meta.dtypes[0:meta_rows])])
         # print `...` if more than `meta_rows` columns

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -182,35 +182,41 @@ class IamDataFrame(object):
     def __repr__(self):
         return self.info()
 
-    def info(self, n=80):
+    def info(self, n=80, meta_rows=5):
         """Print a summary of the object index dimensions and meta indicators
 
         Parameters
         ----------
         n : int
             The maximum line length
+        meta_rows : int
+            The maximum number of meta indicators printed
         """
         # concatenate list of index dimensions and levels
-        repr = f'{type(self)}\nIndex dimensions:\n'
-        _len = max([len(i) for i in self._LONG_IDX]) + 1
-        repr += '\n'.join(
-            [f' * {i:{_len}}: {print_list(get_index_levels(self._data, i))}'
+        info = f'{type(self)}\nIndex dimensions:\n'
+        c1 = max([len(i) for i in self._LONG_IDX]) + 1
+        c2 = n - c1 - 5
+        info += '\n'.join(
+            [f' * {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
              for i in self._LONG_IDX])
 
         # concatenate list of meta indicators and levels/values
-        repr += '\nMeta indicators:\n'
-        _len = max([len(i) for i in self.meta.columns[0:n]])
-        repr += '\n'.join(
-            [f' * {m:{_len}} ({t}): {print_list(self.meta[m].unique())}'
-             for m, t in zip(self.meta.columns[0:n], self.meta.dtypes[0:n])])
-        if len(self.meta.columns) > n:  # print `...` if more than n columns
-            repr += f'\n * ...'
+        info += '\nMeta indicators:\n'
+        c1 = max([len(i) for i in self.meta.columns[0:meta_rows]])
+        c2 = n - c1 - 8
+        info += '\n'.join(
+            [f' * {m:{c1}} ({t}): {print_list(self.meta[m].unique(), c2)}'
+             for m, t in zip(self.meta.columns[0:meta_rows],
+                             self.meta.dtypes[0:meta_rows])])
+        # print `...` if more than `meta_rows` columns
+        if len(self.meta.columns) > meta_rows:
+            info += f'\n * ...'
 
         # add info on size
         size = self._data.memory_usage() + sum(self.meta.memory_usage())
-        repr += f'\nMemory usage: {size} bytes'
+        info += f'\nMemory usage: {size} bytes'
 
-        return repr
+        return info
 
     def _execute_run_control(self):
         for module_block in run_control()['exec']:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -202,10 +202,9 @@ class IamDataFrame(object):
 
         # concatenate list of meta indicators and levels/values
         info += '\nMeta indicators:\n'
-        c1 = max([len(i) for i in self.meta.columns[0:meta_rows]])
-        c2 = n - c1 - 8
         info += '\n'.join(
-            [f' * {m:{c1}} ({t}): {print_list(self.meta[m].unique(), c2)}'
+            [f'   {m} ({t}) ' +
+             print_list(self.meta[m].unique(), n - len(m) - len(t) - 7)
              for m, t in zip(self.meta.columns[0:meta_rows],
                              self.meta.dtypes[0:meta_rows])])
         # print `...` if more than `meta_rows` columns

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -505,6 +505,14 @@ def datetime_match(data, dts):
     return data.isin(dts)
 
 
+def print_list(x, n=5):
+    """Return a (shortened) printable string of a list"""
+    if len(x) < n + 2:
+        return ', '.join(map(str, x))
+    else:
+        return ', '.join(map(str, x[0:n - 1])) + ', ..., ' + str(x[-1])
+
+
 def to_int(x, index=False):
     """Formatting series or timeseries columns to int and checking validity
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -505,12 +505,44 @@ def datetime_match(data, dts):
     return data.isin(dts)
 
 
-def print_list(x, n=5):
-    """Return a (shortened) printable string of a list"""
-    if len(x) < n + 2:
-        return ', '.join(map(str, x))
+def print_list(x, n):
+    """Return a printable string of a list shortened to n characters"""
+    # subtract count added at end from line width
+    x = list(map(str, x))
+
+    # write number of elements
+    count = f' ({len(x)})'
+    n -= len(count)
+
+    # if not enough space to write first item, write shortest sensible line
+    if len(x[0]) > n - 5:
+        return '...' + count
+
+    # if only one item in list
+    if len(x) == 1:
+        return f'{x[0]} (1)'
+
+    # add first item
+    lst = f'{x[0]}, '
+    n -= len(lst)
+
+    # if possible, add last item before number of elements
+    if len(x[-1]) + 4 > n:
+        return lst + '...' + count
     else:
-        return ', '.join(map(str, x[0:n - 1])) + ', ..., ' + str(x[-1])
+        count = f'{x[-1]}{count}'
+        n -= len({x[-1]}) + 3
+
+    # iterate over remaining entries until line is full
+    for i in x[1:-1]:
+        if len(i) + 6 <= n:
+            lst += f'{i}, '
+            n -= len(i) + 2
+        else:
+            lst += '... '
+            break
+
+    return lst + count
 
 
 def to_int(x, index=False):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -131,12 +131,13 @@ def test_print(test_df_year):
         ' * unit     : EJ/yr (1)',
         ' * year     : 2005, 2010 (2)',
         'Meta indicators:',
-        ' * exclude (bool): False (1)',
-        ' * number  (int64): 1, 2 (2)',
-        ' * string  (object): foo, nan (2)',
-        'Memory usage: '])
+        '   exclude (bool) False (1)',
+        '   number (int64) 1, 2 (2)',
+        '   string (object) foo, nan (2)'])
     obs = test_df_year.info()
-    assert obs.startswith(exp) and obs.endswith('bytes')
+
+    print(obs)
+    assert obs == exp
 
 
 def test_as_pandas(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,16 +124,16 @@ def test_print(test_df_year):
     exp = '\n'.join([
         "<class 'pyam.core.IamDataFrame'>",
         'Index dimensions:',
-        ' * model    : model_a',
-        ' * scenario : scen_a, scen_b',
-        ' * region   : World',
-        ' * variable : Primary Energy, Primary Energy|Coal',
-        ' * unit     : EJ/yr',
-        ' * year     : 2005, 2010',
+        ' * model    : model_a (1)',
+        ' * scenario : scen_a, scen_b (2)',
+        ' * region   : World (1)',
+        ' * variable : Primary Energy, Primary Energy|Coal (2)',
+        ' * unit     : EJ/yr (1)',
+        ' * year     : 2005, 2010 (2)',
         'Meta indicators:',
-        ' * exclude (bool): False',
-        ' * number  (int64): 1, 2',
-        ' * string  (object): foo, nan',
+        ' * exclude (bool): False (1)',
+        ' * number  (int64): 1, 2 (2)',
+        ' * string  (object): foo, nan (2)',
         'Memory usage: '])
     obs = test_df_year.info()
     assert obs.startswith(exp) and obs.endswith('bytes')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -119,6 +119,26 @@ def test_init_empty_message(test_pd_df, caplog):
     assert caplog.records[message_idx].levelno == logging.WARNING
 
 
+def test_print(test_df_year):
+    """Assert that `print(IamDataFrame)` (and `info()`) returns as expected"""
+    exp = '\n'.join([
+        "<class 'pyam.core.IamDataFrame'>",
+        'Index dimensions:',
+        ' * model    : model_a',
+        ' * scenario : scen_a, scen_b',
+        ' * region   : World',
+        ' * variable : Primary Energy, Primary Energy|Coal',
+        ' * unit     : EJ/yr',
+        ' * year     : 2005, 2010',
+        'Meta indicators:',
+        ' * exclude (bool): False',
+        ' * number  (int64): 1, 2',
+        ' * string  (object): foo, nan',
+        'Memory usage: '])
+    obs = test_df_year.info()
+    assert obs.startswith(exp) and obs.endswith('bytes')
+
+
 def test_as_pandas(test_df):
     # test that `as_pandas()` returns the right columns
     df = test_df.copy()


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds an `info()` function similar to the pandas equivalent ([read the docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.info.html)) and when calling `print()` on an xarray object, which is the also used in `print(df)` (via `__repr__`).

The output in the first-steps tutorial is:
```
<class 'pyam.core.IamDataFrame'>
Index dimensions:
 * model    : AIM/CGE 2.1, GENeSYS-MOD 1.0, ... WITCH-GLOBIOM 4.4 (8)
 * scenario : 1.0, CD-LINKS_INDCi, CD-LINKS_NPi, ... Faster Transition Scenario (8)
 * region   : R5ASIA, R5LAM, R5MAF, R5OECD90+EU, R5REF, R5ROWO, World (7)
 * variable : ... (6)
 * unit     : EJ/yr, Mt CO2/yr, °C (3)
 * year     : 2010, 2020, 2030, 2040, 2050, 2060, 2070, 2080, ... 2100 (10)
Meta indicators:
   exclude (bool) False (1)
```
