### PR TITLE
Pin xlrd due to failing unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ REQUIREMENTS = [
     'matplotlib',
     'seaborn',
     'six',
+    'xlrd<2.0'
 ]
 
 EXTRA_REQUIREMENTS = {


### PR DESCRIPTION
Quickfix due to failure after recent xlrd release, see https://github.com/equinor/fmu-tools/issues/88 for a similar discussion and fix