### PR TITLE
Add feature to compute weights for de-biasing using count

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Next Release
 
 - [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe basic mathematical operations `subtract`, `add`, `multiply`, `divide`
+- [#523](https://github.com/IAMconsortium/pyam/pull/523) Add feature to compute weights for de-biasing using count
 - [#519](https://github.com/IAMconsortium/pyam/pull/519) Enable explicit `label` and fix for non-string items in plot legend 
 
 # Release v0.11.0

--- a/pyam/_debiasing.py
+++ b/pyam/_debiasing.py
@@ -1,0 +1,8 @@
+def _compute_bias(df, name, method, axis):
+    """Internal implementation for computing bias weights"""
+    if method == "count":
+        count = df.meta.groupby(axis).count().exclude
+        count.name = name
+        df.meta = df.meta.join(count, on=axis, how="outer")
+    else:
+        raise ValueError(f"Unknown method {method} for computing bias weights!")

--- a/pyam/_debiasing.py
+++ b/pyam/_debiasing.py
@@ -1,7 +1,8 @@
 def _compute_bias(df, name, method, axis):
     """Internal implementation for computing bias weights"""
     if method == "count":
-        count = df.meta.groupby(axis).count().exclude
+        # invert from the count to obtain the weighting factor
+        count = 1 / df.meta.groupby(axis).count().exclude
         count.name = name
         df.meta = df.meta.join(count, on=axis, how="outer")
     else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -977,7 +977,31 @@ class IamDataFrame(object):
 
         The following methods are implemented:
 
-        - "count": use the inverse of the number of scenarios grouped by `axis` names
+        - "count": use the inverse of the number of scenarios grouped by `axis` names.
+
+          Using the following method on an IamDataFrame with three scenarios
+
+          .. code-block:: python
+
+              df.compute_bias(name="bias-weight", method="count", axis="scenario")
+
+          results in the following column to be added to *df.meta*:
+
+          .. list-table::
+             :header-rows: 1
+
+             * - model
+               - scenario
+               - bias-weight
+             * - model_a
+               - scen_a
+               - 0.5
+             * - model_a
+               - scen_b
+               - 1
+             * - model_b
+               - scen_a
+               - 0.5
 
         """
         _compute_bias(self, name, method, axis)
@@ -1088,7 +1112,7 @@ class IamDataFrame(object):
     def convert_unit(
         self, current, to, factor=None, registry=None, context=None, inplace=False
     ):
-        r"""Convert all data having *current* units to new units.
+        """Convert all timeseries data having *current* units to new units.
 
         If *factor* is given, existing values are multiplied by it, and the
         *to* units are assigned to the 'unit' column.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -11,6 +11,8 @@ import pandas as pd
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from pyam._debiasing import _compute_bias
+
 try:
     from datapackage import Package
 
@@ -957,6 +959,27 @@ class IamDataFrame(object):
             if exclude_on_fail and len(df) > 0:
                 self._exclude_on_fail(df)
             return df.reset_index()
+
+    def compute_bias(self, name, method, axis):
+        """Compute the bias weights and add to `self.meta`
+
+        Parameters
+        ----------
+        name : str
+           Column name in the `meta` dataframe
+        method : str
+            Method to compute the bias weights, see the notes
+        axis : str
+            Index dimensions on which apply the method
+
+        Notes
+        -----
+        The following `methods` are implemented:
+
+        - "count": count the number of scenarios grouped by `axis` names
+
+        """
+        _compute_bias(self, name, method, axis)
 
     def rename(
         self, mapping=None, inplace=False, append=False, check_duplicates=True, **kwargs

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -961,22 +961,23 @@ class IamDataFrame(object):
             return df.reset_index()
 
     def compute_bias(self, name, method, axis):
-        """Compute the bias weights and add to `self.meta`
+        """Compute the bias weights and add to 'meta'
 
         Parameters
         ----------
         name : str
-           Column name in the `meta` dataframe
+           Column name in the 'meta' dataframe
         method : str
             Method to compute the bias weights, see the notes
         axis : str
-            Index dimensions on which apply the method
+            Index dimensions on which to apply the `method`
 
         Notes
         -----
-        The following `methods` are implemented:
 
-        - "count": count the number of scenarios grouped by `axis` names
+        The following methods are implemented:
+
+        - "count": use the inverse of the number of scenarios grouped by `axis` names
 
         """
         _compute_bias(self, name, method, axis)

--- a/tests/test_feature_debiasing.py
+++ b/tests/test_feature_debiasing.py
@@ -1,0 +1,13 @@
+from pyam import IamDataFrame
+from numpy.testing import assert_array_equal
+
+
+def test_debiasing_count(test_pd_df):
+    """Check computing bias weights counting the number of scenarios by scenario name"""
+
+    # modify the default test data to have three distinct scenarios
+    test_pd_df.loc[1, "model"] = "model_b"
+    df = IamDataFrame(test_pd_df)
+    df.compute_bias(method="count", name="bias", axis="scenario")
+
+    assert_array_equal(df["bias"].values, [2, 2, 1])

--- a/tests/test_feature_debiasing.py
+++ b/tests/test_feature_debiasing.py
@@ -1,13 +1,18 @@
 from pyam import IamDataFrame
+import pytest
 from numpy.testing import assert_array_equal
 
 
-def test_debiasing_count(test_pd_df):
+@pytest.mark.parametrize(
+    "axis, exp",
+    (["scenario", [2, 2, 1]], [["model", "scenario"], [1, 1, 1]]),
+)
+def test_debiasing_count(test_pd_df, axis, exp):
     """Check computing bias weights counting the number of scenarios by scenario name"""
 
     # modify the default test data to have three distinct scenarios
     test_pd_df.loc[1, "model"] = "model_b"
     df = IamDataFrame(test_pd_df)
-    df.compute_bias(method="count", name="bias", axis="scenario")
+    df.compute_bias(method="count", name="bias", axis=axis)
 
-    assert_array_equal(df["bias"].values, [2, 2, 1])
+    assert_array_equal(df["bias"].values, exp)

--- a/tests/test_feature_debiasing.py
+++ b/tests/test_feature_debiasing.py
@@ -16,3 +16,10 @@ def test_debiasing_count(test_pd_df, axis, exp):
     df.compute_bias(method="count", name="bias", axis=axis)
 
     assert_array_equal(df["bias"].values, exp)
+
+
+def test_debiasing_unknown_method(test_df_year):
+    """Check computing bias weights counting the number of scenarios by scenario name"""
+    msg = f"Unknown method foo for computing bias weights!"
+    with pytest.raises(ValueError, match=msg):
+        test_df_year.compute_bias(method="foo", name="bias", axis="scenario")

--- a/tests/test_feature_debiasing.py
+++ b/tests/test_feature_debiasing.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_equal
 
 @pytest.mark.parametrize(
     "axis, exp",
-    (["scenario", [2, 2, 1]], [["model", "scenario"], [1, 1, 1]]),
+    (["scenario", [0.5, 0.5, 1]], [["model", "scenario"], [1, 1, 1]]),
 )
 def test_debiasing_count(test_pd_df, axis, exp):
     """Check computing bias weights counting the number of scenarios by scenario name"""

--- a/tests/test_feature_debiasing.py
+++ b/tests/test_feature_debiasing.py
@@ -20,6 +20,6 @@ def test_debiasing_count(test_pd_df, axis, exp):
 
 def test_debiasing_unknown_method(test_df_year):
     """Check computing bias weights counting the number of scenarios by scenario name"""
-    msg = f"Unknown method foo for computing bias weights!"
+    msg = "Unknown method foo for computing bias weights!"
     with pytest.raises(ValueError, match=msg):
         test_df_year.compute_bias(method="foo", name="bias", axis="scenario")


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Based on a rekindling of the discussion on de-biasing of scenario ensembles by @Rlamboll, this is an initial implementation using the most basic approach to compute de-biasing weights: counting the number of model or scenario names. My hope is that having this initial PR can help to structure the discussion on provide a template to think about more advanced methods for debiasing (e.g., based on generic meta-indicators like projects, differences between certain variables, etc.)

Intended results
----------------

In the test, there is a simple IamDataFrame with three scenarios (i.e., scenario runs) from two models, where `model_a` implements scenarios (in the sense of a scenario protocol) `scen_a` and `scen_b` and `model_b` implements only `scen_a`. The method counts the number of occurrences by name on the `axis` (in the test case: "scenario"). The expected output is

|  model    | scenario | bias |
|----------|--------|-------|
|  model_a | scen_a |  0.5   |
|  model_b | scen_a |  0.5  |
|  model_a | scen_b |  1     |

Note: setting `axis=["model", "scenario"]` returns a bias-vector of 1 in a standard IAMC-template IamDataFrame.

Open questions
----------------

- ~Should the computed bias weights be inverted? i.e., `0.5, 0.5, 1`~
  -> Per discussion below: yes, changed from initial implementation
- Does the function signature make sense?
- The function directly adds the bias-weights to `df.meta` so that they can be retrieved with `df[<name>]`.
  An alternative implementation could be:
  The function `compute_bias()` returns the weights as pd.Series, so that a used would have to add it to `meta` explicitly
  e.g., `df.set_meta(meta=df.compute_bias(...), name="bias")`