### PR TITLE
Allow numpy int in interpolate

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,6 +3,6 @@ linters:
     black:
     flake8:
         python: 3
-        ignore: I002, F403, E402, E731, W503, W605
+        ignore: I002, F403, E203, E402, E731, W503, W605
         max-line-length: 88
         max-complexity: 20

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -607,7 +607,7 @@ class IamDataFrame(object):
             raise ValueError(f"The `time` argument {time} contains non-integers")
 
         old_cols = list(ret[ret.time_col].unique())
-        columns = np.sort(np.unique(old_cols + time))
+        columns = np.unique(np.concatenate([old_cols, time]))
 
         # calculate a separate dataframe with full interpolation
         df = ret.timeseries()

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -7,6 +7,7 @@ import sys
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_integer
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -602,7 +603,7 @@ class IamDataFrame(object):
         # could enforce as we do for year below
         if self.time_col == "time":
             time = list(map(np.datetime64, time))
-        elif not all(isinstance(x, (int, np.integer)) for x in time):
+        elif not all(is_integer(x) for x in time):
             raise ValueError(f"The `time` argument {time} contains non-integers")
 
         old_cols = list(ret[ret.time_col].unique())

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -42,6 +42,7 @@ from pyam.utils import (
     hour_match,
     day_match,
     datetime_match,
+    to_list,
     isstr,
     islistable,
     print_list,
@@ -596,12 +597,12 @@ class IamDataFrame(object):
         ret = self.copy() if not inplace else self
         interp_kwargs = dict(method="slinear", axis=1)
         interp_kwargs.update(kwargs)
-        time = list(time) if islistable(time) else [time]
+        time = to_list(time)
         # TODO - have to explicitly cast to numpy datetime to sort later,
         # could enforce as we do for year below
         if self.time_col == "time":
             time = list(map(np.datetime64, time))
-        elif not all(isinstance(x, int) for x in time):
+        elif not all(isinstance(x, (int, np.integer)) for x in time):
             raise ValueError(f"The `time` argument {time} contains non-integers")
 
         old_cols = list(ret[ret.time_col].unique())

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -518,9 +518,8 @@ def _escape_regexp(s):
 
 def years_match(data, years):
     """Return rows where data matches year"""
-    years = [years] if (isinstance(years, (int, np.int64))) else years
-    dt = (datetime.datetime, np.datetime64)
-    if isinstance(years, dt) or isinstance(years[0], dt):
+    years = to_list(years)
+    if isinstance(years[0], (datetime.datetime, np.datetime64)):
         error_msg = "Filter by `year` requires integers!"
         raise TypeError(error_msg)
     return np.isin(data, years)
@@ -538,7 +537,7 @@ def day_match(data, days):
 
 def hour_match(data, hours):
     """Return rows where data matches hours"""
-    hours = [hours] if isinstance(hours, int) else hours
+    hours = to_list(hours)
     return np.isin(data, hours)
 
 
@@ -561,7 +560,7 @@ def time_match(data, times, conv_codes, strptime_attr, name):
         except NameError:
             raise ValueError("Could not convert {} to integer".format(name))
 
-    times = [times] if isinstance(times, (int, str)) else times
+    times = to_list(times)
     if isinstance(times[0], str):
         to_delete = []
         to_append = []
@@ -590,8 +589,8 @@ def time_match(data, times, conv_codes, strptime_attr, name):
 
 def datetime_match(data, dts):
     """Matching of datetimes in time columns for data filtering"""
-    dts = dts if islistable(dts) else [dts]
-    if any([not (isinstance(i, (datetime.datetime, np.datetime64))) for i in dts]):
+    dts = to_list(dts)
+    if not all(isinstance(i, (datetime.datetime, np.datetime64)) for i in dts):
         error_msg = "`time` can only be filtered by datetimes and datetime64s"
         raise TypeError(error_msg)
     return data.isin(dts).values

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -744,6 +744,13 @@ def test_interpolate_with_list(test_df_year):
     npt.assert_allclose(obs, [3, 4, 1.5, 2, 4, 5])
 
 
+def test_interpolate_with_numpy_list(test_df_year):
+    test_df_year.interpolate(np.r_[2007 : 2008 + 1], inplace=True)
+    obs = test_df_year.filter(year=[2007, 2008])._data.reset_index(drop=True)
+    exp = pd.Series([3, 4, 1.5, 2, 4, 5], name="value")
+    pd.testing.assert_series_equal(obs, exp)
+
+
 def test_interpolate_full_example():
     cols = ["model_a", "scen_a", "World"]
     df = IamDataFrame(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -746,9 +746,8 @@ def test_interpolate_with_list(test_df_year):
 
 def test_interpolate_with_numpy_list(test_df_year):
     test_df_year.interpolate(np.r_[2007 : 2008 + 1], inplace=True)
-    obs = test_df_year.filter(year=[2007, 2008])._data.reset_index(drop=True)
-    exp = pd.Series([3, 4, 1.5, 2, 4, 5], name="value")
-    pd.testing.assert_series_equal(obs, exp)
+    obs = test_df_year.filter(year=[2007, 2008])._data.values
+    npt.assert_allclose(obs, [3, 4, 1.5, 2, 4, 5])
 
 
 def test_interpolate_full_example():


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [ ] ~Documentation Added~
- [x] Name of contributors Added to AUTHORS.rst
- [ ] ~Description in RELEASE_NOTES.md Added~

# Description of PR

Numpy has its own integer types. Here we added `np.integer` as allowed type to several integerness tests especially for years.

Enables the use of helpful constructs like:
```
df.interpolate(np.r_[2020:2030, 2030:2100:5])
```

Also removed list generation of an `any` test, since it can short-circuit that way, ie consider:
```
def is_four(i):
    print(i, end=" ")
    return i == 4

print(any(is_four(i) for i in range(10)))

print(any([is_four(i) for i in range(10)]))
```
which outputs
```
0 1 2 3 4 True
0 1 2 3 4 5 6 7 8 9 True
```