### PR TITLE
Add `iiasa.set_config` to the API docs and improve docstrings

### DIFF
--- a/doc/source/api/iiasa.rst
+++ b/doc/source/api/iiasa.rst
@@ -3,7 +3,7 @@
 The **Connection** class
 ========================
 
-IIASA's ixmp scenario explorer infrastructure implements a RestAPI
+IIASA's ixmp Scenario Explorer infrastructure implements a RestAPI
 to directly query the database server connected to an explorer instance.
 See https://software.ene.iiasa.ac.at/ixmp-server for more information.
 

--- a/doc/source/api/iiasa.rst
+++ b/doc/source/api/iiasa.rst
@@ -17,3 +17,5 @@ See `this tutorial <../tutorials/iiasa_dbs.html>`_ for more information.
 
 .. autofunction:: read_iiasa
    :noindex:
+
+.. autofunction:: set_config

--- a/doc/source/api/io.rst
+++ b/doc/source/api/io.rst
@@ -33,10 +33,10 @@ The |pyam| package supports reading and writing to the
 .. automethod:: IamDataFrame.to_datapackage
    :noindex:
 
-Connecting to an IIASA scenario explorer instance
+Connecting to an IIASA Scenario Explorer instance
 -------------------------------------------------
 
-IIASA's ixmp scenario explorer infrastructure implements a RestAPI
+IIASA's ixmp Scenario Explorer infrastructure implements a RestAPI
 to directly query the database server connected to an explorer instance.
 See https://software.ene.iiasa.ac.at/ixmp-server for more information.
 

--- a/doc/source/tutorials/iiasa_dbs.ipynb
+++ b/doc/source/tutorials/iiasa_dbs.ipynb
@@ -29,7 +29,7 @@
     "## Connecting to a data resource (aka the database API of a Scenario Explorer instance)\n",
     "\n",
     "Accessing a data resource is done via a **Connection** object.\n",
-    "By default, your can connect to all public scenario explorers instances. "
+    "By default, your can connect to all public Scenario Explorer instances. "
    ]
   },
   {

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -30,7 +30,7 @@ DEFAULT_IIASA_CREDS = Path('~').expanduser() / '.local' / 'pyam' / 'iiasa.yaml'
 
 
 def set_config(user, password, file=None):
-    """Save username and password for IIASA API connection to file"""
+    """Save username and password for the IIASA API connection to a file"""
     file = Path(file) if file is not None else DEFAULT_IIASA_CREDS
     if not file.parent.exists():
         file.parent.mkdir(parents=True)
@@ -107,14 +107,18 @@ class Connection(object):
         See :attr:`pyam.iiasa.Connection.valid_connections` for a list
         of available APIs.
     creds : str, :class:`pathlib.Path`, list-like, or dict, optional
-        By default, this function will (try to) read user credentials which
-        were set using :meth:`pyam.iiasa.set_config(<user>, <password>)`.
+        By default, the class will search for user credentials which
+        were set using :meth:`pyam.iiasa.set_config`.
         Alternatively, you can provide a path to a yaml file
         with entries of 'username' and 'password'.
-    base_url : str, custom authentication server URL
+    base_url : str, optional
+        custom authentication server URL
 
     Notes
     -----
+    Credentials (username & password) are not required to access any public
+    Scenario Explorer instances (i.e., with Guest login).
+
     Providing credentials as an ordered container (tuple, list, etc.)
     or as a dictionary with keys `user` and `password` is (still) supported
     for backwards compatibility. However, this option is NOT RECOMMENDED
@@ -499,9 +503,12 @@ def read_iiasa(name, default=True, meta=True, creds=None, base_url=_AUTH_URL,
     meta : bool or list of strings, optional
         If `True`, include all meta categories & quantitative indicators
         (or subset if list is given).
-    creds : dict
-        Credentials to access scenario explorer instance and
-        authentication service APIs (username/password)
+    creds : str, :class:`pathlib.Path`, list-like, or dict, optional
+        | Credentials (username & password) are not required to access
+          any public Scenario Explorer instances (i.e., with Guest login).
+        | See :class:`pyam.iiasa.Connection` for details.
+        | Use :meth:`pyam.iiasa.set_config` to set credentials
+          for accessing private/restricted Scenario Explorer instances.
     base_url : str
         Authentication server URL
     kwargs


### PR DESCRIPTION
# Description of PR

Per a discussion with @OFR-IIASA, I noticed that the function `pyam.iiasa.set_config()` was not included in the API docs. This PR adds the function and improves some of the related docs.
