### PR TITLE
Add list of authors to the repo and the docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,7 +11,7 @@ The following persons contributed to the development of the |pyam| framework:
 - Robin Lamboll `@Rlamboll <https://github.com/Rlamboll>`_
 - Oliver Fricko `@OFR-IIASA <https://github.com/OFR-IIASA>`_
 - Jonas Hörsch `@coroa <https://github.com/coroa>`_
-- Paul Kishimoto `@khaeru <https://github.com/khaeru>`_
+- Paul Natsuo Kishimoto `@khaeru <https://github.com/khaeru>`_
 - Thorsten Burandt `@tburandt <https://github.com/tburandt>`_
 - Ross Ursino `@rossursino <https://github.com/rossursino>`_
 - Maik Budzinski `@mabudz <https://github.com/mabudz>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,5 @@
-Authors and Contributors
-========================
+Authors and Developers
+======================
 
 The following persons contributed to the development of the |pyam| framework:
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,19 @@
+Authors and Contributors
+========================
+
+The following persons contributed to the development of the |pyam| framework:
+
+- Matthew Gidden `@gidden <https://github.com/gidden>`_
+- Daniel Huppmann `@danielhuppmann <https://github.com/danielhuppmann>`_,
+  `iiasa <https://www.iiasa.ac.at/staff/huppmann>`_
+- Zebedee Nicholls `@znicholls <https://github.com/znicholls>`_
+- Nikolay Kushin `@zikolach <https://github.com/zikolach>`_
+- Robin Lamboll `@Rlamboll <https://github.com/Rlamboll>`_
+- Oliver Fricko `@OFR-IIASA <https://github.com/OFR-IIASA>`_
+- Jonas Hörsch `@coroa <https://github.com/coroa>`_
+- Paul Kishimoto `@khaeru <https://github.com/khaeru>`_
+- Thorsten Burandt `@tburandt <https://github.com/tburandt>`_
+- Ross Ursino `@rossursino <https://github.com/rossursino>`_
+- Maik Budzinski `@mabudz <https://github.com/mabudz>`_
+- Jarmo Kikstra `@jkikstra <https://github.com/jkikstra>`_
+- Michael Pimmer `@fonfon <https://github.com/fonfon>`_

--- a/LICENSE
+++ b/LICENSE
@@ -172,30 +172,3 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2018 Matthew J. Gidden and Daniel Huppmann
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
-   Copyright 2017-2018 IIASA Energy Program
+   Copyright 2017-2020 IIASA and the pyam developer team
 
-   The `pyam` package is licensed under
+   The **pyam** package is licensed under
    the Apache License, Version 2.0 (the "License");
    you may not use the package except in compliance with the License.
    You may obtain a copy of the License at

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 - [ ] Tests Added
 - [ ] Documentation Added
+- [ ] Name of contributors Added to AUTHORS.rst
 - [ ] Description in RELEASE_NOTES.md Added
 
 ## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 pyam: analysis & visualization <br /> of integrated-assessment scenarios
 ========================================================================
 
-[![license](https://anaconda.org/conda-forge/pyam/badges/license.svg)](https://anaconda.org/conda-forge/pyam)
+[![license](https://img.shields.io/badge/License-Apache%202.0-black)](https://github.com/IAMconsortium/pyam/blob/master/LICENSE)
 [![pypi](https://img.shields.io/pypi/v/pyam-iamc.svg)](https://pypi.python.org/pypi/pyam-iamc/)
 [![conda](https://anaconda.org/conda-forge/pyam/badges/version.svg)](https://anaconda.org/conda-forge/pyam)
 [![latest](https://anaconda.org/conda-forge/pyam/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/pyam)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ and Daniel Huppmann ([@danielhuppmann](https://github.com/danielhuppmann/)).
 License
 -------
 
-Copyright 2017-2020 IIASA Energy Program
+Copyright 2017-2020 IIASA and the pyam developer team
 
 The **pyam** package is licensed
 under the Apache License, Version 2.0 (the "License");

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#461](https://github.com/IAMconsortium/pyam/pull/461) Add list of authors to repo and docs pages
 - [#458](https://github.com/IAMconsortium/pyam/pull/458) Enable `Path` for IamDataFrame initialization 
 - [#454](https://github.com/IAMconsortium/pyam/pull/454) Enable dimensionless units and fix `info()` if IamDataFrame is empty
 - [#451](https://github.com/IAMconsortium/pyam/pull/451) Fix unit conversions from C to CO2eq

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -11,6 +11,8 @@
 
 1. Make a release candidate branch (e.g., `rc_v<release version>`)
    and pull request it into `master` with the following updates:
+   1. If it's the first release in a new year,
+      search for `Copyright 2017` and bump the year
    1. Deprecate any stated portion of the API
       (you can find them by searching the code base for "deprecate")
    1. Update `RELEASE_NOTES.md` (see the examples of previous releases)

--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -1,0 +1,1 @@
+.. include:: ../../AUTHORS.rst

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,8 +71,8 @@ master_doc = 'index'
 # General information about the project.
 project = u'pyam'
 year = datetime.now().year
-copyright = '{}, Matthew Gidden & Daniel Huppmann'.format(year)
-author = u'Matthew Gidden & Daniel Huppmann'
+copyright = '{}, IIASA and the pyam developer team'.format(year)
+author = u'pyam developer team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,8 +9,8 @@ Release v\ |version|.
 
 |joss| |doi|
 
-.. |license| image:: https://anaconda.org/conda-forge/pyam/badges/license.svg
-   :target: https://anaconda.org/conda-forge/pyam
+.. |license| image:: https://img.shields.io/badge/License-Apache%202.0-black
+   :target: https://github.com/IAMconsortium/pyam/blob/master/LICENSE
 
 .. |pypi| image:: https://img.shields.io/pypi/v/pyam-iamc.svg
    :target: https://pypi.python.org/pypi/pyam-iamc/

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -77,19 +77,23 @@ Table of Contents
    :maxdepth: 2
 
    install
+   authors
    contributing
    data
    tutorials
    examples/index
    api
 
-License
--------
+Copyright & License
+-------------------
 
 The development of the |pyam| package was started at the IIASA Energy Program,
-with contributions from a number of individuals & institutions over the years.
+with contributions from a number of `individuals & institutions`_ over the years.
+
 The package is available under the open-source `Apache License`_.
 Refer to the `NOTICE`_ in the GitHub repository for more information.
+
+.. _individuals & institutions: authors.html
 
 .. _Apache License: http://www.apache.org/licenses/LICENSE-2.0.html
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -86,9 +86,14 @@ Table of Contents
 License
 -------
 
-|pyam| is available under the open source `Apache License`_.
+The development of the |pyam| package was started at the IIASA Energy Program,
+with contributions from a number of individuals & institutions over the years.
+The package is available under the open-source `Apache License`_.
+Refer to the `NOTICE`_ in the GitHub repository for more information.
 
 .. _Apache License: http://www.apache.org/licenses/LICENSE-2.0.html
+
+.. _NOTICE: https://github.com/IAMconsortium/pyam/blob/master/NOTICE.md
 
 Scientific reference
 --------------------


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR harmonizes the copyright notice and acknowledges the contribution from (non-IIASA) contributors over the past years. The logic follows the [pandas copyright model](https://github.com/pandas-dev/pandas/blob/master/AUTHORS.md). The order follows the current GitHub contributors insights (leaving out a few persons that made non-functional changes).

The PR adds a list of authors to the GitHub repo and also includes it on the docs pages. It also switches to a slightly nicer license badge on the docs page and the readme.