### PR TITLE
Enable `Path` as arg 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#458](https://github.com/IAMconsortium/pyam/pull/458) Enable `Path` for IamDataFrame initialization 
 - [#454](https://github.com/IAMconsortium/pyam/pull/454) Enable dimensionless units and fix `info()` if IamDataFrame is empty
 - [#451](https://github.com/IAMconsortium/pyam/pull/451) Fix unit conversions from C to CO2eq
 - [#450](https://github.com/IAMconsortium/pyam/pull/450) Defer logging set-up to when the first logging message is generated

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -132,14 +132,13 @@ class IamDataFrame(object):
             # TODO read meta indicators from ixmp
             meta = None
             _data = read_ix(data, **kwargs)
-        # read from file
         else:
             if islistable(data):
                 raise ValueError(
                     'Initializing from list is not supported, '
                     'use `IamDataFrame.append()` or `pyam.concat()`'
                 )
-
+            # read from file
             try:
                 data = Path(data)  # casting str or LocalPath to Path
                 is_file = data.is_file()
@@ -1831,9 +1830,8 @@ class IamDataFrame(object):
         inplace : bool, optional
             if True, do operation inplace and return None
         """
-        models = self.meta.index.get_level_values('model').unique()
         fname = fname or run_control()['region_mapping']['default']
-        mapping = read_pandas(fname).rename(str.lower, axis='columns')
+        mapping = read_pandas(Path(fname)).rename(str.lower, axis='columns')
         map_col = map_col.lower()
 
         ret = self.copy() if not inplace else self
@@ -1842,7 +1840,7 @@ class IamDataFrame(object):
 
         # merge data
         dfs = []
-        for model in models:
+        for model in self.model:
             df = _df[_df['model'] == model]
             _col = region_col or '{}.REGION'.format(model)
             _map = mapping.rename(columns={_col.lower(): 'region'})

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -131,6 +131,9 @@ class IamDataFrame(object):
             # TODO read meta indicators from ixmp
             meta = None
             _data = read_ix(data, **kwargs)
+        elif islistable(data):
+            raise ValueError('Initializing from list is not supported, '
+                             'use `IamDataFrame.append()` or `pyam.concat()`')
         else:
             meta = None
             logger.info('Reading file `{}`'.format(data))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 
 
 class IamDataFrame(object):
-    """Scenario timeseries data following the IAMC-structure
+    """Scenario timeseries data following the IAMC data format
 
     The class provides a number of diagnostic features (including validation of
     data, completeness of variables provided), processing tools (e.g.,
@@ -72,11 +72,11 @@ class IamDataFrame(object):
 
     Parameters
     ----------
-    data : ixmp.Scenario, pd.DataFrame or data file
-        an instance of an :class:`ixmp.Scenario`, :class:`pandas.DataFrame`,
-        or data file with the required data columns.
-        A pandas.DataFrame can have the required data as columns or index.
-        Support is provided additionally for R-style data columns for years,
+    data : :class:`pandas.DataFrame`, :class:`ixmp.Scenario`,
+            or file-like object as str or :class:`pathlib.Path`
+        Scenario timeseries data following the IAMC data format or
+        a supported variation as pandas object, a path to a file,
+        or a scenario of an ixmp instance.
     meta : :class:`pandas.DataFrame`, optional
         A dataframe with suitable 'meta' indicators for the new instance.
         The index will be downselected to scenarios present in `data`.
@@ -91,10 +91,14 @@ class IamDataFrame(object):
 
     Notes
     -----
+    A :class:`pandas.DataFrame` can have the required dimensions
+    as columns or index.
+    R-style integer column headers (i.e., `X2015`) are acceptable.
+
     When initializing an :class:`IamDataFrame` from an xlsx file,
     |pyam| will per default look for the sheets 'data' and 'meta' to
     populate the respective tables. Custom sheet names can be specified with
-    kwargs :code:`sheet_name` ('data') and :code:`meta_sheet_name` ('meta')
+    kwargs :code:`sheet_name` ('data') and :code:`meta_sheet_name` ('meta').
     Calling the class with :code:`meta_sheet_name=False` will
     skip the import of the 'meta' table.
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1657,7 +1657,7 @@ class IamDataFrame(object):
             any valid string path or :class:`pathlib.Path`
         """
         # load from file
-        df = read_pandas(path, default_sheet='meta', *args, **kwargs)
+        df = read_pandas(Path(path), default_sheet='meta', *args, **kwargs)
 
         # cast model-scenario column headers to lower-case (if necessary)
         df = df.rename(columns=dict([(i.capitalize(), i) for i in META_IDX]))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -123,10 +123,6 @@ class IamDataFrame(object):
         # pop kwarg for meta_sheet_name (prior to reading data from file)
         meta_sheet = kwargs.pop('meta_sheet_name', 'meta')
 
-        if islistable(data):
-            raise ValueError('Initializing from list is not supported, '
-                             'use `IamDataFrame.append()` or `pyam.concat()`')
-
         # cast data from pandas
         if isinstance(data, pd.DataFrame) or isinstance(data, pd.Series):
             meta = kwargs.pop('meta') if 'meta' in kwargs else None
@@ -138,6 +134,12 @@ class IamDataFrame(object):
             _data = read_ix(data, **kwargs)
         # read from file
         else:
+            if islistable(data):
+                raise ValueError(
+                    'Initializing from list is not supported, '
+                    'use `IamDataFrame.append()` or `pyam.concat()`'
+                )
+
             try:
                 data = Path(data)  # casting str or LocalPath to Path
                 is_file = data.is_file()

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import itertools
 import logging
 import string
@@ -108,7 +109,9 @@ def write_sheet(writer, name, df, index=False):
 
 def read_pandas(path, default_sheet='data', *args, **kwargs):
     """Read a file and return a pandas.DataFrame"""
-    if path.endswith('csv'):
+    if isinstance(path, Path) and path.suffix == '.csv':
+        df = pd.read_csv(path, *args, **kwargs)
+    elif isstr(path) and path.endswith('csv'):
         df = pd.read_csv(path, *args, **kwargs)
     else:
         xl = pd.ExcelFile(path)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -111,8 +111,6 @@ def read_pandas(path, default_sheet='data', *args, **kwargs):
     """Read a file and return a pandas.DataFrame"""
     if isinstance(path, Path) and path.suffix == '.csv':
         df = pd.read_csv(path, *args, **kwargs)
-    elif isstr(path) and path.endswith('csv'):
-        df = pd.read_csv(path, *args, **kwargs)
     else:
         xl = pd.ExcelFile(path)
         if len(xl.sheet_names) > 1 and 'sheet_name' not in kwargs:

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -120,9 +120,6 @@ def read_pandas(path, default_sheet='data', *args, **kwargs):
 
 def read_file(path, *args, **kwargs):
     """Read data from a file"""
-    if not isstr(path):
-        raise ValueError('Reading multiple files not supported, '
-                         'use `IamDataFrame.append()` or `pyam.concat()`')
     format_kwargs = {}
     # extract kwargs that are intended for `format_data`
     for c in [i for i in IAMC_IDX + ['year', 'time', 'value'] if i in kwargs]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import matplotlib
 matplotlib.use('agg')
 
+from pathlib import Path
 import os
 from requests.exceptions import ConnectionError
 import pytest
@@ -23,9 +24,9 @@ TEST_API = 'integration-test'
 TEST_API_NAME = 'IXSE_INTEGRATION_TEST'
 
 
-here = os.path.dirname(os.path.realpath(__file__))
-IMAGE_BASELINE_DIR = os.path.join(here, 'expected_figs')
-TEST_DATA_DIR = os.path.join(here, 'data')
+here = Path(__file__).parent
+IMAGE_BASELINE_DIR = here / 'expected_figs'
+TEST_DATA_DIR = here / 'data'
 
 
 TEST_YEARS = [2005, 2010]


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR was initiated by a comment by @znicholls (https://github.com/IAMconsortium/pyam/pull/454#discussion_r524185343) about using `tmpdir` facility in the tests.

Changes:
 - enable initializing an `IamDataFrame` with a `Path` or `LocalPath` object (in addition to passing a file path as string)
 - raise a dedicated error message when initializing without meaningful args 'IamDataFrame constructor not properly called!' rather than showing the message `Initializing from list is not supported, ...` (which was previously shown in that case)
 - rework the initialization workflow and add more comments
 - use `tmpdir` facility in the io-tests
