### PR TITLE
Read all sheets starting with `data` when reading from xlsx

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Next Release
 
+## API changes
+
+PR [#488](https://github.com/IAMconsortium/pyam/pull/488) changes the default
+behavior when initializing an IamDataFrame from xlsx: now, all sheets names
+starting with `data` will be parsed for timeseries data.
+
+## Individual updates
+
+- [#488](https://github.com/IAMconsortium/pyam/pull/488) Read all sheets starting with `data` when reading from xlsx
 - [#481](https://github.com/IAMconsortium/pyam/pull/481) Enable custom index columns
 - [#477](https://github.com/IAMconsortium/pyam/pull/477) Add a nightly test suite
 - [#476](https://github.com/IAMconsortium/pyam/pull/476) Add docstrings to plotting functions `df.plot.<kind>()`

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -98,9 +98,10 @@ class IamDataFrame(object):
     R-style integer column headers (i.e., `X2015`) are acceptable.
 
     When initializing an :class:`IamDataFrame` from an xlsx file,
-    |pyam| will per default look for the sheets 'data' and 'meta' to
-    populate the respective tables. Custom sheet names can be specified with
-    kwargs :code:`sheet_name` ('data') and :code:`meta_sheet_name` ('meta').
+    |pyam| will per default parse all sheets starting with 'data'
+    for timeseries and a sheet 'meta' to populate the respective table.
+    Custom sheet names can be specified with kwargs :code:`sheet_name` ('data')
+    and :code:`meta_sheet_name` ('meta').
     Calling the class with :code:`meta_sheet_name=False` will
     skip the import of the 'meta' table.
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1722,16 +1722,18 @@ class IamDataFrame(object):
         # return the package (needs to reloaded because `tmp` was deleted)
         return Package(path)
 
-    def load_meta(self, path, *args, **kwargs):
+    def load_meta(self, path, sheet_name='meta', *args, **kwargs):
         """Load 'meta' indicators from file
 
         Parameters
         ----------
         path : str or path object
-            any valid string path or :class:`pathlib.Path`
+            Any valid string path or :class:`pathlib.Path`
+        sheet_name : str, optional
+            Name of the sheet to be parsed
         """
         # load from file
-        df = read_pandas(Path(path), *args, **kwargs)
+        df = read_pandas(Path(path), sheet_name=sheet_name, *args, **kwargs)
 
         # cast model-scenario column headers to lower-case (if necessary)
         df = df.rename(columns=dict([(i.capitalize(), i) for i in META_IDX]))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1681,9 +1681,9 @@ class IamDataFrame(object):
         sheet_name : str
             name of sheet which will contain dataframe of 'meta' indicators
         """
+        close = False
         if not isinstance(excel_writer, pd.ExcelWriter):
-            close = True
-            excel_writer = pd.ExcelWriter(excel_writer)
+            excel_writer, close = pd.ExcelWriter(excel_writer), True
         write_sheet(excel_writer, sheet_name, self.meta, index=True)
         if close:
             excel_writer.close()

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1731,7 +1731,7 @@ class IamDataFrame(object):
             any valid string path or :class:`pathlib.Path`
         """
         # load from file
-        df = read_pandas(Path(path), default_sheet='meta', *args, **kwargs)
+        df = read_pandas(Path(path), *args, **kwargs)
 
         # cast model-scenario column headers to lower-case (if necessary)
         df = df.rename(columns=dict([(i.capitalize(), i) for i in META_IDX]))

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -111,7 +111,7 @@ def write_sheet(writer, name, df, index=False):
             pass
 
 
-def read_pandas(path, default_sheet_name='data*', *args, **kwargs):
+def read_pandas(path, sheet_name='data*', *args, **kwargs):
     """Read a file and return a pandas.DataFrame"""
     if isinstance(path, Path) and path.suffix == '.csv':
         df = pd.read_csv(path, *args, **kwargs)
@@ -119,7 +119,7 @@ def read_pandas(path, default_sheet_name='data*', *args, **kwargs):
         xl = pd.ExcelFile(path)
         sheet_names = pd.Series(xl.sheet_names)
         if len(sheet_names) > 1:
-            sheets = kwargs.pop('sheet_name', default_sheet_name)
+            sheets = kwargs.pop('sheet_name', sheet_name)
             # apply pattern-matching for sheet names (use * as wildcard)
             sheets = sheet_names[pattern_match(sheet_names, values=sheets)]
             df = pd.concat([xl.parse(s, *args, **kwargs) for s in sheets])


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR allows reading multiple sheets when initializing an IamDataFrame from an xlsx file. It also changes the default such that all sheets starting with 'data' (including a sheet called 'data' ) will be read.

This PR pulls a feature from the ixmp-server processing workflow to the (public) pyam feature list.

closes #479
