### PR TITLE
Reactivate flake8 on stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,3 +1,8 @@
 ---
 linters:
     black:
+    flake8:
+        python: 3
+        ignore: I002, F403, E402, E731, W503, W605
+        max-line-length: 88
+        max-complexity: 20

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -8,6 +8,8 @@ import sys
 import numpy as np
 import pandas as pd
 
+import yaml  # this is a test to try out how flake8 versus black behave on stickler just because
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -8,8 +8,6 @@ import sys
 import numpy as np
 import pandas as pd
 
-import yaml  # this is a test to try out how flake8 versus black behave on stickler just because
-
 from pathlib import Path
 from tempfile import TemporaryDirectory
 


### PR DESCRIPTION
# Description of PR

I realized that Black does not guard against all pep8 issues, so this PR reinserts running flake8 on stickler.
