### PR TITLE
Use warnings module for deprecation warning

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Individual updates
 
 - [#445](https://github.com/IAMconsortium/pyam/pull/445) Prevent conflicts between attributes and data/meta columns
+- [#444](https://github.com/IAMconsortium/pyam/pull/444) Use warnings module for deprecation warnings
 
 # Release v0.8.0
 

--- a/pyam/logging.py
+++ b/pyam/logging.py
@@ -19,5 +19,5 @@ def deprecation_warning(msg, type='This method'):
     warnings.warn(
         '{} {} {}'.format(type, warn, msg),
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=3
     )

--- a/pyam/logging.py
+++ b/pyam/logging.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import logging
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -15,4 +16,8 @@ def adjust_log_level(logger, level='ERROR'):
 def deprecation_warning(msg, type='This method'):
     """Write deprecation warning to log"""
     warn = 'is deprecated and will be removed in future versions.'
-    logger.warning('{} {} {}'.format(type, warn, msg))
+    warnings.warn(
+        '{} {} {}'.format(type, warn, msg),
+        DeprecationWarning,
+        stacklevel=2
+    )


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] ~Tests Added~ -> single line change, deprecation_warning function did not have tests before
- [ ] ~Documentation Added~
- [x] Description in RELEASE_NOTES.md Added ?

# Description of PR

The new deprecation warnings are quite intense (i could attach a screenshot). The [warnings](https://docs.python.org/3/library/warnings.html) module has a few benefits over them. Notably:

- Has the `stacklevel` attribute to highlight the place where the user has to adapt her code
- Only warns once per line of code, where it is misused
- One can easily filter out the warnings or even raise them as an error

```python
import warnings
warnings.filterwarnings(message="This method is deprecated.*", action="error")
```

I did not (yet) include all the tick-boxes.  Can do, if you think it makes sense?

