### PR TITLE
Bugfix for GH Action failing to build the docs due to pandoc

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,12 +6,10 @@ name: nightly
 # even though it is scheduled to run only once per week...
 
 on:
-#  schedule:
+  schedule:
     # see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
     # 05:00 UTC = 06:00 CET = 07:00 CEST
-#    - cron: "0 5 * * TUE"
-  pull_request:
-    branches: [ '**' ]
+    - cron: "0 5 * * TUE"
 
 jobs:
   pytest:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,10 +6,12 @@ name: nightly
 # even though it is scheduled to run only once per week...
 
 on:
-  schedule:
+#  schedule:
     # see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
     # 05:00 UTC = 06:00 CET = 07:00 CEST
-    - cron: "0 5 * * TUE"
+#    - cron: "0 5 * * TUE"
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   pytest:
@@ -33,6 +35,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install Pandoc
+      uses: r-lib/actions/setup-pandoc@v1
 
     - name: Install dependencies and package
       run: |

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ EXTRA_REQUIREMENTS = {
     'docs': ['sphinx', 'nbsphinx', 'sphinx-gallery', 'cloud_sptheme', 'pillow',
              'sphinxcontrib-bibtex<2.0', 'sphinxcontrib-programoutput',
              'numpydoc', 'openpyxl', 'kaleido']  # docs requires 'tutorials'
+    # GitHub Actions requires pandoc explicitly to build the docs
 }
 
 # building the docs on readthedocs fails with a FileNotFoundError


### PR DESCRIPTION
For some (unknown) reason, GitHub Actions now requires `pandoc` explicitly to build the docs. this PR adds a note to the setup instructions and adds `pandoc` to the `nightly` workflow.