### PR TITLE
Fix return type of validation after data refactoring

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@ via getter and setter functions.
 
 ## Individual updates
 
-- [#429](https://github.com/IAMconsortium/pyam/pull/429) Fix return type of `valiedate()` after data refactoring
+- [#429](https://github.com/IAMconsortium/pyam/pull/429) Fix return type of `validate()` after data refactoring
 - [#427](https://github.com/IAMconsortium/pyam/pull/427) Add an `info()` function and use in `print(IamDataFrame)`
 - [#424](https://github.com/IAMconsortium/pyam/pull/424) Add a tutorial reading results from a GAMS model (via a gdx file).
 - [#420](https://github.com/IAMconsortium/pyam/pull/420) Add a `_data` object (implemented as a pandas.Series) to handle timeseries data internally.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ via getter and setter functions.
 
 ## Individual updates
 
+- [#429](https://github.com/IAMconsortium/pyam/pull/429) Fix return type of `valiedate()` after data refactoring
 - [#427](https://github.com/IAMconsortium/pyam/pull/427) Add an `info()` function and use in `print(IamDataFrame)`
 - [#424](https://github.com/IAMconsortium/pyam/pull/424) Add a tutorial reading results from a GAMS model (via a gdx file).
 - [#420](https://github.com/IAMconsortium/pyam/pull/420) Add a `_data` object (implemented as a pandas.Series) to handle timeseries data internally.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -723,6 +723,13 @@ class IamDataFrame(object):
             ('up' and 'lo' for respective bounds, 'year' for years)
         exclude_on_fail : bool, optional
             flag scenarios failing validation as `exclude: True`
+
+        Returns
+        -------
+        :class:`pandas.DataFrame`
+            All data points that do not satisfy the criteria.
+        None
+            If all scenarios satisfy the criteria.
         """
         df = _apply_criteria(self._data, criteria, in_range=False)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -732,7 +732,7 @@ class IamDataFrame(object):
 
             if exclude_on_fail and len(df) > 0:
                 self._exclude_on_fail(df)
-            return df
+            return df.reset_index()
 
     def rename(self, mapping=None, inplace=False, append=False,
                check_duplicates=True, **kwargs):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,13 +7,11 @@ import numpy as np
 import pandas as pd
 from numpy import testing as npt
 
-from pyam import IamDataFrame, validate, categorize, \
-    require_variable, filter_by_meta, META_IDX, IAMC_IDX, sort_data, compare
+from pyam import IamDataFrame, filter_by_meta, META_IDX, IAMC_IDX, sort_data,\
+    compare
 from pyam.core import _meta_idx, concat
 from pyam.utils import isstr
 from pyam.testing import assert_iamframe_equal
-
-from conftest import TEST_DTS
 
 
 df_filter_by_meta_matching_idx = pd.DataFrame([
@@ -564,169 +562,6 @@ def test_filter_meta_index(test_df):
 def test_meta_idx(test_df):
     # assert that the `drop_duplicates()` in `_meta_idx()` returns right length
     assert len(_meta_idx(test_df.data)) == 2
-
-
-def test_require_variable(test_df):
-    obs = test_df.require_variable(variable='Primary Energy|Coal',
-                                   exclude_on_fail=True)
-    assert len(obs) == 1
-    assert obs.loc[0, 'scenario'] == 'scen_b'
-
-    assert list(test_df['exclude']) == [False, True]
-
-
-def test_require_variable_top_level(test_df):
-    obs = require_variable(test_df, variable='Primary Energy|Coal',
-                           exclude_on_fail=True)
-    assert len(obs) == 1
-    assert obs.loc[0, 'scenario'] == 'scen_b'
-
-    assert list(test_df['exclude']) == [False, True]
-
-
-def test_require_variable_year_list(test_df):
-    years = [2005, 2010]
-
-    # checking for variables that have ANY of the years in the list
-    df = IamDataFrame(test_df.data[1:])
-    df.require_variable(variable='Primary Energy',
-                        year=years,
-                        exclude_on_fail=True)
-    df.filter(exclude=False, inplace=True)
-
-    assert len(df.variables()) == 2
-    assert len(df.scenarios()) == 2
-
-    # checking for variables that have ALL of the years in the list
-    df = IamDataFrame(test_df.data[1:])
-    for y in years:
-        df.require_variable(variable='Primary Energy',
-                            year=y,
-                            exclude_on_fail=True)
-    df.filter(exclude=False, inplace=True)
-
-    assert len(df.variables()) == 1
-    assert len(df.scenarios()) == 1
-
-
-def test_validate_all_pass(test_df):
-    obs = test_df.validate(
-        {'Primary Energy': {'up': 10}}, exclude_on_fail=True)
-    assert obs is None
-    assert len(test_df.data) == 6  # data unchanged
-
-    assert list(test_df['exclude']) == [False, False]  # none excluded
-
-
-def test_validate_nonexisting(test_df):
-    obs = test_df.validate({'Primary Energy|Coal': {'up': 2}},
-                           exclude_on_fail=True)
-    assert len(obs) == 1
-    assert obs.index.get_level_values('scenario').values[0] == 'scen_a'
-
-    assert list(test_df['exclude']) == [True, False]  # scenario with failed
-    # validation excluded, scenario with non-defined value passes validation
-
-
-def test_validate_up(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 6.5}},
-                           exclude_on_fail=False)
-    assert len(obs) == 1
-    if 'year' in test_df.data:
-        assert obs.index.get_level_values('year').values[0] == 2010
-    else:
-        exp_time = pd.to_datetime(datetime.datetime(2010, 7, 21))
-        assert pd.to_datetime(obs.index.get_level_values('time')
-                              .values[0]).date() == exp_time
-
-    assert list(test_df['exclude']) == [False, False]  # assert none excluded
-
-
-def test_validate_lo(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 8, 'lo': 2.0}})
-    assert len(obs) == 1
-    if 'year' in test_df.data:
-        assert obs.index.get_level_values('year').values[0] == 2005
-    else:
-        exp_year = pd.to_datetime(datetime.datetime(2005, 6, 17))
-        assert pd.to_datetime(obs.index.get_level_values('time')
-                              .values[0]).date() == exp_year
-
-    assert list(obs.index.get_level_values('scenario').values) == ['scen_a']
-
-
-def test_validate_both(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 6.5, 'lo': 2.0}})
-    assert len(obs) == 2
-    if 'year' in test_df.data:
-        assert list(obs.index.get_level_values('year').values) == [2005, 2010]
-    else:
-        exp_time = pd.to_datetime(TEST_DTS)
-        obs.index.set_levels(obs.index.get_level_values('time')
-                                .normalize(), level=5)
-        assert (pd.to_datetime(obs.index.get_level_values('time').values)
-                .date == exp_time).all()
-
-    exp = ['scen_a', 'scen_b']
-    assert list(obs.index.get_level_values('scenario').values) == exp
-
-
-def test_validate_year(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 5.0, 'year': 2005}},
-                           exclude_on_fail=False)
-    assert obs is None
-
-    obs = test_df.validate({'Primary Energy': {'up': 5.0, 'year': 2010}},
-                           exclude_on_fail=False)
-    assert len(obs) == 2
-
-
-def test_validate_exclude(test_df):
-    test_df.validate({'Primary Energy': {'up': 6.0}}, exclude_on_fail=True)
-    assert list(test_df['exclude']) == [False, True]
-
-
-def test_validate_top_level(test_df):
-    obs = validate(test_df, criteria={'Primary Energy': {'up': 6.0}},
-                   exclude_on_fail=True, variable='Primary Energy')
-    assert len(obs) == 1
-    if 'year' in test_df._data.index.names:
-        assert obs.index.get_level_values('year').values[0] == 2010
-    else:
-        exp_time = datetime.datetime(2010, 7, 21).date()
-        obs_time = obs.index.get_level_values('time')[0].date()
-        assert exp_time == obs_time
-    assert list(test_df['exclude']) == [False, True]
-
-
-def test_category_none(test_df):
-    test_df.categorize('category', 'Testing', {'Primary Energy': {'up': 0.8}})
-    assert 'category' not in test_df.meta.columns
-
-
-def test_category_pass(test_df):
-    dct = {'model': ['model_a', 'model_a'],
-           'scenario': ['scen_a', 'scen_b'],
-           'category': ['foo', None]}
-    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])['category']
-
-    test_df.categorize('category', 'foo', {'Primary Energy':
-                                           {'up': 6, 'year': 2010}})
-    obs = test_df['category']
-    pd.testing.assert_series_equal(obs, exp)
-
-
-def test_category_top_level(test_df):
-    dct = {'model': ['model_a', 'model_a'],
-           'scenario': ['scen_a', 'scen_b'],
-           'category': ['foo', None]}
-    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])['category']
-
-    categorize(test_df, 'category', 'foo',
-               criteria={'Primary Energy': {'up': 6, 'year': 2010}},
-               variable='Primary Energy')
-    obs = test_df['category']
-    pd.testing.assert_series_equal(obs, exp)
 
 
 def test_interpolate(test_pd_df):

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -1,8 +1,6 @@
-from datetime import datetime
 import pandas as pd
 import pandas.testing as pdt
 from pyam import IamDataFrame, validate, categorize, require_variable, META_IDX
-from conftest import TEST_DTS
 
 
 def test_require_variable_pass(test_df):

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -58,93 +58,83 @@ def test_require_variable_year_list(test_df):
     pdt.assert_frame_equal(obs, exp)
 
 
-def test_validate_all_pass(test_df):
-    obs = test_df.validate(
-        {'Primary Energy': {'up': 10}}, exclude_on_fail=True)
+def test_validate_pass(test_df):
+    obs = test_df.validate({'Primary Energy': {'up': 10}},
+                           exclude_on_fail=True)
     assert obs is None
-    assert len(test_df.data) == 6  # data unchanged
-
     assert list(test_df['exclude']) == [False, False]  # none excluded
 
 
 def test_validate_nonexisting(test_df):
+    # checking that a scenario with no relevant value does not fail validation
     obs = test_df.validate({'Primary Energy|Coal': {'up': 2}},
                            exclude_on_fail=True)
-    assert len(obs) == 1
-    assert obs.index.get_level_values('scenario').values[0] == 'scen_a'
-
-    assert list(test_df['exclude']) == [True, False]  # scenario with failed
-    # validation excluded, scenario with non-defined value passes validation
+    # checking that the return-type is correct
+    pdt.assert_frame_equal(obs, test_df.data[3:4].reset_index(drop=True))
+    # scenario with failed validation excluded, scenario with no value passes
+    assert list(test_df['exclude']) == [True, False]
 
 
 def test_validate_up(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 6.5}},
-                           exclude_on_fail=False)
-    assert len(obs) == 1
-    if 'year' in test_df.data:
-        assert obs.index.get_level_values('year').values[0] == 2010
-    else:
-        exp_time = pd.to_datetime(datetime(2010, 7, 21))
-        assert pd.to_datetime(obs.index.get_level_values('time')
-                              .values[0]).date() == exp_time
+    # checking that the return-type is correct
+    obs = test_df.validate({'Primary Energy': {'up': 6.5}})
+    pdt.assert_frame_equal(obs, test_df.data[5:6].reset_index(drop=True))
+    assert list(test_df['exclude']) == [False, False]
 
-    assert list(test_df['exclude']) == [False, False]  # assert none excluded
+    # checking exclude on fail
+    obs = test_df.validate({'Primary Energy': {'up': 6.5}},
+                           exclude_on_fail=True)
+    pdt.assert_frame_equal(obs, test_df.data[5:6].reset_index(drop=True))
+    assert list(test_df['exclude']) == [False, True]
 
 
 def test_validate_lo(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 8, 'lo': 2.0}})
-    assert len(obs) == 1
-    if 'year' in test_df.data:
-        assert obs.index.get_level_values('year').values[0] == 2005
-    else:
-        exp_year = pd.to_datetime(datetime(2005, 6, 17))
-        assert pd.to_datetime(obs.index.get_level_values('time')
-                              .values[0]).date() == exp_year
+    # checking that the return-type is correct
+    obs = test_df.validate({'Primary Energy': {'up': 8, 'lo': 2}})
+    pdt.assert_frame_equal(obs, test_df.data[0:1].reset_index(drop=True))
+    assert list(test_df['exclude']) == [False, False]
 
-    assert list(obs.index.get_level_values('scenario').values) == ['scen_a']
+    # checking exclude on fail
+    obs = test_df.validate({'Primary Energy': {'up': 8, 'lo': 2}},
+                           exclude_on_fail=True)
+    pdt.assert_frame_equal(obs, test_df.data[0:1].reset_index(drop=True))
+    assert list(test_df['exclude']) == [True, False]
 
 
 def test_validate_both(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 6.5, 'lo': 2.0}})
-    assert len(obs) == 2
-    if 'year' in test_df.data:
-        assert list(obs.index.get_level_values('year').values) == [2005, 2010]
-    else:
-        exp_time = pd.to_datetime(TEST_DTS)
-        obs.index.set_levels(obs.index.get_level_values('time')
-                                .normalize(), level=5)
-        assert (pd.to_datetime(obs.index.get_level_values('time').values)
-                .date == exp_time).all()
+    # checking that the return-type is correct
+    obs = test_df.validate({'Primary Energy': {'up': 6.5, 'lo': 2}})
+    pdt.assert_frame_equal(obs, test_df.data[0:6:5].reset_index(drop=True))
+    assert list(test_df['exclude']) == [False, False]
 
-    exp = ['scen_a', 'scen_b']
-    assert list(obs.index.get_level_values('scenario').values) == exp
+    # checking exclude on fail
+    obs = test_df.validate({'Primary Energy': {'up': 6.5, 'lo': 2}},
+                           exclude_on_fail=True)
+    pdt.assert_frame_equal(obs, test_df.data[0:6:5].reset_index(drop=True))
+    assert list(test_df['exclude']) == [True, True]
 
 
 def test_validate_year(test_df):
-    obs = test_df.validate({'Primary Energy': {'up': 5.0, 'year': 2005}},
-                           exclude_on_fail=False)
+    # checking that the year filter works as expected
+    obs = test_df.validate({'Primary Energy': {'up': 6, 'year': 2005}})
     assert obs is None
 
-    obs = test_df.validate({'Primary Energy': {'up': 5.0, 'year': 2010}},
-                           exclude_on_fail=False)
-    assert len(obs) == 2
+    # checking that the return-type is correct
+    obs = test_df.validate({'Primary Energy': {'up': 6, 'year': 2010}})
+    pdt.assert_frame_equal(obs, test_df.data[5:6].reset_index(drop=True))
+    assert list(test_df['exclude']) == [False, False]
 
-
-def test_validate_exclude(test_df):
-    test_df.validate({'Primary Energy': {'up': 6.0}}, exclude_on_fail=True)
+    # checking exclude on fail
+    obs = test_df.validate({'Primary Energy': {'up': 6, 'year': 2010}},
+                           exclude_on_fail=True)
+    pdt.assert_frame_equal(obs, test_df.data[5:6].reset_index(drop=True))
     assert list(test_df['exclude']) == [False, True]
 
 
 def test_validate_top_level(test_df):
-    obs = validate(test_df, criteria={'Primary Energy': {'up': 6.0}},
+    obs = validate(test_df, criteria={'Primary Energy': {'up': 6}},
                    exclude_on_fail=True, variable='Primary Energy')
-    assert len(obs) == 1
-    if 'year' in test_df._data.index.names:
-        assert obs.index.get_level_values('year').values[0] == 2010
-    else:
-        exp_time = datetime(2010, 7, 21).date()
-        obs_time = obs.index.get_level_values('time')[0].date()
-        assert exp_time == obs_time
+    pdt.assert_frame_equal(obs, test_df.data[5:6].reset_index(drop=True))
     assert list(test_df['exclude']) == [False, True]
 
 

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -1,0 +1,165 @@
+from datetime import datetime
+import pandas as pd
+from pyam import IamDataFrame, validate, categorize, require_variable
+from conftest import TEST_DTS
+
+
+def test_require_variable(test_df):
+    obs = test_df.require_variable(variable='Primary Energy|Coal',
+                                   exclude_on_fail=True)
+    assert len(obs) == 1
+    assert obs.loc[0, 'scenario'] == 'scen_b'
+
+    assert list(test_df['exclude']) == [False, True]
+
+
+def test_require_variable_top_level(test_df):
+    obs = require_variable(test_df, variable='Primary Energy|Coal',
+                           exclude_on_fail=True)
+    assert len(obs) == 1
+    assert obs.loc[0, 'scenario'] == 'scen_b'
+
+    assert list(test_df['exclude']) == [False, True]
+
+
+def test_require_variable_year_list(test_df):
+    years = [2005, 2010]
+
+    # checking for variables that have ANY of the years in the list
+    df = IamDataFrame(test_df.data[1:])
+    df.require_variable(variable='Primary Energy', year=years,
+                        exclude_on_fail=True)
+    df.filter(exclude=False, inplace=True)
+
+    assert len(df.variables()) == 2
+    assert len(df.scenarios()) == 2
+
+    # checking for variables that have ALL of the years in the list
+    df = IamDataFrame(test_df.data[1:])
+    for y in years:
+        df.require_variable(variable='Primary Energy', year=y,
+                            exclude_on_fail=True)
+    df.filter(exclude=False, inplace=True)
+
+    assert len(df.variables()) == 1
+    assert len(df.scenarios()) == 1
+
+
+def test_validate_all_pass(test_df):
+    obs = test_df.validate(
+        {'Primary Energy': {'up': 10}}, exclude_on_fail=True)
+    assert obs is None
+    assert len(test_df.data) == 6  # data unchanged
+
+    assert list(test_df['exclude']) == [False, False]  # none excluded
+
+
+def test_validate_nonexisting(test_df):
+    obs = test_df.validate({'Primary Energy|Coal': {'up': 2}},
+                           exclude_on_fail=True)
+    assert len(obs) == 1
+    assert obs.index.get_level_values('scenario').values[0] == 'scen_a'
+
+    assert list(test_df['exclude']) == [True, False]  # scenario with failed
+    # validation excluded, scenario with non-defined value passes validation
+
+
+def test_validate_up(test_df):
+    obs = test_df.validate({'Primary Energy': {'up': 6.5}},
+                           exclude_on_fail=False)
+    assert len(obs) == 1
+    if 'year' in test_df.data:
+        assert obs.index.get_level_values('year').values[0] == 2010
+    else:
+        exp_time = pd.to_datetime(datetime(2010, 7, 21))
+        assert pd.to_datetime(obs.index.get_level_values('time')
+                              .values[0]).date() == exp_time
+
+    assert list(test_df['exclude']) == [False, False]  # assert none excluded
+
+
+def test_validate_lo(test_df):
+    obs = test_df.validate({'Primary Energy': {'up': 8, 'lo': 2.0}})
+    assert len(obs) == 1
+    if 'year' in test_df.data:
+        assert obs.index.get_level_values('year').values[0] == 2005
+    else:
+        exp_year = pd.to_datetime(datetime(2005, 6, 17))
+        assert pd.to_datetime(obs.index.get_level_values('time')
+                              .values[0]).date() == exp_year
+
+    assert list(obs.index.get_level_values('scenario').values) == ['scen_a']
+
+
+def test_validate_both(test_df):
+    obs = test_df.validate({'Primary Energy': {'up': 6.5, 'lo': 2.0}})
+    assert len(obs) == 2
+    if 'year' in test_df.data:
+        assert list(obs.index.get_level_values('year').values) == [2005, 2010]
+    else:
+        exp_time = pd.to_datetime(TEST_DTS)
+        obs.index.set_levels(obs.index.get_level_values('time')
+                                .normalize(), level=5)
+        assert (pd.to_datetime(obs.index.get_level_values('time').values)
+                .date == exp_time).all()
+
+    exp = ['scen_a', 'scen_b']
+    assert list(obs.index.get_level_values('scenario').values) == exp
+
+
+def test_validate_year(test_df):
+    obs = test_df.validate({'Primary Energy': {'up': 5.0, 'year': 2005}},
+                           exclude_on_fail=False)
+    assert obs is None
+
+    obs = test_df.validate({'Primary Energy': {'up': 5.0, 'year': 2010}},
+                           exclude_on_fail=False)
+    assert len(obs) == 2
+
+
+def test_validate_exclude(test_df):
+    test_df.validate({'Primary Energy': {'up': 6.0}}, exclude_on_fail=True)
+    assert list(test_df['exclude']) == [False, True]
+
+
+def test_validate_top_level(test_df):
+    obs = validate(test_df, criteria={'Primary Energy': {'up': 6.0}},
+                   exclude_on_fail=True, variable='Primary Energy')
+    assert len(obs) == 1
+    if 'year' in test_df._data.index.names:
+        assert obs.index.get_level_values('year').values[0] == 2010
+    else:
+        exp_time = datetime(2010, 7, 21).date()
+        obs_time = obs.index.get_level_values('time')[0].date()
+        assert exp_time == obs_time
+    assert list(test_df['exclude']) == [False, True]
+
+
+def test_category_none(test_df):
+    test_df.categorize('category', 'Testing', {'Primary Energy': {'up': 0.8}})
+    assert 'category' not in test_df.meta.columns
+
+
+def test_category_pass(test_df):
+    dct = {'model': ['model_a', 'model_a'],
+           'scenario': ['scen_a', 'scen_b'],
+           'category': ['foo', None]}
+    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])['category']
+
+    test_df.categorize('category', 'foo', {'Primary Energy':
+                                           {'up': 6, 'year': 2010}})
+    obs = test_df['category']
+    pd.testing.assert_series_equal(obs, exp)
+
+
+def test_category_top_level(test_df):
+    dct = {'model': ['model_a', 'model_a'],
+           'scenario': ['scen_a', 'scen_b'],
+           'category': ['foo', None]}
+    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])['category']
+
+    categorize(test_df, 'category', 'foo',
+               criteria={'Primary Energy': {'up': 6, 'year': 2010}},
+               variable='Primary Energy')
+    obs = test_df['category']
+    pd.testing.assert_series_equal(obs, exp)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR reverts the behavior of the `validate()` function to the status before the refactoring of the data-backend.

 - changes the return type back to a `pandas.DataFrame`
 - moves all validation tests to an own file (ignore the first commit to see only the relevant functional changes)
 - refactors all related tests to explicitly test the return type
 - adds a `Returns` section to the docstring

closes #428 
