### PR TITLE
Bugfix when replacing index values leads to duplicates

### DIFF
--- a/pyam/index.py
+++ b/pyam/index.py
@@ -10,8 +10,8 @@ def replace_index_values(df, level, mapping):
     """Replace one or several category-values at a specific level"""
     index = df.index.copy()
     n = index._get_level_number(level)
-    unused_levels = False
 
+    # replace the levels
     _levels = [mapping[i] if i in mapping else i for i in index.levels[n]]
     _unique_levels = list(set(_levels))
 

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -17,12 +17,12 @@ def replace_index_values(df, level, mapping):
         try:  # replace in index codes if value (target) is in the index levels
             _k = _levels.index(key)
             _v = _levels.index(value)
-            _codes = index.codes[n]
-            index = index.set_codes([_v if c == _k else c for c in _codes], n)
+            index = index.set_codes([_v if c == _k else c
+                                     for c in index.codes[n]], n)
             unused_levels = True
         except ValueError:  # else replace key for value in the levels
-            index = index.set_levels([value if l == key else l
-                                     for l in _levels], n)
+            index = index.set_levels([value if i == key else i
+                                     for i in _levels], n)
     if unused_levels:
         index = index.remove_unused_levels()
     return index

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -16,27 +16,20 @@ def test_get_index_levels_raises(test_df_index):
         get_index_levels(test_df_index, 'foo')
 
 
-def test_replace_index_level(test_pd_df, test_df_index):
+@pytest.mark.parametrize('exp_scen, mapping', [
+    (['scen_c', 'scen_c', 'scen_b'], {'scen_a': 'scen_c'}),
+    (['scen_c', 'scen_c', 'scen_c'], {'scen_a': 'scen_c', 'scen_b': 'scen_c'}),
+    (['scen_b', 'scen_b', 'scen_c'], {'scen_a': 'scen_b', 'scen_b': 'scen_c'})
+    # this test ensures that no transitive replacing occurs
+])
+def test_replace_index_level(test_pd_df, test_df_index, exp_scen, mapping):
     """Assert that replace_index_value works as expected"""
     pd_df = test_pd_df.copy()
-    pd_df['scenario'] = ['scen_c', 'scen_c', 'scen_b']
+    pd_df['scenario'] = exp_scen
     exp = pd_df.set_index(IAMC_IDX)
 
     obs = test_df_index.copy()
-    obs.index = replace_index_values(obs, 'scenario', {'scen_a': 'scen_c'})
-
-    pdt.assert_frame_equal(exp, obs)
-
-
-def test_replace_index_level_to_existing(test_pd_df, test_df_index):
-    """Assert that replace_index_value can rename to existing values (#430)"""
-    pd_df = test_pd_df.copy()
-    pd_df['scenario'] = ['scen_c', 'scen_c', 'scen_c']
-    exp = pd_df.set_index(IAMC_IDX)
-
-    obs = test_df_index.copy()
-    obs.index = replace_index_values(obs, 'scenario',
-                                     {'scen_a': 'scen_c', 'scen_b': 'scen_c'})
+    obs.index = replace_index_values(obs, 'scenario', mapping)
 
     pdt.assert_frame_equal(exp, obs)
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -28,6 +28,19 @@ def test_replace_index_level(test_pd_df, test_df_index):
     pdt.assert_frame_equal(exp, obs)
 
 
+def test_replace_index_level_to_existing(test_pd_df, test_df_index):
+    """Assert that replace_index_value can rename to existing values (#430)"""
+    pd_df = test_pd_df.copy()
+    pd_df['scenario'] = ['scen_c', 'scen_c', 'scen_c']
+    exp = pd_df.set_index(IAMC_IDX)
+
+    obs = test_df_index.copy()
+    obs.index = replace_index_values(obs, 'scenario',
+                                     {'scen_a': 'scen_c', 'scen_b': 'scen_c'})
+
+    pdt.assert_frame_equal(exp, obs)
+
+
 def test_replace_index_level_raises(test_df_index):
     """Assert that replace_index_value raises with non-existing level"""
     with pytest.raises(KeyError):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added

# Description of PR

This fixes the bug reported by @Rlamboll in #430. The replacing does not do transitive renaming within one operation, similar to the behaviour of `pandas.Series.replace()`.

closes #430 