### PR TITLE
Clarification of initialization-error message if file does not exist

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Next Release
 
+- [#463](https://github.com/IAMconsortium/pyam/pull/463) Clarification of initialization-error message if file does not exist
+
 # Release v0.9.0
 
 ## Highlights

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -141,15 +141,12 @@ class IamDataFrame(object):
             # read from file
             try:
                 data = Path(data)  # casting str or LocalPath to Path
-                is_file = data.is_file()
+                if data.is_file():
+                    logger.info('Reading file `{}`'.format(data))
+                    _data = read_file(data, **kwargs)
+                else:
+                    raise ValueError(f'{data} is not a file!')
             except TypeError:  # `data` cannot be cast to Path
-                is_file = False
-
-            if is_file:
-                logger.info('Reading file `{}`'.format(data))
-                _data = read_file(data, **kwargs)
-            # if not a readable file...
-            else:
                 msg = 'IamDataFrame constructor not properly called!'
                 raise ValueError(msg)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -142,10 +142,10 @@ class IamDataFrame(object):
             try:
                 data = Path(data)  # casting str or LocalPath to Path
                 if data.is_file():
-                    logger.info('Reading file `{}`'.format(data))
+                    logger.info(f'Reading file {data}')
                     _data = read_file(data, **kwargs)
                 else:
-                    raise ValueError(f'{data} is not a file!')
+                    raise FileNotFoundError(f'File {data} does not exist')
             except TypeError:  # `data` cannot be cast to Path
                 msg = 'IamDataFrame constructor not properly called!'
                 raise ValueError(msg)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -27,8 +27,8 @@ def test_unknown_type():
 
 def test_not_a_file():
     # initializing with a file-like that's not a file raises an error
-    match = 'foo.csv is not a file!'
-    with pytest.raises(ValueError, match=match):
+    match = 'File foo.csv does not exist'
+    with pytest.raises(FileNotFoundError, match=match):
         IamDataFrame('foo.csv')
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,6 +11,34 @@ from conftest import TEST_DATA_DIR
 FILTER_ARGS = dict(scenario='scen_a')
 
 
+def test_data_none():
+    # initializing with 'data=None' raises an error
+    match = 'IamDataFrame constructor not properly called!'
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame(None)
+
+
+def test_unknown_type():
+    # initializing with unsupported argument type raises an error
+    match = 'IamDataFrame constructor not properly called!'
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame(True)
+
+
+def test_not_a_file():
+    # initializing with a file-like that's not a file raises an error
+    match = 'foo.csv is not a file!'
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame('foo.csv')
+
+
+def test_io_list():
+    # initializing with a list raises an error
+    match = r'Initializing from list is not supported,*.'
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame([1, 2])
+
+
 def test_io_csv(test_df, tmpdir):
     # write to csv
     file = tmpdir / 'testing_io_write_read.csv'


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR refactor to `FileNotFoundError` when initializing an `IamDataFrame` with an argument that is file-like (str or Path) but where the file does not exist. Previously, a `ValueError: 'IamDataFrame constructor not properly called!'` was raised in these cases. This brings pyam closer to pandas behaviour. 

A `ValueError: 'IamDataFrame constructor not properly called!'` is still raised when the `data` arg is not a known type or file-like. This is now also explicitly tested.