### PR TITLE
Add docstrings to plotting functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - [#481](https://github.com/IAMconsortium/pyam/pull/481) Enable custom index columns
 - [#477](https://github.com/IAMconsortium/pyam/pull/477) Add a nightly test suite
+- [#476](https://github.com/IAMconsortium/pyam/pull/476) Add docstrings to plotting functions `df.plot.<kind>()`
 - [#471](https://github.com/IAMconsortium/pyam/pull/471) Add a `iiasa.Connection.properties()` function to retrieve scenario audit data
 
 # Release v0.10.0

--- a/pyam/plotting.py
+++ b/pyam/plotting.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 
 from pyam.logging import deprecation_warning
 from pyam.run_control import run_control
-from pyam import figures
+from pyam.figures import sankey
 from pyam.timeseries import cross_threshold
 from pyam.utils import META_IDX, IAMC_IDX, SORT_IDX, YEAR_IDX,\
     isstr, islistable, _raise_data_error
@@ -77,6 +77,20 @@ class PlotAccessor():
     def __init__(self, df):
         self._parent = df
 
+        # assign plotting functions as attributes
+        PLOT_MAPPING = {
+            'line': line,
+            'bar': bar,
+            'stack': stack,
+            'box': box,
+            'pie': pie,
+            'scatter': scatter,
+            'sankey': sankey
+        }
+        # inherit the docstring from the plot function
+        for name, func in PLOT_MAPPING.items():
+            getattr(self, name).__func__.__doc__ = func.__doc__
+
     def __call__(self, kind='line', *args, **kwargs):
         return getattr(self, kind)(**kwargs)
 
@@ -102,7 +116,7 @@ class PlotAccessor():
         return scatter(self._parent, *args, **kwargs)
 
     def sankey(self, *args, **kwargs):
-        return figures.sankey(self._parent, *args, **kwargs)
+        return sankey(self._parent, *args, **kwargs)
 
 
 def reset_default_props(**kwargs):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Per an offline discussion with @byersiiasa, this PR is a first attempt to add docstrings to the new `plot.<kind>` functions by inheriting them from the plotting library functions.

Any suggestions/comments? 