### PR TITLE
Set-up deferred logging with basicConfig

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,7 +3,7 @@ linters:
     python: 3
     max-line-length: 79
     fixer: false
-    ignore: I002, F403, E402, E731
+    ignore: I002, F403, E402, E731, W503
     # stickler doesn't support 'exclude' for flake8 properly, so we disable it
     # below with files.ignore:
     # https://github.com/markstory/lint-review/issues/184

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#450](https://github.com/IAMconsortium/pyam/pull/450) Defer logging set-up to when the first logging message is generated
 - [#445](https://github.com/IAMconsortium/pyam/pull/445) Prevent conflicts between attributes and data/meta columns
 - [#444](https://github.com/IAMconsortium/pyam/pull/444) Use warnings module for deprecation warnings
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -21,7 +21,7 @@ and methods.
 
 **Notebook logging behaviour**
 
-Pyam wants to provide sensitive defaults for users unfamiliar with
+|pyam| wants to provide sensible defaults for users unfamiliar with
 `setting up python's logging library <https://realpython.com/python-logging/#basic-configurations>`_,
 and therefore will provide a basic configuration by invoking
 
@@ -33,7 +33,7 @@ and therefore will provide a basic configuration by invoking
 if (and only if):
 
 1. it determines to be running within a notebook, and
-2. logging is still *unconfigured by the time the first logging message is to be emitted*.
+2. logging is still *unconfigured by the time the first logging message by |pyam| is to be emitted*.
 
 **Intersphinx mapping**
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -19,6 +19,22 @@ and methods.
    api/variables
 
 
+**Notebook logging behaviour**
+
+Pyam wants to provide sensitive defaults for users unfamiliar with
+`setting up python's logging library <https://realpython.com/python-logging/#basic-configurations>`_,
+and therefore will provide a basic configuration by invoking
+
+.. code-block:: python
+
+   import logging
+   logging.basicConfig(level="INFO", format="%(name)s - %(levelname)s: %(message)s")
+
+if (and only if):
+
+1. it determines to be running within a notebook, and
+2. logging is still *unconfigured by the time the first logging message is to be emitted*.
+
 **Intersphinx mapping**
 
 To use sphinx.ext.intersphinx_ for generating automatic links from your project

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -26,8 +26,10 @@ try:
             u'IPython.OutputArea.prototype._should_scroll = '
             u'function(lines) { return false; }'
         )
-
-        log_msg = "Running in a notebook, setting root logging level to INFO"
+        log_msg = (
+            "Running in a notebook, "
+            "setting up a basic logging config at level INFO"
+        )
         defer_logging_config(
             logger, log_msg, level="INFO",
             format="%(name)s - %(levelname)s: %(message)s",

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -10,26 +10,28 @@ from pyam.run_control import *
 from pyam.iiasa import read_iiasa  # noqa: F401
 from pyam.datareader import read_worldbank  # noqa: F401
 
+from pyam.logging import defer_logging_config
+
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
-# in Jupyter notebooks: disable autoscroll and set logger to info
+# in Jupyter notebooks: disable autoscroll and set-up logging
 try:
-    get_ipython().run_cell_magic(u'javascript', u'',
-                                 u'IPython.OutputArea.prototype._should_scroll = function(lines) { return false; }')
+    from ipykernel.zmqshell import ZMQInteractiveShell
+    from IPython import get_ipython
 
-    logger.setLevel(logging.INFO)
+    shell = get_ipython()
+    if isinstance(shell, ZMQInteractiveShell):
+        shell.run_cell_magic(
+            u'javascript', u'',
+            u'IPython.OutputArea.prototype._should_scroll = '
+            u'function(lines) { return false; }'
+        )
 
-    stderr_info_handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(name)s - %(levelname)s: %(message)s')
-    stderr_info_handler.setFormatter(formatter)
-    logger.addHandler(stderr_info_handler)
-
-    log_msg = (
-        "Running in a notebook, setting `{}` logging level to `logging.INFO` "
-        "and adding stderr handler".format(__name__)
-    )
-    logger.info(log_msg)
+        log_msg = "Running in a notebook, setting root logging level to INFO"
+        defer_logging_config(
+            logger, log_msg, level="INFO",
+            format="%(name)s - %(levelname)s: %(message)s",
+        )
 
 except Exception:
     pass

--- a/pyam/logging.py
+++ b/pyam/logging.py
@@ -21,3 +21,51 @@ def deprecation_warning(msg, type='This method'):
         DeprecationWarning,
         stacklevel=3
     )
+
+
+class ConfigPseudoHandler(logging.Handler):
+    """Pseudo logging handler to defer configuring logging until the first message
+
+    Registers itself as a handler for the provided logger and temporarily
+    sets the logger as sensitive to INFO messages. Upon receival of the first
+    message (of at least INFO level), it configures logging with the provided
+    `config_kwargs` and prints `log_msg`
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        Logger to listen for the first message
+    log_msg : str, optional
+        Message to print once logging is configured, by default None
+    **config_kwargs
+        Arguments to pass on to logging.basicConfig
+    """
+    def __init__(self, logger, log_msg=None, **config_kwargs):
+        super().__init__()
+
+        self.logger = logger
+        self.log_msg = log_msg
+        self.config_kwargs = config_kwargs
+
+        self.logger.addHandler(self)
+
+        # temporarily set the logging level to a non-standard value,
+        # slightly below logging.INFO == 20 and use that as a sentinel
+        # to switch back to logging.NOTSET later
+        self.logger.setLevel(19)
+
+    def emit(self, record):
+        self.logger.removeHandler(self)
+
+        if self.logger.level == 19:
+            self.logger.setLevel(logging.NOTSET)
+
+        if not self.logger.root.hasHandlers():
+            logging.basicConfig(**self.config_kwargs)
+
+            if self.log_msg is not None:
+                self.logger.info(self.log_msg)
+
+
+# Give the Handler a function like alias
+defer_logging_config = ConfigPseudoHandler

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -56,6 +56,16 @@ def test_pyam_first_steps(capsys):
     assert errors == []
     assert os.path.exists(os.path.join(tut_path, 'tutorial_export.xlsx'))
 
+    def has_log_output(cell):
+        return (
+            cell['cell_type'] == 'code' and
+            any(
+                'Running in a notebook' in output.get('text', '')
+                for output in cell['outputs']
+            )
+        )
+    assert any(has_log_output(cell) for cell in nb['cells'])
+
 
 def test_data_table_formats():
     fname = os.path.join(

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -58,8 +58,8 @@ def test_pyam_first_steps(capsys):
 
     def has_log_output(cell):
         return (
-            cell['cell_type'] == 'code' and
-            any(
+            cell['cell_type'] == 'code'
+            and any(
                 'Running in a notebook' in output.get('text', '')
                 for output in cell['outputs']
             )


### PR DESCRIPTION
Fixes #449.

See also discussion in the issue.

# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

As outlined as option 2a in https://github.com/IAMconsortium/pyam/issues/449#issuecomment-718725665 , this PR creates a `ConfigPseudoHandler` with the sole job of setting up logging after receiving the first log message.

To set up logging it calls `logging.basicConfig` and optionally emits a logging message about having it set up.
