### PR TITLE
Quickfix for World Bank data update

### DIFF
--- a/pyam/testing.py
+++ b/pyam/testing.py
@@ -3,10 +3,9 @@ import pandas.testing as pdt
 
 
 def assert_iamframe_equal(a, b, **assert_kwargs):
-    diff = compare(a, b)
+    diff = compare(a, b, **assert_kwargs)
     if not diff.empty:
         msg = 'IamDataFrame.data are different: \n {}'
         raise AssertionError(msg.format(diff.head()))
 
-    pdt.assert_frame_equal(a.meta, b.meta, check_dtype=False, check_like=True,
-                           **assert_kwargs)
+    pdt.assert_frame_equal(a.meta, b.meta, check_dtype=False, check_like=True)

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -15,7 +15,7 @@ except ConnectionError:
 WB_REASON = 'World Bank API unavailable'
 
 WB_DF = pd.DataFrame([
-    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39356.9,	40517.5, 42141.8],
+    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39356.9, 40517.5, 42141.8],
     ['foo', 'WDI', 'Mexico', 'GDP', 'n/a', 17262.3, 17693.0, 17846.0],
     ['foo', 'WDI', 'United States', 'GDP', 'n/a', 51569.8, 53035.7, 54395.4]
 ], columns=IAMC_IDX + [2003, 2004, 2005])
@@ -25,5 +25,5 @@ WB_DF = pd.DataFrame([
 def test_worldbank():
     obs = read_worldbank(model='foo', indicator={'NY.GDP.PCAP.PP.KD': 'GDP'})
     exp = IamDataFrame(WB_DF)
-    # test data with 1% relative tolerance to guard against minor data changes
-    assert_iamframe_equal(obs, exp, rtol=1.0e-2)
+    # test data with 5% relative tolerance to guard against minor data changes
+    assert_iamframe_equal(obs, exp, rtol=5.0e-2)

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -25,4 +25,5 @@ WB_DF = pd.DataFrame([
 def test_worldbank():
     obs = read_worldbank(model='foo', indicator={'NY.GDP.PCAP.PP.KD': 'GDP'})
     exp = IamDataFrame(WB_DF)
-    assert_iamframe_equal(obs, exp)
+    # test data with 1% relative tolerance to guard against minor data changes
+    assert_iamframe_equal(obs, exp, rtol=1.0e-2)

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -15,8 +15,8 @@ except ConnectionError:
 WB_REASON = 'World Bank API unavailable'
 
 WB_DF = pd.DataFrame([
-    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39473.4, 40637.4, 42266.5],
-    ['foo', 'WDI', 'Mexico', 'GDP', 'n/a', 17288.6, 17720.0, 17874.0],
+    ['foo', 'WDI', 'Canada', 'GDP', 'n/a', 39356.9,	40517.5, 42141.8],
+    ['foo', 'WDI', 'Mexico', 'GDP', 'n/a', 17262.3, 17693.0, 17846.0],
     ['foo', 'WDI', 'United States', 'GDP', 'n/a', 51569.8, 53035.7, 54395.4]
 ], columns=IAMC_IDX + [2003, 2004, 2005])
 


### PR DESCRIPTION
Quickfix due to failure after update in the World Bank database, and reducing the tolerance of this test to guard against future data updates.