### PR TITLE
Fix iterable regression in concat introduced by #510

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2340,17 +2340,20 @@ def concat(dfs, ignore_meta_conflict=False, **kwargs):
             f"you passed an object of type '{dfs.__class__.__name__}'!"
         )
 
-    dfs_iter = iter(dfs)
+    dfs = list(dfs)
+
+    if len(dfs) < 1:
+        raise ValueError("No objects to concatenate")
 
     # cast to IamDataFrame if necessary
     def as_iamdataframe(df):
         return df if isinstance(df, IamDataFrame) else IamDataFrame(df, **kwargs)
 
-    df = as_iamdataframe(next(dfs_iter))
+    df = as_iamdataframe(dfs[0])
     ret_data, ret_meta = [df._data], df.meta
     index, time_col = df._data.index.names, df.time_col
 
-    for df in dfs_iter:
+    for df in dfs[1:]:
         # skip merging meta if element is a pd.DataFrame
         _meta_merge = not isinstance(df, pd.DataFrame)
         df = as_iamdataframe(df)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2315,7 +2315,7 @@ def concat(dfs, ignore_meta_conflict=False, **kwargs):
     Parameters
     ----------
     dfs : iterable of IamDataFrames
-        A list of :class:`IamDataFrame` instances
+        A list of objects castable to :class:`IamDataFrame`
     ignore_meta_conflict : bool, default False
         If False, raise an error if any meta columns present in `dfs` are not identical.
         If True, values in earlier elements of `dfs` take precendence.


### PR DESCRIPTION
Before #510, `concat` transparently accepted an iterable of `IamDataFrame`s, but the introduction of the subscripts `dfs[0]` and `dfs[1:]` broke this behaviour.

Examples of such iterables would be anything produced by `map(_do_something, dfs)` or `filter`.

~Here we explicitly cast to iterable using `iter` to work with iterables.~

Here we explicitly cast to list for readibility.