### PR TITLE
Make duplicate index exceptions more descriptive

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -479,12 +479,12 @@ class IamDataFrame(object):
         ----------
         other : IamDataFrame, ixmp.Scenario, pandas.DataFrame or data file
             Any object castable as IamDataFrame to be appended
-        ignore_meta_conflict : bool, default False
+        ignore_meta_conflict : bool, optional
             If False and `other` is an IamDataFrame, raise an error if
             any meta columns present in `self` and `other` are not identical.
-        inplace : bool, default False
+        inplace : bool, optional
             If True, do operation inplace and return None
-        verify_integrity : bool, default True
+        verify_integrity : bool, optional
             If True, verify integrity of index
         kwargs
             Passed to :class:`IamDataFrame(other, **kwargs) <IamDataFrame>`

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import numpy as np
 
+from .utils import print_list
+
 
 def get_index_levels(index, level):
     """Return the category-values for a specific level"""
@@ -47,3 +49,28 @@ def append_index_level(index, codes, level, name, order=False):
     if order:
         new_index = new_index.reorder_levels(order)
     return new_index
+
+
+def verify_index_integrity(df):
+    """Verify integrity of index
+
+    Arguments
+    ---------
+    df : Union[pd.DataFrame, pd.Series, pd.Index]
+
+    Raises
+    ------
+    ValueError
+    """
+    index = df if isinstance(df, pd.Index) else df.index
+    if not index.is_unique:
+        overlap = index[index.duplicated()].unique()
+
+        n = 80
+        c1 = max([len(i) for i in overlap]) + 1
+        c2 = n - c1 - 5
+        summary = "\n".join(
+            f" * {i:{c1}}: {print_list(get_index_levels(overlap, i), c2)}"
+            for i in overlap.names
+        )
+        raise ValueError(f"Indexes have overlapping values:\n{summary}")

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-from .utils import print_list
+from .utils import _raise_data_error
 
 
 def get_index_levels(index, level):
@@ -66,11 +66,4 @@ def verify_index_integrity(df):
     if not index.is_unique:
         overlap = index[index.duplicated()].unique()
 
-        n = 80
-        c1 = max([len(i) for i in overlap]) + 1
-        c2 = n - c1 - 5
-        summary = "\n".join(
-            f" * {i:{c1}}: {print_list(get_index_levels(overlap, i), c2)}"
-            for i in overlap.names
-        )
-        raise ValueError(f"Indexes have overlapping values:\n{summary}")
+        _raise_data_error("Timeseries data has overlapping values", overlap.to_frame(index=False))

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -66,4 +66,6 @@ def verify_index_integrity(df):
     if not index.is_unique:
         overlap = index[index.duplicated()].unique()
 
-        _raise_data_error("Timeseries data has overlapping values", overlap.to_frame(index=False))
+        _raise_data_error(
+            "Timeseries data has overlapping values", overlap.to_frame(index=False)
+        )

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -148,7 +148,7 @@ def test_append_extra_col(test_df, shuffle_cols):
 def test_append_duplicates_raises(test_df_year, inplace):
     # Merging objects with overlapping values (merge conflict) raises an error
     other = copy.deepcopy(test_df_year)
-    with pytest.raises(ValueError, match="Indexes have overlapping values:"):
+    with pytest.raises(ValueError, match="Timeseries data has overlapping values:"):
         test_df_year.append(other=other, inplace=inplace)
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~ -> no new behavior
- ~Documentation Added~ -> no changes
- ~Name of contributors Added to AUTHORS.rst~
- ~Description in RELEASE_NOTES.md Added~ -> I'd say not noteworthy enough! objections?

# Description of PR

`IamDataFrame.append` and (by transitivity) `pyam.concat` defaulted to using `pd.Series.append`'s `verify_integrity`, which lists only the first 3 levels of the overlapping multi-index.

This PR re-uses the index summary part of the `info` representation to give a high-level overview of the conflicts.

## Synthetic example

```python
df.append(df.filter(variable="Primary_Energy|Biomass", region=["DEU", "USA"]))
```

### Previous behaviour
```
[ ... 8-level stacktrace ... ]
ValueError: Indexes have overlapping values: MultiIndex([(       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            (       'PAC',             'PAC', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...),
            ('REMIND_1.7', 'CEMICS-1.5-CDR8', 'DEU', ...)],
           names=['model', 'scenario', 'region', 'variable', 'unit', 'year'])
```

## New behaviour
```
pyam.utils - ERROR: Timeseries data have overlapping values:
   model          scenario region                variable     unit  year
0  IMAGE  SSP1-19-SPA1-V17    DEU  Primary_Energy|Biomass  EJ / yr  2017
1  IMAGE  SSP1-19-SPA1-V17    DEU  Primary_Energy|Biomass  EJ / yr  2020
2  IMAGE  SSP1-19-SPA1-V17    DEU  Primary_Energy|Biomass  EJ / yr  2025
3  IMAGE  SSP1-19-SPA1-V17    DEU  Primary_Energy|Biomass  EJ / yr  2030
4  IMAGE  SSP1-19-SPA1-V17    DEU  Primary_Energy|Biomass  EJ / yr  2035
```