### PR TITLE
Add get_variable_components() function incl doc and tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#459](https://github.com/IAMconsortium/pyam/pull/459) Add a `get_variable_components()` function to retrieve or join variable components
 - [#451](https://github.com/IAMconsortium/pyam/pull/451) Fix unit conversions from C to CO2eq
 - [#450](https://github.com/IAMconsortium/pyam/pull/450) Defer logging set-up to when the first logging message is generated
 - [#445](https://github.com/IAMconsortium/pyam/pull/445) Prevent conflicts between attributes and data/meta columns

--- a/doc/source/api/variables.rst
+++ b/doc/source/api/variables.rst
@@ -17,3 +17,5 @@ The package provides several functions to work with such strings.
 .. autofunction:: find_depth
 
 .. autofunction:: reduce_hierarchy
+
+.. autofunction:: get_variable_components

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -585,3 +585,10 @@ def reduce_hierarchy(x, depth):
     _x = x.split('|')
     depth = len(_x) + depth - 1 if depth < 0 else depth
     return '|'.join(_x[0:(depth + 1)])
+
+def get_variable_components(x, depths):
+    """Return (or merge and return) the variable component(s) in regard to
+    the hierarchy (indicated by ``|``) of x to the specified depth(s)"""
+    depths = [depths] if type(depths) == int else depths
+    _x = x.split('|')
+    return '|'.join([_x[d] for d in depths])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -587,9 +587,22 @@ def reduce_hierarchy(x, depth):
     return '|'.join(_x[0:(depth + 1)])
 
 
-def get_variable_components(x, depths):
-    """Return (or merge and return) the variable component(s) in regard to
-    the hierarchy (indicated by ``|``) of x to the specified depth(s)"""
-    depths = [depths] if type(depths) == int else depths
+def get_variable_components(x, level, join=False):
+    """Return components for requested level in a list or join these in a str.
+
+    Parameters
+    ----------
+    x : str
+        Uses ``|`` to separate the components of the variable.
+    level : int or list of int
+        Position of the component.
+    join : bool or str, optional
+        If True, IAMC-style (``|``) is used as separator for joined components.
+    """
+    level = [level] if type(level) == int else level
     _x = x.split('|')
-    return '|'.join([_x[d] for d in depths])
+    if join is False:
+        return [_x[i] for i in level] if islistable(level) else _x[level]
+    else:
+        join = '|' if join is True else join
+        return join.join([_x[i] for i in level])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -586,6 +586,7 @@ def reduce_hierarchy(x, depth):
     depth = len(_x) + depth - 1 if depth < 0 else depth
     return '|'.join(_x[0:(depth + 1)])
 
+
 def get_variable_components(x, depths):
     """Return (or merge and return) the variable component(s) in regard to
     the hierarchy (indicated by ``|``) of x to the specified depth(s)"""

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -599,10 +599,10 @@ def get_variable_components(x, level, join=False):
     join : bool or str, optional
         If True, IAMC-style (``|``) is used as separator for joined components.
     """
-    level = [level] if type(level) == int else level
     _x = x.split('|')
     if join is False:
         return [_x[i] for i in level] if islistable(level) else _x[level]
     else:
+        level = [level] if type(level) == int else level
         join = '|' if join is True else join
         return join.join([_x[i] for i in level])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,3 +213,16 @@ def test_merge_meta():
 
     obs = utils.merge_meta(left, right, ignore_meta_conflict=True)
     pdt.assert_frame_equal(exp, obs)
+
+
+def test_get_variable_components_int():
+    assert utils.get_variable_components('foo|bar|baz', 1) == 'bar'
+    
+
+def test_get_variable_components_list():
+    assert utils.get_variable_components('foo|bar|baz', [1,2]) == 'bar|baz'
+
+
+def test_get_variable_components_indexError():
+    with pytest.raises(IndexError):
+        utils.get_variable_components('foo|bar|baz', 3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -216,13 +216,24 @@ def test_merge_meta():
 
 
 def test_get_variable_components_int():
-    assert utils.get_variable_components('foo|bar|baz', 1) == 'bar'
+    assert utils.get_variable_components('foo|bar|baz', 1) == ['bar']
 
 
 def test_get_variable_components_list():
-    assert utils.get_variable_components('foo|bar|baz', [1, 2]) == 'bar|baz'
+    assert utils.get_variable_components('foo|bar|baz',
+                                         [1, 2]) == ['bar', 'baz']
 
 
 def test_get_variable_components_indexError():
     with pytest.raises(IndexError):
         utils.get_variable_components('foo|bar|baz', 3)
+
+
+def test_get_variable_components_joinTRUE():
+    assert utils.get_variable_components('foo|bar|baz', [0, 2],
+                                         join=True) == 'foo|baz'
+
+
+def test_get_variable_components_joinstr():
+    assert utils.get_variable_components('foo|bar|baz', [2, 1],
+                                         join='_') == 'baz_bar'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -216,7 +216,7 @@ def test_merge_meta():
 
 
 def test_get_variable_components_int():
-    assert utils.get_variable_components('foo|bar|baz', 1) == ['bar']
+    assert utils.get_variable_components('foo|bar|baz', 1) == 'bar'
 
 
 def test_get_variable_components_list():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,10 +217,10 @@ def test_merge_meta():
 
 def test_get_variable_components_int():
     assert utils.get_variable_components('foo|bar|baz', 1) == 'bar'
-    
+
 
 def test_get_variable_components_list():
-    assert utils.get_variable_components('foo|bar|baz', [1,2]) == 'bar|baz'
+    assert utils.get_variable_components('foo|bar|baz', [1, 2]) == 'bar|baz'
 
 
 def test_get_variable_components_indexError():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This pull request adds a new function 'get_variable_components()' to utils.py. It returns (or merges and returns) the variable component(s) in regard to the hierarchy (indicated by ``|``) of x to the specified level(s).