### PR TITLE
Use yaml.FullLoader with `run_control().update()`

### DIFF
--- a/pyam/run_control.py
+++ b/pyam/run_control.py
@@ -119,7 +119,7 @@ class RunControl(Mapping):
             with open(fname) as f:
                 obj = f.read()
         if not isinstance(obj, dict):
-            obj = yaml.load(obj)
+            obj = yaml.load(obj, Loader=yaml.FullLoader)
         return obj
 
     def recursive_update(self, k, d):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- ~Documentation Added~
- ~Description in RELEASE_NOTES.md Added~

# Description of PR

Using `yaml.load(input)` without specifying a loader is deprecated, see [here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation). This PR uses the default loader explicitly.
