### PR TITLE
Add a nightly test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,54 @@
+# This workflow installs the package on Python 3.8 and runs the tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: nightly
+# This workflow is called nightly for consistency with other packages
+# even though it is scheduled to run only once per week...
+
+on:
+  push:
+    branches: [ 'master', 'devops/nightly' ]
+  pull_request:
+    branches:
+  schedule:
+      # see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
+      # 05:00 UTC = 06:00 CET = 07:00 CEST
+      - cron: "0 5 * * SUN"
+
+jobs:
+  pytest:
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        python-version:
+        - '3.8'
+
+      fail-fast: false
+
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies and package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[tests,deploy,optional-io-formats,tutorials,docs]
+
+    - name: Test with pytest (including Matplotlib)
+      run: |
+        pytest tests --mpl
+
+    - name: Build the docs
+      run: |
+        cd doc
+        make html
+        cd ..

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
-# This workflow installs the package on Python 3.8 and runs the tests
+# This workflow installs the package on Python 3.8, runs the tests and builds the docs
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: nightly
-# This workflow is called nightly for consistency with other packages
+# This workflow is called nightly for consistency with programming convention
 # even though it is scheduled to run only once per week...
 
 on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,14 +6,10 @@ name: nightly
 # even though it is scheduled to run only once per week...
 
 on:
-  push:
-    branches: [ 'master', 'devops/nightly' ]
-  pull_request:
-    branches:
   schedule:
-      # see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
-      # 05:00 UTC = 06:00 CET = 07:00 CEST
-      - cron: "0 5 * * SUN"
+    # see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
+    # 05:00 UTC = 06:00 CET = 07:00 CEST
+    - cron: "0 5 * * TUE"
 
 jobs:
   pytest:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Next Release
 
+- [#477](https://github.com/IAMconsortium/pyam/pull/477) Add a nightly test suite
+
 # Release v0.10.0
 
 ## Highlights


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a nightly test (actually executed once a week Tuesday morning in the current configuration) as a safeguard and warning against errors arising from dependency API changes.

I tested it by setting `devops/nightly` as the default branch on my fork, forked from an outdated version that I knew to have dependency conflicts with the latest pandas release. The test ran and failed as expected this morning.