### PR TITLE
Clean-up of `convert_unit` docstrings and ixmp intersphinx

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -318,19 +318,18 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
+# Intersphinx configuration.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'pint': ('https://pint.readthedocs.io/en/stable', None),
-    'ixmp': ('https://message.iiasa.ac.at/projects/ixmp/en/stable/', None),
+    'ixmp': ('https://docs.messageix.org/projects/ixmp/en/stable/', None),
     'pandas_datareader':
         ('https://pandas-datareader.readthedocs.io/en/stable', None)
 }
 
-# extend the timeout limit for running notebooks
+# Extend the timeout limit for running notebooks
 nbsphinx_timeout = 120
 
 # prolog for all rst files

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -871,7 +871,7 @@ class IamDataFrame(object):
         The default *registry* includes additional unit definitions relevant
         for integrated assessment models and energy systems analysis, via the
         `iam-units <https://github.com/IAMconsortium/units>`_ package.
-        This registry can also be accessed directly, using::
+        This registry can also be accessed directly, using:
 
         .. code-block:: python
 
@@ -898,14 +898,13 @@ class IamDataFrame(object):
             'unit' column.
         factor : value, optional
             Explicit factor for conversion without `pint`.
-        registry : pint.UnitRegistry, optional
+        registry : :class:`pint.UnitRegistry`, optional
             Specific unit registry to use for conversion. Default: the
             `iam-units <https://github.com/IAMconsortium/units>`_ registry.
-        context : str or pint.Context, optional
-            (Name of) a :ref:`pint context <pint:context>` to use in
-            conversion. Required when converting between GHG species using GWP
-            metrics, unless the species indicated by *current* and *to* are the
-            same.
+        context : str or :class:`pint.Context`, optional
+            (Name of) the context to use in conversion.
+            Required when converting between GHG species using GWP metrics,
+            unless the species indicated by *current* and *to* are the same.
         inplace : bool, optional
             Whether to return a new IamDataFrame.
 


### PR DESCRIPTION
# Description of PR

This PR fixes the formatting of the `convert_unit()` docstring and the intersphinx mapping to the ixmp docs.