### PR TITLE
Fix stale Codecov integration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,0 @@
-coverage:
-  precision: 1
-  status:
-    project:
-      default:
-        threshold: 0.2%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  precision: 1
+  status:
+    project:
+      default:
+        threshold: 0.2%

--- a/.github/workflows/pytest_38.yml
+++ b/.github/workflows/pytest_38.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Upload coverage report to Codecov
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: codecov/codecov-action@v1.0.7
+      uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
         env_vars: ${{ matrix.os }} py${{ matrix.python-version }}


### PR DESCRIPTION
# Description of PR

For some reason, reports were not uploaded to Codecov for a few months. This PR resets the codecov-GitHub-Actions module version to 1, which seems to fix that issue.