### PR TITLE
Add attributes to access index dimensions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Next release
 
+## API changes
+
+PR [#432](https://github.com/IAMconsortium/pyam/pull/432) added attributes to
+access the list of (unique) items of each index dimension
+(`model`, `scenario`, ...).
+The PR also marked as deprecated the equivalent functions
+(`models()`, `scenarios()`, ...). The new behaviour is closer
+(though still different) to what a pandas user would expect. 
+
 ## Notes
 
 PR [#420](https://github.com/IAMconsortium/pyam/pull/420) added
@@ -13,6 +22,7 @@ via getter and setter functions.
 
 - [#437](https://github.com/IAMconsortium/pyam/pull/437) Improved test for appending mismatched timeseries
 - [#436](https://github.com/IAMconsortium/pyam/pull/436) Raise an error with appending mismatching timeseries index dimensions
+- [#432](https://github.com/IAMconsortium/pyam/pull/432) Add attributes to access index dimensions
 - [#429](https://github.com/IAMconsortium/pyam/pull/429) Fix return type of `validate()` after data refactoring
 - [#427](https://github.com/IAMconsortium/pyam/pull/427) Add an `info()` function and use in `print(IamDataFrame)`
 - [#424](https://github.com/IAMconsortium/pyam/pull/424) Add a tutorial reading results from a GAMS model (via a gdx file).

--- a/doc/source/tutorials/pyam_first_steps.ipynb
+++ b/doc/source/tutorials/pyam_first_steps.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.models()"
+    "df.model"
    ]
   },
   {
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.scenarios()"
+    "df.scenario"
    ]
   },
   {
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.regions()"
+    "df.region"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.filter(model='MESSAGE').scenarios()"
+    "df.filter(model='MESSAGE').scenario"
    ]
   },
   {
@@ -221,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.filter(model='MESSAGE*').scenarios()"
+    "df.filter(model='MESSAGE*').scenario"
    ]
   },
   {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,12 +50,12 @@ def test_init_from_iamdf(test_df_year):
 
     # inplace-operations on the new object have effects on the original object
     df.rename(scenario={'scen_a': 'scen_foo'}, inplace=True)
-    assert all(test_df_year.scenarios().values == ['scen_b', 'scen_foo'])
+    assert test_df_year.scenario == ['scen_b', 'scen_foo']
 
     # overwrites on the new object do not have effects on the original object
     df = df.rename(scenario={'scen_foo': 'scen_bar'})
-    assert all(df.scenarios().values == ['scen_b', 'scen_bar'])
-    assert all(test_df_year.scenarios().values == ['scen_b', 'scen_foo'])
+    assert df.scenario == ['scen_b', 'scen_bar']
+    assert test_df_year.scenario == ['scen_b', 'scen_foo']
 
 
 def test_init_from_iamdf_raises(test_df_year):
@@ -108,7 +108,7 @@ def test_init_df_with_extra_col(test_pd_df):
                                   tdf, check_like=True)
 
 
-def test_init_empty_message(test_pd_df, caplog):
+def test_init_empty_message(caplog):
     IamDataFrame(data=df_empty)
     drop_message = (
         "Formatted data is empty!"
@@ -197,6 +197,25 @@ def test_equals_raises(test_pd_df):
 
 def test_get_item(test_df):
     assert test_df['model'].unique() == ['model_a']
+
+
+def test_index_attributes(test_df):
+    # assert that the
+    assert test_df.model == ['model_a']
+    assert test_df.scenario == ['scen_a', 'scen_b']
+    assert test_df.region == ['World']
+    assert test_df.variable == ['Primary Energy', 'Primary Energy|Coal']
+    assert test_df.unit == ['EJ/yr']
+    if test_df.time_col == 'year':
+        assert test_df.year == [2005, 2010]
+    else:
+        assert test_df.time.equals(pd.Index(test_df.data.time.unique()))
+
+
+def test_index_attributes_extra_col(test_pd_df):
+    test_pd_df['subannual'] = ['summer', 'summer', 'winter']
+    df = IamDataFrame(test_pd_df)
+    assert df.subannual == ['summer', 'winter']
 
 
 def test_model(test_df):
@@ -503,8 +522,8 @@ def test_filter_year_with_time_col(test_pd_df):
 
 
 def test_filter_as_kwarg(test_df):
-    obs = list(test_df.filter(variable='Primary Energy|Coal').scenarios())
-    assert obs == ['scen_a']
+    _df = test_df.filter(variable='Primary Energy|Coal')
+    assert _df.scenario == ['scen_a']
 
 
 def test_filter_keep_false(test_df):

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -66,7 +66,7 @@ def test_append_reconstructed_time(test_df):
         .rename({'scenario': {'scen_b': 'scen_c'}})
     other.time_col = other.time_col[0:1] + other.time_col[1:]
     test_df.append(other, inplace=True)
-    assert "scen_c" in test_df.scenarios().values
+    assert "scen_c" in test_df.scenario
 
 
 def test_append_same_scenario(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Per [this comment](https://github.com/danielhuppmann/pyam/pull/21#issuecomment-671278221) by @Rlamboll that `scenario` would be a more intuitive way to retrieve the list of scenarios compared to `scenarios()`, this PR adds the index dimensions as attributes. This is closer to the behavior that a pandas-user would expect.

Open questions:
 - the return type is a list, but could also be a pandas.Series - any preferences?
   (except for continuous-time, which is a `pandas.DateTimeIndex`)
 - the existing functions (`models()`, `scenarios()`, `regions()`) are marked for deprecation - any objections?
 - the existing function `variables()` can either return a series (only variables) or a dataframe (variables and units) - any preferences whether to keep this as is, or alternative suggestions?
