### PR TITLE
Enable custom index columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#481](https://github.com/IAMconsortium/pyam/pull/481) Enable custom index columns
 - [#477](https://github.com/IAMconsortium/pyam/pull/477) Add a nightly test suite
 
 # Release v0.10.0

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 
 
 class IamDataFrame(object):
-    """Scenario timeseries data following the IAMC data format
+    """Scenario timeseries data and meta indicators
 
     The class provides a number of diagnostic features (including validation of
     data, completeness of variables provided), processing tools (e.g.,

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -152,19 +152,17 @@ class IamDataFrame(object):
                 msg = 'IamDataFrame constructor not properly called!'
                 raise ValueError(msg)
 
-        _df, self.time_col, self.extra_cols = _data
-        self._LONG_IDX = IAMC_IDX + [self.time_col] + self.extra_cols
-        # cast time_col to desired format
-        self._data = _df.set_index(self._LONG_IDX).value
+        self._data, index, self.time_col, self.extra_cols = _data
+        self._LONG_IDX = self._data.index.names
 
         # define `meta` dataframe for categorization & quantitative indicators
-        self.meta = pd.DataFrame(index=_make_index(self._data))
+        self.meta = pd.DataFrame(index=_make_index(self._data, cols=index))
         self.reset_exclude()
 
         # merge meta dataframe (if given in kwargs)
         if meta is not None:
-            self.meta = merge_meta(meta.loc[_make_index(self.data)],
-                                   self.meta, ignore_meta_conflict=True)
+            self.meta = merge_meta(meta.loc[self.meta.index], self.meta,
+                                   ignore_meta_conflict=True)
 
         # if initializing from xlsx, try to load `meta` table from file
         if meta_sheet and isinstance(data, Path) and data.suffix == '.xlsx':

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -222,17 +222,17 @@ class IamDataFrame(object):
         """
         # concatenate list of index dimensions and levels
         info = f'{type(self)}\nIndex dimensions:\n'
-        c1 = max([len(i) for i in self._LONG_IDX]) + 1
+        c1 = max([len(i) for i in self._data.index.names]) + 1
         c2 = n - c1 - 5
         info += '\n'.join(
             [f' * {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
-             for i in META_IDX])
+             for i in self.index.names])
 
         # concatenate list of index of _data (not in META_IDX)
         info += '\nTimeseries data coordinates:\n'
         info += '\n'.join(
             [f'   {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
-             for i in self._LONG_IDX if i not in META_IDX])
+             for i in self._data.index.names if i not in self.index.names])
 
         # concatenate list of (head of) meta indicators and levels/values
         def print_meta_row(m, t, lst):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -116,7 +116,8 @@ class IamDataFrame(object):
                 msg = 'Invalid arguments `{}` for initializing an IamDataFrame'
                 raise ValueError(msg.format(kwargs))
             if index != data.index.names:
-                raise ValueError(f'Index `{index}` incompatible with index in `data`:\n{data.index.names}')
+                msg = f'Index {index} incompatible with {type(data)} index '
+                raise ValueError(msg + str(data.index.names))
             for attr, value in data.__dict__.items():
                 setattr(self, attr, value)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -189,14 +189,19 @@ class IamDataFrame(object):
     def _set_attributes(self):
         """Utility function to set attributes"""
 
-        # add time domain and extra-cols as attributes
+        # add time domain as attributes
         if self.time_col == 'year':
             setattr(self, 'year', get_index_levels(self._data, 'year'))
         else:
             setattr(self, 'time', pd.Index(
                 get_index_levels(self._data, 'time')))
 
-        # set extra-cols as attributes
+        # set non-standard index columns as attributes
+        for c in self.meta.index.names:
+            if c not in META_IDX:
+                setattr(self, c, get_index_levels(self.meta, c))
+
+        # set extra data columns as attributes
         for c in self.extra_cols:
             setattr(self, c, get_index_levels(self._data, c))
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -117,8 +117,8 @@ class IamDataFrame(object):
                 msg = 'Invalid arguments {} for initializing from IamDataFrame'
                 raise ValueError(msg.format(list(kwargs)))
             if index != data.index.names:
-                msg = f'Index {index} incompatible with {type(data)} index '
-                raise ValueError(msg + str(data.index.names))
+                msg = f'Incompatible `index={index}` with {type(data)} '
+                raise ValueError(msg + f'(index={data.index.names})')
             for attr, value in data.__dict__.items():
                 setattr(self, attr, value)
         else:
@@ -131,8 +131,8 @@ class IamDataFrame(object):
 
         # if meta is given explicitly, verify that index matches
         if meta is not None and not meta.index.names == index:
-            raise ValueError(f'Incompatible `index` {index} with `meta` index '
-                             + str(meta.index.names))
+            raise ValueError(f'Incompatible `index={index}` with `meta` '
+                             f'(index={meta.index.names})!')
 
         # cast data from pandas
         if isinstance(data, pd.DataFrame) or isinstance(data, pd.Series):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -116,7 +116,7 @@ class IamDataFrame(object):
                 msg = 'Invalid arguments `{}` for initializing an IamDataFrame'
                 raise ValueError(msg.format(kwargs))
             if index != data.index.names:
-                raise ValueError(f'Index {index} incompatible with:\n{data}')
+                raise ValueError(f'Index `{index}` incompatible with index in `data`:\n{data.index.names}')
             for attr, value in data.__dict__.items():
                 setattr(self, attr, value)
         else:
@@ -299,7 +299,7 @@ class IamDataFrame(object):
         if name in self.meta.index.names:
             return get_index_levels(self.meta, name)
         # in case of non-standard meta.index.names
-        raise AttributeError(f'Index `{name}` does not exist!')
+        raise KeyError(f'Index `{name}` does not exist!')
 
     @property
     def region(self):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -78,6 +78,8 @@ class IamDataFrame(object):
     meta : :class:`pandas.DataFrame`, optional
         A dataframe with suitable 'meta' indicators for the new instance.
         The index will be downselected to scenarios present in `data`.
+    index : list, optional
+        Columns to use for resulting IamDataFrame index.
     kwargs
         If `value=<col>`, melt column `<col>` to 'value' and use `<col>` name
         as 'variable'; or mapping of required columns (:code:`IAMC_IDX`) to
@@ -107,16 +109,18 @@ class IamDataFrame(object):
     This is intended behaviour and consistent with pandas but may be confusing
     for those who are not used to the pandas/Python universe.
     """
-    def __init__(self, data, meta=None, **kwargs):
+    def __init__(self, data, meta=None, index=['model', 'scenario'], **kwargs):
         """Initialize an instance of an IamDataFrame"""
         if isinstance(data, IamDataFrame):
             if kwargs:
                 msg = 'Invalid arguments `{}` for initializing an IamDataFrame'
                 raise ValueError(msg.format(kwargs))
+            if index != data.index.names:
+                raise ValueError(f'Index {index} incompatible with:\n{data}')
             for attr, value in data.__dict__.items():
                 setattr(self, attr, value)
         else:
-            self._init(data, meta, **kwargs)
+            self._init(data, meta, index=index, **kwargs)
 
     def _init(self, data, meta=None, **kwargs):
         """Process data and set attributes for new instance"""

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -287,12 +287,19 @@ class IamDataFrame(object):
     @property
     def model(self):
         """Return the list of (unique) model names"""
-        return get_index_levels(self.meta, 'model')
+        return self._get_meta_index_levels('model')
 
     @property
     def scenario(self):
         """Return the list of (unique) scenario names"""
-        return get_index_levels(self.meta, 'scenario')
+        return self._get_meta_index_levels('scenario')
+
+    def _get_meta_index_levels(self, name):
+        """Return the list of a level from meta"""
+        if name in self.meta.index.names:
+            return get_index_levels(self.meta, name)
+        # in case of non-standard meta.index.names
+        raise AttributeError(f'Index `{name}` does not exist!')
 
     @property
     def region(self):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -634,6 +634,7 @@ class IamDataFrame(object):
         ret._data = _data.set_index(ret._LONG_IDX)
         ret.time_col = 'year'
         ret._set_attributes()
+        delattr(self, 'time')
 
         if not inplace:
             return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -160,10 +160,10 @@ class IamDataFrame(object):
         self.meta = pd.DataFrame(index=_make_index(self._data, cols=index))
         self.reset_exclude()
 
-        # merge meta dataframe (if given in kwargs)
+        # if given explicitly, merge meta dataframe after downselecting
         if meta is not None:
-            self.meta = merge_meta(meta.loc[self.meta.index], self.meta,
-                                   ignore_meta_conflict=True)
+            meta = meta.loc[self.meta.index.intersection(meta.index)]
+            self.meta = merge_meta(meta, self.meta, ignore_meta_conflict=True)
 
         # if initializing from xlsx, try to load `meta` table from file
         if meta_sheet and isinstance(data, Path) and data.suffix == '.xlsx':

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -177,14 +177,7 @@ class IamDataFrame(object):
             if meta_sheet in excel_file.sheet_names:
                 self.load_meta(excel_file, sheet_name=meta_sheet)
 
-        # add time domain and extra-cols as attributes
-        if self.time_col == 'year':
-            setattr(self, 'year', get_index_levels(self._data, 'year'))
-        else:
-            setattr(self, 'time', pd.Index(
-                get_index_levels(self._data, 'time')))
-        for c in self.extra_cols:
-            setattr(self, c, get_index_levels(self._data, c))
+        self._set_attributes()
 
         # execute user-defined code
         if 'exec' in run_control():
@@ -192,6 +185,20 @@ class IamDataFrame(object):
 
         # add the `plot` handler
         self.plot = PlotAccessor(self)
+
+    def _set_attributes(self):
+        """Utility function to set attributes"""
+
+        # add time domain and extra-cols as attributes
+        if self.time_col == 'year':
+            setattr(self, 'year', get_index_levels(self._data, 'year'))
+        else:
+            setattr(self, 'time', pd.Index(
+                get_index_levels(self._data, 'time')))
+
+        # set extra-cols as attributes
+        for c in self.extra_cols:
+            setattr(self, c, get_index_levels(self._data, c))
 
     def __getitem__(self, key):
         _key_check = [key] if isstr(key) else key

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -346,6 +346,9 @@ class IamDataFrame(object):
     @data.setter
     def data(self, df):
         """Set the timeseries data from a long :class:`pandas.DataFrame`"""
+        logger.warning('Setting `data` via the setter can cause'
+                       'inconsistencies with `meta` and other attributes.')
+        deprecation_warning('Please use `IamDataFrame(<data>)` instead!')
         self._data = format_time_col(df, self.time_col)\
             .set_index(self._LONG_IDX).value
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -630,14 +630,14 @@ class IamDataFrame(object):
         rows = _data[_index].duplicated()
         if any(rows):
             error_msg = 'Swapping time for year causes duplicates in `data`'
-            _raise_data_error(error_msg, _data.loc[rows, ret._LONG_IDX])
+            _raise_data_error(error_msg, _data[_index])
 
         # assign data and other attributes
         ret._LONG_IDX = _index
         ret._data = _data.set_index(ret._LONG_IDX)
         ret.time_col = 'year'
         ret._set_attributes()
-        delattr(self, 'time')
+        delattr(ret, 'time')
 
         if not inplace:
             return ret

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -20,6 +20,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # common indices
+DEFAULT_META_INDEX = ['model', 'scenario']
 META_IDX = ['model', 'scenario']
 YEAR_IDX = ['model', 'scenario', 'region', 'year']
 IAMC_IDX = ['model', 'scenario', 'region', 'variable', 'unit']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -129,9 +129,10 @@ def test_init_df_with_meta_incompatible_index(test_pd_df):
                         index=META_DF.index.rename(index))
 
     # assert that using an incompatible index for the meta arg raises
-    match = "Incompatible `index` \['model', 'scenario'\] with `meta` index *."
+    match = "Incompatible `index=\['model', 'scenario'\]` with `meta` *."
     with pytest.raises(ValueError, match=match):
         IamDataFrame(test_pd_df, meta=meta)
+
 
 def test_init_df_with_custom_index(test_pd_df):
     # rename 'model' column and add a version column to the dataframe

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -60,10 +60,9 @@ def test_init_from_iamdf(test_df_year):
 
 def test_init_from_iamdf_raises(test_df_year):
     # casting an IamDataFrame instance again with extra args fails
-    args = dict(model='foo')
     match = "Invalid arguments \['model'\] for initializing from IamDataFrame"
     with pytest.raises(ValueError, match=match):
-        IamDataFrame(test_df_year, **args)
+        IamDataFrame(test_df_year, model='foo')
 
 
 def test_init_df_with_float_cols_raises(test_pd_df):
@@ -104,9 +103,6 @@ def test_init_df_with_extra_col(test_pd_df):
     tdf[extra_col] = extra_value
 
     df = IamDataFrame(tdf)
-
-    # check that extra-cols attribute is set correctly
-    assert df.extra_cols == [extra_col]
 
     # check that timeseries data is as expected
     obs = df.timeseries().reset_index()
@@ -290,7 +286,7 @@ def test_index(test_df_year):
 
 
 def test_index_attributes(test_df):
-    # assert that the
+    # assert that the index and data column attributes are set correcty
     assert test_df.model == ['model_a']
     assert test_df.scenario == ['scen_a', 'scen_b']
     assert test_df.region == ['World']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,6 +122,17 @@ def test_init_df_with_meta(test_pd_df):
     pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
 
 
+def test_init_df_with_custom_index(test_pd_df):
+    # rename 'model' column and add a version column to the dataframe
+    test_pd_df.rename(columns={'model': 'source'}, inplace=True)
+    test_pd_df['version'] = [1, 2, 3]
+
+    # initialize with custom index columns, check that index is set correctly
+    index = ['source', 'scenario', 'version']
+    df = IamDataFrame(test_pd_df, index=index)
+    assert df.index.names == index
+
+
 def test_init_empty_message(caplog):
     IamDataFrame(data=df_empty)
     drop_message = (

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1006,10 +1006,12 @@ def test_swap_time_to_year(test_df, inplace):
 
     if inplace:
         assert obs is None
-        assert compare(test_df, exp).empty
-    else:
-        assert compare(obs, exp).empty
-        assert "year" not in test_df.data.columns
+        obs = test_df
+
+    assert compare(obs, exp).empty
+    assert obs.year == [2005, 2010]
+    with pytest.raises(AttributeError):
+        obs.time
 
 
 @pytest.mark.parametrize("inplace", [True, False])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,7 +61,7 @@ def test_init_from_iamdf(test_df_year):
 def test_init_from_iamdf_raises(test_df_year):
     # casting an IamDataFrame instance again with extra args fails
     args = dict(model='foo')
-    match = f'Invalid arguments `{args}` for initializing an IamDataFrame'
+    match = "Invalid arguments \['model'\] for initializing from IamDataFrame"
     with pytest.raises(ValueError, match=match):
         IamDataFrame(test_df_year, **args)
 
@@ -121,6 +121,17 @@ def test_init_df_with_meta(test_pd_df):
     # check that scenario not existing in data is removed during initialization
     pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
 
+
+def test_init_df_with_meta_incompatible_index(test_pd_df):
+    # define a meta dataframe with a non-standard index
+    index = ['source', 'scenario']
+    meta = pd.DataFrame([False, False, False], columns=['exclude'],
+                        index=META_DF.index.rename(index))
+
+    # assert that using an incompatible index for the meta arg raises
+    match = "Incompatible `index` \['model', 'scenario'\] with `meta` index *."
+    with pytest.raises(ValueError, match=match):
+        IamDataFrame(test_pd_df, meta=meta)
 
 def test_init_df_with_custom_index(test_pd_df):
     # rename 'model' column and add a version column to the dataframe

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,6 +28,14 @@ df_filter_by_meta_nonmatching_idx = pd.DataFrame([
 ], columns=['model', 'scenario', 'region', 2010, 2020]
 ).set_index(['model', 'region'])
 
+META_DF = pd.DataFrame([
+    ['model_a', 'scen_a', 1, False],
+    ['model_a', 'scen_b', np.nan, False],
+    ['model_a', 'scen_c', 2, False],
+], columns=META_IDX + ['foo', 'exclude']
+).set_index(META_IDX)
+
+
 df_empty = pd.DataFrame([], columns=IAMC_IDX + [2005, 2010])
 
 
@@ -104,6 +112,14 @@ def test_init_df_with_extra_col(test_pd_df):
     obs = df.timeseries().reset_index()
     exp = tdf[obs.columns]  # get the columns into the right order
     pd.testing.assert_frame_equal(obs, exp)
+
+
+def test_init_df_with_meta(test_pd_df):
+    # pass explicit meta dataframe with a scenario that doesn't exist in data
+    df = IamDataFrame(test_pd_df, meta=META_DF.iloc[[0, 2]][['foo']])
+
+    # check that scenario not existing in data is removed during initialization
+    pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
 
 
 def test_init_empty_message(caplog):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -144,6 +144,12 @@ def test_init_df_with_custom_index(test_pd_df):
     df = IamDataFrame(test_pd_df, index=index)
     assert df.index.names == index
 
+    # check that index attributes were set correctly and that df.model fails
+    assert df.source == ['model_a']
+    assert df.version == [1, 2, 3]
+    with pytest.raises(KeyError, match='Index `model` does not exist!'):
+        df.model
+
 
 def test_init_empty_message(caplog):
     IamDataFrame(data=df_empty)

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -109,6 +109,8 @@ def test_append_extra_col(test_df, shuffle_cols):
     other_data = base_data[base_data["variable"] == "Primary Energy"].copy()
     other_data["variable"] = "Primary Energy|Gas"
     other_df = IamDataFrame(other_data)
+    # cast from FrozenList to list for test
+    other_df._LONG_IDX = list(other_df._LONG_IDX)
 
     if shuffle_cols:
         c1_idx = other_df._LONG_IDX.index("col_1")


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Per discussions with related energy modelling projects (in particular OpenEnergyPlatform, SENTINEL), it became obvious that the restriction of the IAMC format to use `['model', 'scenario']` as the index (ie the organizing structure of timeseries data) is a limitation of the current package implementation.

Two specific examples:
 - The OpenEnergyPlatform is discussing a data model indexed on `['source', 'scenario']` to highlight that not all data are derived from models but can also come from *reference sources* <sup>[[citation needed]]()</sup>
 - When reading multiple versions of a model/scenario from an IIASA database, the API returns the index `['model', 'scenario', 'version]`, which can currently not be processed by pyam.

This PR extends the IamDataFrame class to accept an `index` argument such that timeseries data following the two examples above (or other index columns) can be handled by pyam. This PR is intended for discussion and as a first step to full-fledged support - only the initialization and `IamDataFrame.info()` are known to work at this point.

See this example below for an illustration

```python
import pandas as pd
import pyam

TEST_DF = pd.DataFrame([
    ['model_a', 'scen_a', 1, 'World', 'Primary Energy', 'EJ/yr', 1, 6.],
    ['model_a', 'scen_a', 2, 'World', 'Primary Energy|Coal', 'EJ/yr', 0.5, 3],
    ['model_a', 'scen_b', 3, 'World', 'Primary Energy', 'EJ/yr', 2, 7],
],
    columns=['source', 'scenario', 'version', 'region', 'variable', 'unit'] + [2005, 2010],
)

df = pyam.IamDataFrame(TEST_DF, index=['source', 'scenario', 'version'])
df.info()
```

This PR also solves an problem with the dynamically created attributes like `d.year` or `df.time`, closes #485 