### PR TITLE
Use ordinary pint conversion only if both units are parsable by pint

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#451](https://github.com/IAMconsortium/pyam/pull/451) Fix unit conversions from C to CO2eq
 - [#450](https://github.com/IAMconsortium/pyam/pull/450) Defer logging set-up to when the first logging message is generated
 - [#445](https://github.com/IAMconsortium/pyam/pull/445) Prevent conflicts between attributes and data/meta columns
 - [#444](https://github.com/IAMconsortium/pyam/pull/444) Use warnings module for deprecation warnings

--- a/doc/source/tutorials/unit_conversion.ipynb
+++ b/doc/source/tutorials/unit_conversion.ipynb
@@ -182,7 +182,7 @@
     "\n",
     "To facilitate such use cases, **pint** provides \"contexts\" to allow specifying the appropriate metric.\n",
     "The [IAMconsortium/units](https://github.com/IAMconsortium/units) parametrizes multiple contexts\n",
-    "for the comversion of greenhouse gases;\n",
+    "for the conversion of greenhouse gases;\n",
     "see the [emissions module](https://github.com/IAMconsortium/units/blob/master/modules/emissions) for details.\n",
     "\n",
     "Performing a unit conversion with context is illustrated below using the IPCC AR5-GWP100 factor;\n",
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.convert_unit('Mt CH4/yr', to='Mt CO2e/yr', context='gwp_AR5GWP100').timeseries()"
+    "df.convert_unit('Mt CH4/yr', to='Mt CO2e/yr', context='AR5GWP100').timeseries()"
    ]
   },
   {
@@ -221,7 +221,7 @@
     "gwp = 'AR5GWP100'\n",
     "target = 'Mt CO2e/yr'\n",
     "(\n",
-    "    df.convert_unit('Mt CH4/yr', to=target, context=f'gwp_{gwp}')\n",
+    "    df.convert_unit('Mt CH4/yr', to=target, context=gwp)\n",
     "    .rename(unit={target: f'{target} ({gwp})'})\n",
     "    .timeseries()\n",
     ")"

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -937,9 +937,9 @@ class IamDataFrame(object):
         When using this registry, *current* and *to* may contain the symbols of
         greenhouse gas (GHG) species, such as 'CO2e', 'C', 'CH4', 'N2O',
         'HFC236fa', etc., as well as lower-case aliases like 'co2' supported by
-        :mod:`pyam`. In this case, *context* must contain 'gwp\_' followed by
-        the name of a specific global warming potential (GWP) metric supported
-        by :mod:`iam_units`, e.g. 'gwp_AR5GWP100'.
+        :mod:`pyam`. In this case, *context* must be the name of a specific
+        global warming potential (GWP) metric supported by :mod:`iam_units`,
+        e.g. 'AR5GWP100' (optionally prefixed by 'gwp_', e.g. 'gwp_AR5GWP100').
 
         Rows with units other than *current* are not altered.
 

--- a/pyam/logging.py
+++ b/pyam/logging.py
@@ -13,13 +13,13 @@ def adjust_log_level(logger, level='ERROR'):
     logger.setLevel(old_level)
 
 
-def deprecation_warning(msg, type='This method'):
+def deprecation_warning(msg, type='This method', stacklevel=3):
     """Write deprecation warning to log"""
     warn = 'is deprecated and will be removed in future versions.'
     warnings.warn(
         '{} {} {}'.format(type, warn, msg),
         DeprecationWarning,
-        stacklevel=3
+        stacklevel=stacklevel
     )
 
 

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -18,7 +18,7 @@ def convert_unit(df, current, to, factor=None, registry=None, context=None,
     try:
         where = ret._data.index.get_loc_level(current, 'unit')[0]
     except KeyError:
-        return ret
+        return None if inplace else ret
 
     index_args = [ret._data, 'unit', {current: to}]
 

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -4,6 +4,7 @@ import re
 import iam_units
 import pint
 
+from pyam.logging import deprecation_warning
 from pyam.index import replace_index_values
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ class UndefinedUnitError(pint.UndefinedUnitError):
     def __str__(self):
         return super().__str__() + (
             "\nGWP conversion with IamDataFrame.convert_unit() requires a "
-            "'gwp_...' *context* and mass-based *to* units.")
+            "*context* and mass-based *to* units.")
 
 
 def extract_species(expr):
@@ -104,11 +105,14 @@ def extract_species(expr):
 def convert_gwp(context, qty, to):
     """Helper for :meth:`convert_unit` to perform GWP conversions."""
     # Remove a leading 'gwp_' to produce the metric name
-    metric = (
-        context[len('gwp_'):]
-        if context is not None and context.startswith('gwp_')
-        else context
-    )
+    if context is not None and context.startswith('gwp_'):
+        context = context[len("gwp_"):]
+        deprecation_warning(
+            f"Use context='{context}' instead",
+            type='Prefixing a context with "gwp_"',
+            stacklevel=5
+        )
+    metric = context
 
     # Extract the species from *qty* and *to*, allowing supported aliases
     species_from, units_from = extract_species(qty[1])

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -104,7 +104,11 @@ def extract_species(expr):
 def convert_gwp(context, qty, to):
     """Helper for :meth:`convert_unit` to perform GWP conversions."""
     # Remove a leading 'gwp_' to produce the metric name
-    metric = context.split('gwp_')[1] if context else context
+    metric = (
+        context[len('gwp_'):]
+        if context is not None and context.startswith('gwp_')
+        else context
+    )
 
     # Extract the species from *qty* and *to*, allowing supported aliases
     species_from, units_from = extract_species(qty[1])

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -95,6 +95,7 @@ def test_convert_unit_with_custom_registry(test_df):
     ('AR5GWP100', 'ch4-equiv', 28),
 
     # Converting C -> CO2e should work
+    # TODO remove context once IAMconsortium/units#23 is resolved
     ('AR4GWP100', 'C', 11 / 3)
 ])
 @pytest.mark.parametrize('current_expr, to_expr, exp_factor', [

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -139,7 +139,8 @@ def test_convert_gwp(test_df, context, current_species, current_expr, to_expr,
 
 def test_convert_unit_bad_args(test_pd_df):
     """Unit conversion with bad arguments raises errors."""
-    idf = IamDataFrame(test_pd_df)
+    idf = IamDataFrame(test_pd_df).rename(unit={'EJ/yr': 'Mt CH4'})
+
     # Conversion fails with both *factor* and *registry*
     with pytest.raises(ValueError, match='use either `factor` or `pint...'):
         idf.convert_unit('Mt CH4', 'CO2e', factor=1.0, registry=object())

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -127,9 +127,6 @@ def test_convert_gwp(test_df, context, current_species, current_expr, to_expr,
     # Handle parameters
     current = current_expr.format(current_species)
     to = to_expr.format('CO2e')
-    if context is not None:
-        # pyam-style context
-        context = f'gwp_{context}'
 
     # Expected values
     exp_values = test_df._data.copy()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -92,7 +92,10 @@ def test_convert_unit_with_custom_registry(test_df):
 
     # Using "-equiv" after a unit should make no difference
     ('AR4GWP100', 'co2-equiv', 1.),
-    ('AR5GWP100', 'ch4-equiv', 28)
+    ('AR5GWP100', 'ch4-equiv', 28),
+
+    # Converting C -> CO2e should work
+    ('AR4GWP100', 'C', 11/3)
 ])
 @pytest.mark.parametrize('current_expr, to_expr, exp_factor', [
     # exp_factor is used when the conversion includes both a species *and* unit

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -95,7 +95,7 @@ def test_convert_unit_with_custom_registry(test_df):
     ('AR5GWP100', 'ch4-equiv', 28),
 
     # Converting C -> CO2e should work
-    ('AR4GWP100', 'C', 11/3)
+    ('AR4GWP100', 'C', 11 / 3)
 ])
 @pytest.mark.parametrize('current_expr, to_expr, exp_factor', [
     # exp_factor is used when the conversion includes both a species *and* unit


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [ ] ~Documentation Added~
- [x] Description in RELEASE_NOTES.md Added


# Description of PR

Fix unit conversions from `C` to `CO2eq`

When determining whether the ordinary pint conversion suffices, the previous implementation only considers whether the original unit can or cannot be parsed by pint. In the case of `C` pint misinterprets as Coulomb and then only fails when asked to convert to CO2eq, which it is unable to interpret.

Therefore, the main part of this change moves the `.to(newUnit)` conversion into the try-except clause, so that the late fail still triggers the GWP conversion.

The PR also deprecates the usage of prefixing GWP contexts with `gwp_` in favour of using the contexts of iam-units directly, ie. in place of `gwp_AR4GWP100`, it recommends `AR4GWP100`.

And a third additional change has been sneaked in:
A fast-path if the `current` unit has not been used in the dataframe

Fixes #442 .

