### PR TITLE
Raise an error with appending mismatching timeseries index dimensions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ via getter and setter functions.
 
 ## Individual updates
 
+- [#436](https://github.com/IAMconsortium/pyam/pull/436) Raise an error with appending mismatching timeseries index dimensions
 - [#427](https://github.com/IAMconsortium/pyam/pull/427) Add an `info()` function and use in `print(IamDataFrame)`
 - [#424](https://github.com/IAMconsortium/pyam/pull/424) Add a tutorial reading results from a GAMS model (via a gdx file).
 - [#420](https://github.com/IAMconsortium/pyam/pull/420) Add a `_data` object (implemented as a pandas.Series) to handle timeseries data internally.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -333,14 +333,14 @@ class IamDataFrame(object):
         Parameters
         ----------
         other : IamDataFrame, ixmp.Scenario, pandas.DataFrame or data file
-            any object castable as IamDataFrame to be appended
+            Any object castable as IamDataFrame to be appended
         ignore_meta_conflict : bool, default False
-            if False and `other` is an IamDataFrame, raise an error if
+            If False and `other` is an IamDataFrame, raise an error if
             any meta columns present in `self` and `other` are not identical.
         inplace : bool, default False
-            if True, do operation inplace and return None
+            If True, do operation inplace and return None
         kwargs
-            passed to :class:`IamDataFrame(other, **kwargs) <IamDataFrame>`
+            Passed to :class:`IamDataFrame(other, **kwargs) <IamDataFrame>`
             if `other` is not already an IamDataFrame
 
         Returns
@@ -353,8 +353,7 @@ class IamDataFrame(object):
         Raises
         ------
         ValueError
-            if the time domain or other timeseries data index dimenions
-            do not match
+            If time domain or other timeseries data index dimension don't match
         """
         if not isinstance(other, IamDataFrame):
             other = IamDataFrame(other, **kwargs)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -322,7 +322,6 @@ class IamDataFrame(object):
             .drop_duplicates().sort_values('variable').reset_index(drop=True)
         )
 
-
     def append(self, other, ignore_meta_conflict=False, inplace=False,
                **kwargs):
         """Append any IamDataFrame-like object to this object
@@ -343,13 +342,29 @@ class IamDataFrame(object):
         kwargs
             passed to :class:`IamDataFrame(other, **kwargs) <IamDataFrame>`
             if `other` is not already an IamDataFrame
+
+        Returns
+        -------
+        IamDataFrame
+            If *inplace* is :obj:`False`.
+        None
+            If *inplace* is :obj:`True`.
+
+        Raises
+        ------
+        ValueError
+            if the time domain or other timeseries data index dimenions
+            do not match
         """
         if not isinstance(other, IamDataFrame):
             other = IamDataFrame(other, **kwargs)
             ignore_meta_conflict = True
 
         if self.time_col != other.time_col:
-            raise ValueError('incompatible time format (years vs. datetime)!')
+            raise ValueError('Incompatible time format (`year` vs. `time`)')
+
+        if self._data.index.names != other._data.index.names:
+            raise ValueError('Incompatible timeseries data index dimensions')
 
         ret = self.copy() if not inplace else self
 

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -129,16 +129,18 @@ def test_append_extra_col(test_df, shuffle_cols):
     check_meta_is(res, "col_2", "bye")
 
 
-def test_append_duplicates(test_df_year):
+def test_append_duplicates_raises(test_df_year):
     other = copy.deepcopy(test_df_year)
-    pytest.raises(ValueError, test_df_year.append, other=other)
+    with pytest.raises(ValueError, match='Indexes have overlapping values:'):
+        test_df_year.append(other=other)
 
 
-def test_append_incompatible_col(test_pd_df):
+def test_append_incompatible_col_raises(test_pd_df):
     df = IamDataFrame(test_pd_df)
     test_pd_df['foo'] = 'baz'
     other = IamDataFrame(test_pd_df)
-    pytest.raises(ValueError, df.append, other=other)
+    with pytest.raises(ValueError, match='Incompatible timeseries data index'):
+        df.append(other=other)
 
 
 def test_rename_data_cols_by_dict():

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -130,12 +130,14 @@ def test_append_extra_col(test_df, shuffle_cols):
 
 
 def test_append_duplicates_raises(test_df_year):
+    # Merging objects with overlapping values (merge conflict) raises an error
     other = copy.deepcopy(test_df_year)
     with pytest.raises(ValueError, match='Indexes have overlapping values:'):
         test_df_year.append(other=other)
 
 
 def test_append_incompatible_col_raises(test_pd_df):
+    # Merging objects with different data index dimensions raises an error
     df = IamDataFrame(test_pd_df)
     test_pd_df['foo'] = 'baz'
     other = IamDataFrame(test_pd_df)

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -134,6 +134,13 @@ def test_append_duplicates(test_df_year):
     pytest.raises(ValueError, test_df_year.append, other=other)
 
 
+def test_append_incompatible_col(test_pd_df):
+    df = IamDataFrame(test_pd_df)
+    test_pd_df['foo'] = 'baz'
+    other = IamDataFrame(test_pd_df)
+    pytest.raises(ValueError, df.append, other=other)
+
+
 def test_rename_data_cols_by_dict():
     mapping = dict(variable={'test_1': 'test', 'test_3': 'test'},
                    region={'region_a': 'region_c'})


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR closes #434 by ensuring that an error is raised when trying to append IamDataFrame instances with non-matching timeseries index dimensions.
