### PR TITLE
Add an `index` attribute of model-scenario combinations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ via getter and setter functions.
 
 ## Individual updates
 
+- [#438](https://github.com/IAMconsortium/pyam/pull/438) Add an `index` attribute of model-scenario combinations
 - [#437](https://github.com/IAMconsortium/pyam/pull/437) Improved test for appending mismatched timeseries
 - [#436](https://github.com/IAMconsortium/pyam/pull/436) Raise an error with appending mismatching timeseries index dimensions
 - [#427](https://github.com/IAMconsortium/pyam/pull/427) Add an `info()` function and use in `print(IamDataFrame)`

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -237,6 +237,20 @@ class IamDataFrame(object):
                 f(self)
 
     @property
+    def index(self):
+        """Return all model-scenario combinations as :class:`pandas.MultiIndex`
+
+        The index allows to loop over the available model-scenario combinations
+        using:
+
+        .. code-block:: python
+
+            for model, scenario in df.index:
+                ...
+        """
+        return self.meta.index
+
+    @property
     def data(self):
         """Return the timeseries data as long :class:`pandas.DataFrame`"""
         if self.empty:  # reset_index fails on empty with `datetime` column

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -198,7 +198,13 @@ class IamDataFrame(object):
         c2 = n - c1 - 5
         info += '\n'.join(
             [f' * {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
-             for i in self._LONG_IDX])
+             for i in META_IDX])
+
+        # concatenate list of index of _data (not in META_IDX)
+        info += '\nTimeseries data coordinates:\n'
+        info += '\n'.join(
+            [f'   {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
+             for i in self._LONG_IDX if i not in META_IDX])
 
         # concatenate list of (head of) meta indicators and levels/values
         def print_meta_row(m, t, lst):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -201,6 +201,12 @@ def test_get_item(test_df):
     assert test_df['model'].unique() == ['model_a']
 
 
+def test_index(test_df_year):
+    # assert that the correct index is shown for the IamDataFrame
+    exp = pd.MultiIndex.from_arrays([['model_a'] * 2, ['scen_a', 'scen_b']],
+                                    names=['model', 'scenario'])
+    pd.testing.assert_index_equal(test_df_year.index, exp)
+
 def test_model(test_df):
     exp = pd.Series(data=['model_a'], name='model')
     pd.testing.assert_series_equal(test_df.models(), exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -126,17 +126,16 @@ def test_print(test_df_year):
         'Index dimensions:',
         ' * model    : model_a (1)',
         ' * scenario : scen_a, scen_b (2)',
-        ' * region   : World (1)',
-        ' * variable : Primary Energy, Primary Energy|Coal (2)',
-        ' * unit     : EJ/yr (1)',
-        ' * year     : 2005, 2010 (2)',
+        'Timeseries data coordinates:',
+        '   region   : World (1)',
+        '   variable : Primary Energy, Primary Energy|Coal (2)',
+        '   unit     : EJ/yr (1)',
+        '   year     : 2005, 2010 (2)',
         'Meta indicators:',
         '   exclude (bool) False (1)',
         '   number (int64) 1, 2 (2)',
         '   string (object) foo, nan (2)'])
     obs = test_df_year.info()
-
-    print(obs)
     assert obs == exp
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Per suggestions by @Rlamboll and @znicholls in the discussion related to #432, this PR adds an `index` attribute, where the index dimensions are those common to both the timeseries data and meta dataframes, i.e., `model` and `scenario`.

This allows to easily loop over available models and scenarios, by using
```
for model, scenario in df.index:
    ...
```
This snippet is also shown in the docstring of the new function.

To make the meaning of `index` intuitive for new users of pyam, the `info()` output is changed to the following (inspired by `xarray`):
```
<class 'pyam.core.IamDataFrame'>
Index dimensions:
 * model    : model_a (1)
 * scenario : scen_a, scen_b (2)
Timeseries data coordinates:
   region   : World (1)
   variable : Primary Energy, Primary Energy|Coal (2)
   unit     : EJ/yr (1)
   year     : 2005, 2010 (2)
Meta indicators:
   exclude (bool) False (1)
   number (int64) 1, 2 (2)
   string (object) foo, nan (2)
```
