### PR TITLE
Rewrite the data-model page in the docs

### DIFF
--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,8 +1,8 @@
 Data Model
 ==========
 
-The IAMC timeseries format for scenario data
---------------------------------------------
+Background: The IAMC timeseries scenario data format
+----------------------------------------------------
 
 .. figure:: _static/iamc-logo.png
    :width: 150px
@@ -10,16 +10,18 @@ The IAMC timeseries format for scenario data
 
    `IAMC website`_
 
-.. _`IAMC Website`: http://www.globalchange.umd.edu/iamc/
+.. _`IAMC Website`: http://iamconsortium.org/
 
 Over the past decade, the Integrated Assessment Modeling Consortium (IAMC)
-developed a standardised tabular timeseries format to exchange scenario data.
+developed a standardised tabular timeseries format to exchange scenario data
+related to energy systems modelling, land-use change, demand sectors,
+and economic indicators in the context of the Sustainable Development Goals.
 Previous high-level use cases include reports by the *Intergovernmental Panel
 on Climate Change* (`IPCC`_) and model comparison exercises
 within the *Energy Modeling Forum* (`EMF`_) hosted by Stanford University.
 
 The table below shows a typical example of integrated-assessment scenario data
-following the IAMC format from the `CD-LINKS`_ project.
+following the IAMC format from the Horizon 2020 `CD-LINKS`_ project.
 The |pyam| package is geared for analysis and visualization of any scenario
 data provided in this structure.
 
@@ -30,8 +32,7 @@ data provided in this structure.
 
 .. _`IAMC 1.5°C Scenario Explorer`: https://data.ene.iiasa.ac.at/iamc-1.5c-explorer
 
-Refer to `data.ene.iiasa.ac.at/database`_ for more information on the
-IAMC format and a full list of previous use cases.
+Refer to `data.ene.iiasa.ac.at/database`_ for a list of previous use cases.
 
 .. _`IPCC`: https://www.ipcc.ch
 
@@ -41,105 +42,47 @@ IAMC format and a full list of previous use cases.
 
 .. _`data.ene.iiasa.ac.at/database`: https://data.ene.iiasa.ac.at/database
 
-The :code:`variable` column
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The pyam data model
+-------------------
 
-The 'variable' column implements a "semi-hierarchical" structure
-using the :code:`|` character (*pipe*, not l or i) to indicate the *depth*.
+A :class:`pyam.IamDataFrame` instance is a container for two types of data:
 
-Semi-hierarchical means that a hierarchy can be imposed, e.g., one can enforce
-that the sum of :code:`Emissions|CO2|Energy` and :code:`Emissions|CO2|Other`
-must be equal to :code:`Emissions|CO2`
-(if there are no other :code:`Emissions|CO2|…` variables).
-However, this is not mandatory, e.g., the sum of :code:`Primary Energy|Coal`,
-:code:`Primary Energy|Gas` and :code:`Primary Energy|Fossil` should not be equal
-to :code:`Primary Energy` because this would double-count fossil fuels.
+ - :ref:`data`
+ - :ref:`meta`
 
-Refer to the variable list in the documentation pages of the
-`IAMC 1.5°C Scenario Explorer`_ to see the full list of variables used in the
-recent *IPCC Special Report on Global Warming of 1.5 ºC* (`SR15`_).
+.. _data:
 
-.. _`SR15`: https://www.ipcc.ch/sr15/
+Scenario timeseries data ('data')
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :code:`year` column
-~~~~~~~~~~~~~~~~~~~~~~~
+This attribute holds the timeseries data related to an ensemble of scenarios.
+The data follows the format established by the IAMC shown above.
+It has the following standard columns (i.e., index dimensions, coordinates):
 
-In its original design, the IAMC data format (see above) assumed that the
-temporal dimension of any scenario data was restricted to full years
-represented as integer values.
+- model
+- scenario
+- region
+- variable (more info on variables_)
+- unit
+- year/time (more info on the `temporal domain`_)
 
-Two additional use cases are currently supported by :class:`pyam` in development
-mode (beta):
-
- - using representative sub-annual timesteps via the "extra_cols" feature
-   (see the section on `custom columns`_ in the 'data' table)
-
- - using continuous time via :class:`datetime.datetime`,
-   replacing the 'year' column by a 'time' column
-
-Please reach out to the developers to get more information on this
-ongoing work.
-
-The **IamDataFrame** class
---------------------------
-
-A :class:`pyam.IamDataFrame` instance is a wrapper for
-two :class:`pandas.DataFrame` instances (i.e., tables, see the `pandas docs`_
-for more information).
-
-.. _`pandas docs`: https://pandas.pydata.org/pandas-docs/stable/reference/frame.html
-
-The :code:`data` table
-~~~~~~~~~~~~~~~~~~~~~~
-
-This table contains the timeseries data related to an ensemble of scenarios.
-It is structured in *long format*, where each datapoint is one row. In contrast,
-the standard IAMC-style format is in *wide format* (see the example above),
+When initializing an :class:`IamDataFrame`, the timeseries data can be provided
+in *long format*, where each datapoint is one row in a column named 'value',
+or it can follow the standard IAMC-style *wide format* (see the example above),
 where each timeseries is one row and the timesteps are represented as columns.
 
-While long-format tables have advantages for the internal implementation of many
-|pyam| functions, wide-format tables are more intuitive to users.
-The method :meth:`timeseries() <pyam.IamDataFrame.timeseries>` converts between
-the formats and returns a :class:`pandas.DataFrame` in wide format.
+The attribute :attr:`data <pyam.IamDataFrame.data>` returns the timeseries data
+in long format as a :class:`pandas.DataFrame`, while
+the method :meth:`timeseries() <pyam.IamDataFrame.timeseries>` returns
+an indexed :class:`pandas.DataFrame` in wide format.
 Exporting an :class:`IamDataFrame` to file using
 :meth:`to_excel() <pyam.IamDataFrame.to_excel>` or
 :meth:`to_csv() <pyam.IamDataFrame.to_csv>` also writes the data table
 in wide format.
 
-The standard columns
-^^^^^^^^^^^^^^^^^^^^
+.. note::
 
-The columns of the 'data' table are :code:`['model', 'scenario', 'region',
-'unit', <time_format>, 'value']`, where :code:`time_format` is 'year'
-when timesteps are given in years (as :class:`int`) or 'time' when time
-is represented on a continuous scale (as :class:`datetime.datetime`).
-
-.. _`custom columns`:
-
-Custom columns of the :code:`data` table
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If an :class:`IamDataFrame` is initialised with columns that are not in the
-list above nor interpreted as belonging to the time dimension (in wide format),
-these columns are included in the 'data' table as additional columns
-(:code:`extra_cols`).
-This feature can be used, for example, to distinguish between multiple
-climate models providing different values for the variable
-:code:`Temperature|Global Mean`.
-
-.. warning::
-
-    Not all **pyam** functions currently support the continuous-time format or    
-    custom columns in a 'data' table. Please reach out via the 
-    `mailing list or GitHub issues`_ if you are not sure whether your use case
-    is supported.
-
-.. _`mailing list or GitHub issues`: contributing.html
-
-
-.. warning::
-
-    A word of warning when using custom columns for annotations:
+    When using custom columns for annotations:
     **pyam** drops any data rows where the 'value' column is 'nan',
     and it raises an error for 'nan' in any other column.
     Hence, if you are adding variable/region-specific meta information to
@@ -152,11 +95,84 @@ climate models providing different values for the variable
     Therefore, enforcing that there are no 'nan's in an **IamDataFrame**
     ensures that **pyam** has a clean dataset on which to operate.
 
-The :code:`meta` table
-~~~~~~~~~~~~~~~~~~~~~~
+.. _variables:
 
-This table is intended for categorisation and quantitative indicators at the
-model-scenario level. Examples in the `SR15`_ context are the warming category 
+The 'variable' index
+^^^^^^^^^^^^^^^^^^^^
+
+The 'variable' index describes the type of information represented
+in the specific timeseries.
+The variable implements a "semi-hierarchical" structure
+using the :code:`|` character (*pipe*, not l or i) to indicate the *depth*.
+Variable names (should) follow a structure
+like :code:`Category|Subcategory|Specification`.
+
+Semi-hierarchical means that a hierarchy can be imposed, e.g., one can enforce
+that the sum of :code:`Emissions|CO2|Energy` and :code:`Emissions|CO2|Other`
+must be equal to :code:`Emissions|CO2`
+(if there are no other :code:`Emissions|CO2|…` variables).
+
+However, this is not mandatory, e.g., the sum of :code:`Primary Energy|Coal`,
+:code:`Primary Energy|Gas` and :code:`Primary Energy|Fossil` should not be equal
+to :code:`Primary Energy` because this would double-count fossil fuels.
+
+Refer to the variable list in the documentation pages of the
+`IAMC 1.5°C Scenario Explorer`_ to see the full list of variables used in the
+recent *IPCC Special Report on Global Warming of 1.5 ºC* (`SR15`_).
+
+.. _`SR15`: https://www.ipcc.ch/sr15/
+
+.. _`temporal domain`:
+
+The temporal domain
+^^^^^^^^^^^^^^^^^^^
+
+In its original design, the IAMC data format (see above) assumed that the
+temporal dimension of any scenario data was restricted to full years
+represented as integer values.
+In this case, the time index is named 'year'.
+
+Two additional use cases are currently supported by |pyam|
+in development mode (beta):
+
+- representative sub-annual timesteps via the `custom columns`_ feature
+
+- continuous-time timeseries data by using an index named 'time'
+  populated by :class:`datetime.datetime` instances
+  (replacing the 'year' index)
+
+Please reach out to the developers to get more information on this
+ongoing work.
+
+.. _`custom columns`:
+
+Custom columns of the 'data' table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If an :class:`IamDataFrame` is initialised with columns that are not in the
+list above nor interpreted as belonging to the time dimension (in wide format),
+these columns are included in the 'data' table as additional, custom columns.
+This feature can be used, for example, to distinguish between multiple
+climate models providing different values for the variable
+:code:`Temperature|Global Mean`.
+
+.. warning::
+
+    Not all **pyam** functions currently support the continuous-time format or
+    custom columns in a 'data' table. Please reach out via the 
+    `mailing list or GitHub issues`_ if you are not sure whether your use case
+    is supported.
+
+.. _`mailing list or GitHub issues`: contributing.html
+
+.. _meta:
+
+Quantitative and qualitative indicators of scenarios ('meta')
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This attribute is intended for categorisation and quantitative indicators
+at the model-scenario level.
+Examples in the `SR15`_ context are the warming category
 ('Below 1.5°C', '1.5°C with low overshoot', etc.) and the cumulative
 CO2 emissions until the end of the century.
 
@@ -183,12 +199,12 @@ The |pyam| package provides two methods for filtering scenario data:
 An existing :class:`IamDataFrame` can be filtered using
 :meth:`filter(col=...) <pyam.IamDataFrame.filter>`,
 where :code:`col` can be any column of the 'data' table (i.e.,
-:code:`['model', 'scenario', 'region', 'unit', 'year'/'time']` or any `custom
+'model', 'scenario', 'region', 'unit', 'year'/'time' or any `custom
 columns`_), or a column of the 'meta' table. The returned object is
 a new :class:`IamDataFrame` instance.
 
 A :class:`pandas.DataFrame` ('data') with columns or index
-:code:`['model', 'scenario']` can be filtered by any 'meta' columns from
+['model', 'scenario'] can be filtered by any 'meta' columns from
 an :class:`IamDataFrame` (:code:`df`) using 
 :meth:`pyam.filter_by_meta(data, df, col=..., join_meta=False) <pyam.filter_by_meta>`.
 The returned object is a :class:`pandas.DataFrame` down-selected to those


### PR DESCRIPTION
# Description of PR

This PR rewrites the data-model page in the docs, for a cleaner separation between the concept (what kind of information is in the different attributes) from the implementation (given that it's not two pandas.DataFrames anymore).
