### PR TITLE
Prevent conflicts between attributes and data/meta columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Next Release
 
+## Individual updates
+
+- [#445](https://github.com/IAMconsortium/pyam/pull/445) Prevent conflicts between attributes and data/meta columns
+
 # Release v0.8.0
 
 ## Highlights

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -48,7 +48,8 @@ from pyam.utils import (
     META_IDX,
     YEAR_IDX,
     IAMC_IDX,
-    SORT_IDX
+    SORT_IDX,
+    ILLEGAL_COLS
 )
 from pyam.read_ixmp import read_ix
 from pyam.timeseries import fill_series
@@ -618,8 +619,10 @@ class IamDataFrame(object):
         if (name or (hasattr(meta, 'name') and meta.name)) in [None, False]:
             raise ValueError('Must pass a name or use a named pd.Series')
         name = name or meta.name
-        if name in self.data.columns:
-            raise ValueError(f'A column `{name}` already exists in `data`!')
+        if name in self._data.index.names:
+            raise ValueError(f'Column {name} already exists in `data`!')
+        if name in ILLEGAL_COLS:
+            raise ValueError(f'Name {name} is illegal for meta indicators!')
 
         # check if meta has a valid index and use it for further workflow
         if hasattr(meta, 'index') and hasattr(meta.index, 'names') \

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -210,7 +210,7 @@ def format_data(df, **kwargs):
     conflict_cols = [i for i in df.columns if i in ILLEGAL_COLS]
     if conflict_cols:
         msg = f'Column name {conflict_cols} is illegal for timeseries data.\n'
-        _args = ', '.join([f"{i}_alt='{i}'" for i in conflict_cols])
+        _args = ', '.join([f"{i}_1='{i}'" for i in conflict_cols])
         msg += f'Use `IamDataFrame(..., {_args})` to rename at initalization.'
         raise ValueError(msg)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -117,6 +117,31 @@ def test_init_empty_message(caplog):
     assert caplog.records[message_idx].levelno == logging.WARNING
 
 
+def test_init_with_column_conflict(test_pd_df):
+    # add a column to the timeseries data with a conflict to the meta attribute
+    test_pd_df['meta'] = 'foo'
+
+    # check that initialising an instance with an extra-column `meta` raises
+    msg = re.compile(r"Column name \['meta'\] is illegal for timeseries data.")
+    with pytest.raises(ValueError, match=msg):
+        IamDataFrame(test_pd_df)
+
+    # check that recommended fix works
+    df = IamDataFrame(test_pd_df, alt_meta='meta')
+    assert df.alt_meta == ['foo']
+
+
+def test_set_meta_with_column_conflict(test_df_year):
+    # check that setting a `meta` column with a name conflict raises
+    msg = 'Column model already exists in `data`!'
+    with pytest.raises(ValueError, match=msg):
+        test_df_year.set_meta(name='model', meta='foo')
+
+    msg = 'Name meta is illegal for meta indicators!'
+    with pytest.raises(ValueError, match=msg):
+        test_df_year.set_meta(name='meta', meta='foo')
+
+
 def test_print(test_df_year):
     """Assert that `print(IamDataFrame)` (and `info()`) returns as expected"""
     exp = '\n'.join([

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,8 +127,8 @@ def test_init_with_column_conflict(test_pd_df):
         IamDataFrame(test_pd_df)
 
     # check that recommended fix works
-    df = IamDataFrame(test_pd_df, alt_meta='meta')
-    assert df.alt_meta == ['foo']
+    df = IamDataFrame(test_pd_df, meta_1='meta')
+    assert df.meta_1 == ['foo']
 
 
 def test_set_meta_with_column_conflict(test_df_year):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds explicit checks (and meaningful error messages) to prevent conflicts between IamDataFrame attributes (model, scenario, data, meta, ...) and column names in the data and meta dataframes.

This issue was raised by @Rlamboll in bilateral conversation, causing problems when there is a column "meta" in an IAMC-style Excel file.
