### PR TITLE
Add an in-dataframe subtraction operation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe subtraction operation
 - [#519](https://github.com/IAMconsortium/pyam/pull/519) Enable explicit `label` and fix for non-string items in plot legend 
 
 # Release v0.11.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Next Release
 
-- [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe subtraction operation
+- [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe basic mathematical operations `subtract`, `add`, `multiply`, `divide`
 - [#519](https://github.com/IAMconsortium/pyam/pull/519) Enable explicit `label` and fix for non-string items in plot legend 
 
 # Release v0.11.0

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -5,7 +5,24 @@ def subtract(a, b):
     return a - b
 
 
-KNOWN_OPS = {"subtract": subtract}
+def add(a, b):
+    return a + b
+
+
+def divide(a, b):
+    return a / b
+
+
+def multiply(a, b):
+    return a * b
+
+
+KNOWN_OPS = {
+    "subtract": subtract,
+    "add": add,
+    "divide": divide,
+    "multiply": multiply,
+}
 
 
 def _op_data(df, a, b, name, method, axis):

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -5,9 +5,7 @@ def subtract(a, b):
     return a - b
 
 
-KNOWN_OPS = {
-    "subtract": subtract
-}
+KNOWN_OPS = {"subtract": subtract}
 
 
 def _op_data(df, a, b, name, method, axis):

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -1,27 +1,12 @@
+import operator
 from pyam.index import append_index_level
 
 
-def add(a, b):
-    return a + b
-
-
-def subtract(a, b):
-    return a - b
-
-
-def multiply(a, b):
-    return a * b
-
-
-def divide(a, b):
-    return a / b
-
-
 KNOWN_OPS = {
-    "subtract": subtract,
-    "add": add,
-    "divide": divide,
-    "multiply": multiply,
+    "add": operator.add,
+    "subtract": operator.sub,
+    "multiply": operator.mul,
+    "divide": operator.truediv,
 }
 
 

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -13,14 +13,17 @@ KNOWN_OPS = {
 def _op_data(df, a, b, name, method, axis):
     """Internal implementation of numerical operations on timeseries"""
 
-    cols = df._data.index.names.difference([axis])
-    _a = df.filter(**{axis: a})._data.groupby(cols).sum()
-    _b = df.filter(**{axis: b})._data.groupby(cols).sum()
+    if axis not in df._data.index.names:
+        raise ValueError(f"Unknown axis: {axis}")
 
     if method in KNOWN_OPS:
         method = KNOWN_OPS[method]
     else:
         raise ValueError(f"Unknown method: {method}")
+
+    cols = df._data.index.names.difference([axis])
+    _a = df.filter(**{axis: a})._data.groupby(cols).sum()
+    _b = df.filter(**{axis: b})._data.groupby(cols).sum()
 
     _value = method(_a, _b)
     _value.index = append_index_level(_value.index, 0, name, axis)

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -10,7 +10,7 @@ KNOWN_OPS = {
 }
 
 
-def _op_data(df, a, b, name, method, axis):
+def _op_data(df, method_args, name, method, axis):
     """Internal implementation of numerical operations on timeseries"""
 
     if axis not in df._data.index.names:
@@ -22,10 +22,9 @@ def _op_data(df, a, b, name, method, axis):
         raise ValueError(f"Unknown method: {method}")
 
     cols = df._data.index.names.difference([axis])
-    _a = df.filter(**{axis: a})._data.groupby(cols).sum()
-    _b = df.filter(**{axis: b})._data.groupby(cols).sum()
+    _args = [df.filter(**{axis: i})._data.groupby(cols).sum() for i in method_args]
 
-    _value = method(_a, _b)
+    _value = method(*_args)
     _value.index = append_index_level(_value.index, codes=0, level=name, name=axis)
 
     return _value

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -24,6 +24,6 @@ def _op_data(df, a, b, name, method, axis):
     _b = df.filter(**{axis: b})._data.groupby(cols).sum()
 
     _value = method(_a, _b)
-    _value.index = append_index_level(_value.index, 0, name, axis)
+    _value.index = append_index_level(_value.index, codes=0, level=name, name=axis)
 
     return _value

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -1,0 +1,28 @@
+from pyam.index import append_index_level
+
+
+def subtract(a, b):
+    return a - b
+
+
+KNOWN_OPS = {
+    "subtract": subtract
+}
+
+
+def _op_data(df, a, b, name, method, axis):
+    """Internal implementation of numerical operations on timeseries"""
+
+    cols = df._data.index.names.difference([axis])
+    _a = df.filter(**{axis: a})._data.groupby(cols).sum()
+    _b = df.filter(**{axis: b})._data.groupby(cols).sum()
+
+    if method in KNOWN_OPS:
+        method = KNOWN_OPS[method]
+    else:
+        raise ValueError(f"Unknown method: {method}")
+
+    _value = method(_a, _b)
+    _value.index = append_index_level(_value.index, 0, name, axis)
+
+    return _value

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -1,20 +1,20 @@
 from pyam.index import append_index_level
 
 
-def subtract(a, b):
-    return a - b
-
-
 def add(a, b):
     return a + b
 
 
-def divide(a, b):
-    return a / b
+def subtract(a, b):
+    return a - b
 
 
 def multiply(a, b):
     return a * b
+
+
+def divide(a, b):
+    return a / b
 
 
 KNOWN_OPS = {

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1760,6 +1760,96 @@ class IamDataFrame(object):
         else:
             return IamDataFrame(_value, meta=self.meta)
 
+    def add(self, a, b, name, axis="variable", append=False):
+        """Compute the addition of timeseries data between `a` and `b` along an `axis`
+
+        This function computes `a + b`. If `a` or `b` are lists, the method applies
+        :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
+        If either `a` or `b` are not defined for a row, no value is computed
+        for that row.
+
+        Parameters
+        ----------
+        a, b : str or list of str
+            Items to be used for the addition.
+        name : str
+            Name of the computed timeseries data on the `axis`.
+        axis : str, optional
+            Axis along which to compute.
+        append : bool, optional
+            Whether to append aggregated timeseries data to this instance.
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Computed timeseries data or None if `append=True`.
+        """
+        _value = _op_data(self, a, b, name, "add", axis=axis)
+        if append:
+            self.append(_value, inplace=True)
+        else:
+            return IamDataFrame(_value, meta=self.meta)
+
+    def divide(self, a, b, name, axis="variable", append=False):
+        """Compute the division of timeseries data between `a` and `b` along an `axis`
+
+        This function computes `a / b`. If `a` or `b` are lists, the method applies
+        :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
+        If either `a` or `b` are not defined for a row, no value is computed
+        for that row.
+
+        Parameters
+        ----------
+        a, b : str or list of str
+            Items to be used for the division.
+        name : str
+            Name of the computed timeseries data on the `axis`.
+        axis : str, optional
+            Axis along which to compute.
+        append : bool, optional
+            Whether to append aggregated timeseries data to this instance.
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Computed timeseries data or None if `append=True`.
+        """
+        _value = _op_data(self, a, b, name, "divide", axis=axis)
+        if append:
+            self.append(_value, inplace=True)
+        else:
+            return IamDataFrame(_value, meta=self.meta)
+
+    def multiply(self, a, b, name, axis="variable", append=False):
+        """Compute the division of timeseries data between `a` and `b` along an `axis`
+
+        This function computes `a * b`. If `a` or `b` are lists, the method applies
+        :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
+        If either `a` or `b` are not defined for a row, no value is computed
+        for that row.
+
+        Parameters
+        ----------
+        a, b : str or list of str
+            Items to be used for the division.
+        name : str
+            Name of the computed timeseries data on the `axis`.
+        axis : str, optional
+            Axis along which to compute.
+        append : bool, optional
+            Whether to append aggregated timeseries data to this instance.
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Computed timeseries data or None if `append=True`.
+        """
+        _value = _op_data(self, a, b, name, "multiply", axis=axis)
+        if append:
+            self.append(_value, inplace=True)
+        else:
+            return IamDataFrame(_value, meta=self.meta)
+
     def _to_file_format(self, iamc_index):
         """Return a dataframe suitable for writing to a file"""
         df = self.timeseries(iamc_index=iamc_index).reset_index()

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1183,7 +1183,7 @@ class IamDataFrame(object):
         Returns
         -------
         :class:`IamDataFrame` or **None**
-            Aggregated timeseries data or None if `inplace=True`.
+            Aggregated timeseries data or None if `append=True`.
 
         Notes
         -----
@@ -1754,7 +1754,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, a, b, name, "add", axis=axis)
+        _value = _op_data(self, (a, b), name, "add", axis=axis)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1784,7 +1784,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, a, b, name, "subtract", axis=axis)
+        _value = _op_data(self, (a, b), name, "subtract", axis=axis)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1814,7 +1814,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, a, b, name, "multiply", axis=axis)
+        _value = _op_data(self, (a, b), name, "multiply", axis=axis)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1844,7 +1844,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, a, b, name, "divide", axis=axis)
+        _value = _op_data(self, (a, b), name, "divide", axis=axis)
         if append:
             self.append(_value, inplace=True)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1733,14 +1733,17 @@ class IamDataFrame(object):
     def subtract(self, a, b, name, axis="variable", append=False):
         """Compute the difference of timeseries data between `a` and `b` along an `axis`
 
-        This function computes `a - b`.
+        This function computes `a - b`. If `a` or `b` are lists, the method applies
+        :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
+        If either `a` or `b` are not defined for a row, no value is computed
+        for that row.
 
         Parameters
         ----------
         a, b : str or list of str
             Items to be used for the subtraction.
         name : str
-            Name of the computed timeseries data.
+            Name of the computed timeseries data on the `axis`.
         axis : str, optional
             Axis along which to compute.
         append : bool, optional

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1730,36 +1730,6 @@ class IamDataFrame(object):
         else:
             self.meta[col] = self.meta[col].apply(func, *args, **kwargs)
 
-    def subtract(self, a, b, name, axis="variable", append=False):
-        """Compute the difference of timeseries data between `a` and `b` along an `axis`
-
-        This function computes `a - b`. If `a` or `b` are lists, the method applies
-        :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
-        If either `a` or `b` are not defined for a row, no value is computed
-        for that row.
-
-        Parameters
-        ----------
-        a, b : str or list of str
-            Items to be used for the subtraction.
-        name : str
-            Name of the computed timeseries data on the `axis`.
-        axis : str, optional
-            Axis along which to compute.
-        append : bool, optional
-            Whether to append aggregated timeseries data to this instance.
-
-        Returns
-        -------
-        :class:`IamDataFrame` or **None**
-            Computed timeseries data or None if `append=True`.
-        """
-        _value = _op_data(self, a, b, name, "subtract", axis=axis)
-        if append:
-            self.append(_value, inplace=True)
-        else:
-            return IamDataFrame(_value, meta=self.meta)
-
     def add(self, a, b, name, axis="variable", append=False):
         """Compute the addition of timeseries data between `a` and `b` along an `axis`
 
@@ -1790,10 +1760,10 @@ class IamDataFrame(object):
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def divide(self, a, b, name, axis="variable", append=False):
-        """Compute the division of timeseries data between `a` and `b` along an `axis`
+    def subtract(self, a, b, name, axis="variable", append=False):
+        """Compute the difference of timeseries data between `a` and `b` along an `axis`
 
-        This function computes `a / b`. If `a` or `b` are lists, the method applies
+        This function computes `a - b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
         If either `a` or `b` are not defined for a row, no value is computed
         for that row.
@@ -1801,7 +1771,7 @@ class IamDataFrame(object):
         Parameters
         ----------
         a, b : str or list of str
-            Items to be used for the division.
+            Items to be used for the subtraction.
         name : str
             Name of the computed timeseries data on the `axis`.
         axis : str, optional
@@ -1814,7 +1784,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, a, b, name, "divide", axis=axis)
+        _value = _op_data(self, a, b, name, "subtract", axis=axis)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1845,6 +1815,36 @@ class IamDataFrame(object):
             Computed timeseries data or None if `append=True`.
         """
         _value = _op_data(self, a, b, name, "multiply", axis=axis)
+        if append:
+            self.append(_value, inplace=True)
+        else:
+            return IamDataFrame(_value, meta=self.meta)
+
+    def divide(self, a, b, name, axis="variable", append=False):
+        """Compute the division of timeseries data between `a` and `b` along an `axis`
+
+        This function computes `a / b`. If `a` or `b` are lists, the method applies
+        :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
+        If either `a` or `b` are not defined for a row, no value is computed
+        for that row.
+
+        Parameters
+        ----------
+        a, b : str or list of str
+            Items to be used for the division.
+        name : str
+            Name of the computed timeseries data on the `axis`.
+        axis : str, optional
+            Axis along which to compute.
+        append : bool, optional
+            Whether to append aggregated timeseries data to this instance.
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Computed timeseries data or None if `append=True`.
+        """
+        _value = _op_data(self, a, b, name, "divide", axis=axis)
         if append:
             self.append(_value, inplace=True)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -63,6 +63,7 @@ from pyam._aggregate import (
     _aggregate_recursive,
     _group_and_agg,
 )
+from pyam._ops import _op_data
 from pyam.units import convert_unit
 from pyam.index import (
     get_index_levels,
@@ -1728,6 +1729,33 @@ class IamDataFrame(object):
             self.data[col] = self.data[col].apply(func, *args, **kwargs)
         else:
             self.meta[col] = self.meta[col].apply(func, *args, **kwargs)
+
+    def subtract(self, a, b, name, axis="variable", append=False):
+        """Compute the difference of timeseries data between `a` and `b` along an `axis`
+
+        This function computes `a - b`.
+
+        Parameters
+        ----------
+        a, b : str or list of str
+            Items to be used for the subtraction.
+        name : str
+            Name of the computed timeseries data.
+        axis : str, optional
+            Axis along which to compute.
+        append : bool, optional
+            Whether to append aggregated timeseries data to this instance.
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Computed timeseries data or None if `append=True`.
+        """
+        _value = _op_data(self, a, b, name, "subtract", axis=axis)
+        if append:
+            self.append(_value, inplace=True)
+        else:
+            return IamDataFrame(_value, meta=self.meta)
 
     def _to_file_format(self, iamc_index):
         """Return a dataframe suitable for writing to a file"""

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -63,9 +63,9 @@ def replace_index_values(df, level, mapping):
 def append_index_level(index, codes, level, name, order=False):
     """Append a level to a pd.MultiIndex"""
     new_index = pd.MultiIndex(
-        codes=index.codes + [codes],
-        levels=index.levels + [level],
-        names=index.names + [name],
+        codes=index.codes + [[codes] * len(index.codes[0])],
+        levels=index.levels + [[level]],
+        names=index.names + [name]
     )
     if order:
         new_index = new_index.reorder_levels(order)

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -65,7 +65,7 @@ def append_index_level(index, codes, level, name, order=False):
     new_index = pd.MultiIndex(
         codes=index.codes + [[codes] * len(index.codes[0])],
         levels=index.levels + [[level]],
-        names=index.names + [name]
+        names=index.names + [name],
     )
     if order:
         new_index = new_index.reorder_levels(order)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -398,7 +398,8 @@ def merge_meta(left, right, ignore_conflict=False):
     if not diff.empty:
         left = left.append(right.loc[diff, :], sort=False)
 
-    return left
+    # remove any columns that are all-nan
+    return left.dropna(axis=1, how="all")
 
 
 def find_depth(data, s="", level=None):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -61,5 +61,3 @@ def test_append_index():
         names=["region", "scenario"],
     )
     pdt.assert_index_equal(obs, exp)
-
-

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,7 +1,8 @@
 import pytest
+import pandas as pd
 import pandas.testing as pdt
 
-from pyam.index import get_index_levels, replace_index_values
+from pyam.index import get_index_levels, replace_index_values, append_index_level
 from pyam import IAMC_IDX
 
 
@@ -41,3 +42,24 @@ def test_replace_index_level_raises(test_df_index):
     """Assert that replace_index_value raises with non-existing level"""
     with pytest.raises(KeyError):
         replace_index_values(test_df_index, "foo", {"scen_a": "scen_c"})
+
+
+def test_append_index():
+    """Assert that appending and re-ordering to an index works as expected"""
+
+    index = pd.MultiIndex(
+        codes=[[0, 1]],
+        levels=[["scen_a", "scen_b"]],
+        names=["scenario"],
+    )
+
+    obs = append_index_level(index, 0, "World", "region", order=["region", "scenario"])
+
+    exp = pd.MultiIndex(
+        codes=[[0, 0], [0, 1]],
+        levels=[["World"], ["scen_a", "scen_b"]],
+        names=["region", "scenario"],
+    )
+    pdt.assert_index_equal(obs, exp)
+
+

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -36,7 +36,7 @@ def test_subtract_scenario(test_df_year, append):
 
     v = ("scen_a", "scen_b", "scen_diff")
     exp = IamDataFrame(
-        pd.DataFrame([-1, -1], index=[2005, 2010]).T,
+        pd.DataFrame([1 - 2, 6 - 7], index=[2005, 2010]).T,
         model="model_a",
         scenario=v[2],
         region="World",
@@ -50,8 +50,75 @@ def test_subtract_scenario(test_df_year, append):
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
         obs = test_df_year.subtract(*v, axis="scenario")
-        print(exp)
-        print(obs)
+        assert_iamframe_equal(exp, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_add_scenario(test_df_year, append):
+    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
+
+    v = ("scen_a", "scen_b", "scen_diff")
+    exp = IamDataFrame(
+        pd.DataFrame([1 + 2, 6 + 7], index=[2005, 2010]).T,
+        model="model_a",
+        scenario=v[2],
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.add(*v, axis="scenario", append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.add(*v, axis="scenario")
+        assert_iamframe_equal(exp, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_divide_scenario(test_df_year, append):
+    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
+
+    v = ("scen_a", "scen_b", "scen_diff")
+    exp = IamDataFrame(
+        pd.DataFrame([1 / 2, 6 / 7], index=[2005, 2010]).T,
+        model="model_a",
+        scenario=v[2],
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.divide(*v, axis="scenario", append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.divide(*v, axis="scenario")
+        assert_iamframe_equal(exp, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_multiply_scenario(test_df_year, append):
+    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
+
+    v = ("scen_a", "scen_b", "scen_diff")
+    exp = IamDataFrame(
+        pd.DataFrame([1 * 2, 6 * 7], index=[2005, 2010]).T,
+        model="model_a",
+        scenario=v[2],
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.multiply(*v, axis="scenario", append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.multiply(*v, axis="scenario")
         assert_iamframe_equal(exp, obs)
 
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import pytest
+
+from pyam import IamDataFrame
+from pyam.testing import assert_iamframe_equal
+from pyam._ops import _op_data
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_subtract_variable(test_df_year, append):
+    """Verify that in-dataframe subtraction works on the default `variable` axis"""
+
+    v = ("Primary Energy", "Primary Energy|Coal", "Primary Energy|Other")
+    exp = IamDataFrame(
+        pd.DataFrame([0.5, 3.0], index=[2005, 2010]).T,
+        model="model_a",
+        scenario="scen_a",
+        region="World",
+        variable=v[2],
+        unit="EJ/yr",
+        meta=test_df_year.meta
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.subtract(*v, append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.subtract(*v)
+        assert_iamframe_equal(exp, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_subtract_scenario(test_df_year, append):
+    """Verify that in-dataframe subtraction works on a custom axis (`scenario`)"""
+
+    v = ("scen_a", "scen_b", "scen_diff")
+    exp = IamDataFrame(
+        pd.DataFrame([-1, -1], index=[2005, 2010]).T,
+        model="model_a",
+        scenario=v[2],
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.subtract(*v, axis="scenario", append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.subtract(*v, axis="scenario")
+        print(exp)
+        print(obs)
+        assert_iamframe_equal(exp, obs)
+
+
+def test_ops_unknown_axis(test_df_year):
+    """Using an unknown axis raises an error"""
+    with pytest.raises(ValueError, match="Unknown axis: foo"):
+        _op_data(test_df_year, "_", "_", "_", "_", "foo")
+
+
+def test_ops_unknown_method(test_df_year):
+    """Using an unknown method raises an error"""
+    with pytest.raises(ValueError, match="Unknown method: foo"):
+        _op_data(test_df_year, "_", "_", "_", "foo", "variable")

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -194,10 +194,10 @@ def test_divide_scenario(test_df_year, append):
 def test_ops_unknown_axis(test_df_year):
     """Using an unknown axis raises an error"""
     with pytest.raises(ValueError, match="Unknown axis: foo"):
-        _op_data(test_df_year, "_", "_", "_", "_", "foo")
+        _op_data(test_df_year, "_", "_", "_", "foo")
 
 
 def test_ops_unknown_method(test_df_year):
     """Using an unknown method raises an error"""
     with pytest.raises(ValueError, match="Unknown method: foo"):
-        _op_data(test_df_year, "_", "_", "_", "foo", "variable")
+        _op_data(test_df_year, "_", "_", "foo", "variable")

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -18,7 +18,7 @@ def test_subtract_variable(test_df_year, append):
         region="World",
         variable=v[2],
         unit="EJ/yr",
-        meta=test_df_year.meta
+        meta=test_df_year.meta,
     )
 
     if append:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -7,12 +7,58 @@ from pyam._ops import _op_data
 
 
 @pytest.mark.parametrize("append", (False, True))
+def test_add_variable(test_df_year, append):
+    """Verify that in-dataframe addition works on the default `variable` axis"""
+
+    v = ("Primary Energy", "Primary Energy|Coal", "Sum")
+    exp = IamDataFrame(
+        pd.DataFrame([1 + 0.5, 6 + 3], index=[2005, 2010]).T,
+        model="model_a",
+        scenario="scen_a",
+        region="World",
+        variable=v[2],
+        unit="EJ/yr",
+        meta=test_df_year.meta,
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.add(*v, append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        assert_iamframe_equal(exp, test_df_year.add(*v))
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_add_scenario(test_df_year, append):
+    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
+
+    v = ("scen_a", "scen_b", "scen_sum")
+    exp = IamDataFrame(
+        pd.DataFrame([1 + 2, 6 + 7], index=[2005, 2010]).T,
+        model="model_a",
+        scenario=v[2],
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.add(*v, axis="scenario", append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.add(*v, axis="scenario")
+        assert_iamframe_equal(exp, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
 def test_subtract_variable(test_df_year, append):
     """Verify that in-dataframe subtraction works on the default `variable` axis"""
 
     v = ("Primary Energy", "Primary Energy|Coal", "Primary Energy|Other")
     exp = IamDataFrame(
-        pd.DataFrame([0.5, 3.0], index=[2005, 2010]).T,
+        pd.DataFrame([1 - 0.5, 6 - 3], index=[2005, 2010]).T,
         model="model_a",
         scenario="scen_a",
         region="World",
@@ -54,56 +100,33 @@ def test_subtract_scenario(test_df_year, append):
 
 
 @pytest.mark.parametrize("append", (False, True))
-def test_add_scenario(test_df_year, append):
-    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
+def test_multiply_variable(test_df_year, append):
+    """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    v = ("scen_a", "scen_b", "scen_diff")
+    v = ("Primary Energy", "Primary Energy|Coal", "Product")
     exp = IamDataFrame(
-        pd.DataFrame([1 + 2, 6 + 7], index=[2005, 2010]).T,
+        pd.DataFrame([1 * 0.5, 6 * 3], index=[2005, 2010]).T,
         model="model_a",
-        scenario=v[2],
+        scenario="scen_a",
         region="World",
-        variable="Primary Energy",
+        variable=v[2],
         unit="EJ/yr",
+        meta=test_df_year.meta,
     )
 
     if append:
         obs = test_df_year.copy()
-        obs.add(*v, axis="scenario", append=True)
+        obs.multiply(*v, append=True)
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
-        obs = test_df_year.add(*v, axis="scenario")
-        assert_iamframe_equal(exp, obs)
-
-
-@pytest.mark.parametrize("append", (False, True))
-def test_divide_scenario(test_df_year, append):
-    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
-
-    v = ("scen_a", "scen_b", "scen_diff")
-    exp = IamDataFrame(
-        pd.DataFrame([1 / 2, 6 / 7], index=[2005, 2010]).T,
-        model="model_a",
-        scenario=v[2],
-        region="World",
-        variable="Primary Energy",
-        unit="EJ/yr",
-    )
-
-    if append:
-        obs = test_df_year.copy()
-        obs.divide(*v, axis="scenario", append=True)
-        assert_iamframe_equal(test_df_year.append(exp), obs)
-    else:
-        obs = test_df_year.divide(*v, axis="scenario")
-        assert_iamframe_equal(exp, obs)
+        assert_iamframe_equal(exp, test_df_year.multiply(*v))
 
 
 @pytest.mark.parametrize("append", (False, True))
 def test_multiply_scenario(test_df_year, append):
     """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
 
-    v = ("scen_a", "scen_b", "scen_diff")
+    v = ("scen_a", "scen_b", "scen_product")
     exp = IamDataFrame(
         pd.DataFrame([1 * 2, 6 * 7], index=[2005, 2010]).T,
         model="model_a",
@@ -119,6 +142,52 @@ def test_multiply_scenario(test_df_year, append):
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
         obs = test_df_year.multiply(*v, axis="scenario")
+        assert_iamframe_equal(exp, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_divide_variable(test_df_year, append):
+    """Verify that in-dataframe addition works on the default `variable` axis"""
+
+    v = ("Primary Energy", "Primary Energy|Coal", "Ratio")
+    exp = IamDataFrame(
+        pd.DataFrame([1 / 0.5, 6 / 3], index=[2005, 2010]).T,
+        model="model_a",
+        scenario="scen_a",
+        region="World",
+        variable=v[2],
+        unit="EJ/yr",
+        meta=test_df_year.meta,
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.divide(*v, append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        assert_iamframe_equal(exp, test_df_year.divide(*v))
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_divide_scenario(test_df_year, append):
+    """Verify that in-dataframe addition works on a custom axis (`scenario`)"""
+
+    v = ("scen_a", "scen_b", "scen_ratio")
+    exp = IamDataFrame(
+        pd.DataFrame([1 / 2, 6 / 7], index=[2005, 2010]).T,
+        model="model_a",
+        scenario=v[2],
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    if append:
+        obs = test_df_year.copy()
+        obs.divide(*v, axis="scenario", append=True)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
+    else:
+        obs = test_df_year.divide(*v, axis="scenario")
         assert_iamframe_equal(exp, obs)
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR implements a first version of an in-IamDataFrame subtraction feature, e.g., to compute the difference between total primary energy and the components (and optionally add to the IamDataFrame).

```python
df.subtract("Primary Energy", "Primary Energy|Coal", "Primary Energy|Other", append=True)
```

This is just the most basic approach - it assumes that `a - b` is not computed for a specific row if either `a` or `b` is not defined.

# Future improvements and extensions

 - Allow setting a default value if `a` or `b` is not defined
 - Enable setting `b` as a numerical value (e.g., `Primary Energy * -1`)
 - Add support for across-IamDataFrame operations, e.g.
    ```python
    pyam.subtract(a, b, ...)
    ```
    where `a` and `b` are IamDataFrame-instances.
 - Add similar operations for addition, multiplication, shares... 