### PR TITLE
added feature drop negative weights

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ The following persons contributed to the development of the |pyam| framework:
 - Michael Pimmer `@fonfon <https://github.com/fonfon>`_
 - Patrick Jürgens `@pjuergens <https://github.com/pjuergens>`_
 - Florian Maczek `@macflo8 <https://github.com/macflo8>`_
+- Laura Wienpahl `@LauWien <https://github.com/LauWien>`_

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 - [#541](https://github.com/IAMconsortium/pyam/pull/541) Support units in binary operations
 - [#538](https://github.com/IAMconsortium/pyam/pull/538) Add option to set defaults in binary operations
 - [#537](https://github.com/IAMconsortium/pyam/pull/537) Enhance binary ops to support numerical arguments
+- [#534](https://github.com/IAMconsortium/pyam/pull/534) Add feature to drop negative weights
 - [#532](https://github.com/IAMconsortium/pyam/pull/532) Add an option to skip existing intermediate variables when aggregating recursivly
 - [#533](https://github.com/IAMconsortium/pyam/pull/533) Add an `apply()` function for custom mathematical operations
 - [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe basic mathematical operations `subtract`, `add`, `multiply`, `divide`

--- a/pyam/_aggregate.py
+++ b/pyam/_aggregate.py
@@ -78,7 +78,7 @@ def _aggregate_recursive(df, variable):
 
 
 def _aggregate_region(
-    df, variable, region, subregions=None, components=False, method="sum", weight=None
+    df, variable, region, subregions=None, components=False, method="sum", weight=None, drop_negative=True
 ):
     """Internal implementation for aggregating data over subregions"""
     if not isstr(variable) and components is not False:
@@ -107,7 +107,7 @@ def _aggregate_region(
     else:
         weight_rows = subregion_df._apply_filters(variable=weight)
         _data = _agg_weight(
-            subregion_df._data[rows], subregion_df._data[weight_rows], method
+            subregion_df._data[rows], subregion_df._data[weight_rows], method, drop_negative
         )
 
     # if not `components=False`, add components at the `region` level
@@ -169,7 +169,7 @@ def _group_and_agg(df, by, method=np.sum):
     return df.groupby(cols).agg(_get_method_func(method))
 
 
-def _agg_weight(data, weight, method):
+def _agg_weight(data, weight, method, drop_negative):
     """Aggregate `data` by regions with weights, return indexed `pd.Series`"""
 
     # only summation allowed with weights
@@ -180,6 +180,15 @@ def _agg_weight(data, weight, method):
 
     if not data.droplevel(["variable", "unit"]).index.equals(weight.index):
         raise ValueError("Inconsistent index between variable and weight!")
+
+    if drop_negative is True:
+        if any(i < 0 for i in weight):
+            logger.warning("Some of the weights are negative. All data with negative values will be dropped. "
+                          "If you don't want the values to be dropped please use the keyword drop_negative=False")
+        # Drop negative weights
+            for index, value in weight.items():
+                if value < 0:
+                    weight = weight.drop(labels=[index])
 
     col1 = data.index.names.difference(["region"])
     col2 = data.index.names.difference(["region", "variable", "unit"])

--- a/pyam/_aggregate.py
+++ b/pyam/_aggregate.py
@@ -78,7 +78,14 @@ def _aggregate_recursive(df, variable):
 
 
 def _aggregate_region(
-    df, variable, region, subregions=None, components=False, method="sum", weight=None
+    df,
+    variable,
+    region,
+    subregions=None,
+    components=False,
+    method="sum",
+    weight=None,
+    drop_negative_weights=True,
 ):
     """Internal implementation for aggregating data over subregions"""
     if not isstr(variable) and components is not False:
@@ -103,11 +110,20 @@ def _aggregate_region(
     subregion_df = df.filter(region=subregions)
     rows = subregion_df._apply_filters(variable=variable)
     if weight is None:
+
+        if drop_negative_weights is False:
+            raise ValueError(
+                "Dropping negative weights can only be used with `weights`!"
+            )
+
         _data = _group_and_agg(subregion_df._data[rows], "region", method=method)
     else:
         weight_rows = subregion_df._apply_filters(variable=weight)
         _data = _agg_weight(
-            subregion_df._data[rows], subregion_df._data[weight_rows], method
+            subregion_df._data[rows],
+            subregion_df._data[weight_rows],
+            method,
+            drop_negative_weights,
         )
 
     # if not `components=False`, add components at the `region` level
@@ -169,7 +185,7 @@ def _group_and_agg(df, by, method=np.sum):
     return df.groupby(cols).agg(_get_method_func(method))
 
 
-def _agg_weight(data, weight, method):
+def _agg_weight(data, weight, method, drop_negative_weights):
     """Aggregate `data` by regions with weights, return indexed `pd.Series`"""
 
     # only summation allowed with weights
@@ -181,9 +197,22 @@ def _agg_weight(data, weight, method):
     if not data.droplevel(["variable", "unit"]).index.equals(weight.index):
         raise ValueError("Inconsistent index between variable and weight!")
 
+    if drop_negative_weights is True:
+        if any(weight < 0):
+            logger.warning(
+                "Some of the weights are negative. "
+                "All data weighted by negative values will be dropped. "
+                "To apply both positive and negative weights to the data, "
+                "please use the keyword argument `drop_negative_weights=False`."
+            )
+            # Drop negative weights
+            weight[weight < 0] = None
+
     col1 = data.index.names.difference(["region"])
     col2 = data.index.names.difference(["region", "variable", "unit"])
-    return (data * weight).groupby(col1).sum() / weight.groupby(col2).sum()
+    return (data * weight).groupby(col1).apply(
+        pd.Series.sum, skipna=False
+    ) / weight.groupby(col2).sum()
 
 
 def _get_method_func(method):

--- a/pyam/_aggregate.py
+++ b/pyam/_aggregate.py
@@ -78,7 +78,14 @@ def _aggregate_recursive(df, variable):
 
 
 def _aggregate_region(
-    df, variable, region, subregions=None, components=False, method="sum", weight=None, drop_negative=True
+        df,
+        variable,
+        region,
+        subregions=None,
+        components=False,
+        method="sum",
+        weight=None,
+        drop_negative=True
 ):
     """Internal implementation for aggregating data over subregions"""
     if not isstr(variable) and components is not False:
@@ -107,7 +114,10 @@ def _aggregate_region(
     else:
         weight_rows = subregion_df._apply_filters(variable=weight)
         _data = _agg_weight(
-            subregion_df._data[rows], subregion_df._data[weight_rows], method, drop_negative
+            subregion_df._data[rows],
+            subregion_df._data[weight_rows],
+            method,
+            drop_negative
         )
 
     # if not `components=False`, add components at the `region` level
@@ -183,9 +193,11 @@ def _agg_weight(data, weight, method, drop_negative):
 
     if drop_negative is True:
         if any(i < 0 for i in weight):
-            logger.warning("Some of the weights are negative. All data with negative values will be dropped. "
-                          "If you don't want the values to be dropped please use the keyword drop_negative=False")
-        # Drop negative weights
+            logger.warning("Some of the weights are negative. "
+                           "All data with negative values will be dropped. "
+                           "If you don't want the values to be dropped "
+                           "please use the keyword drop_negative=False")
+            # Drop negative weights
             for index, value in weight.items():
                 if value < 0:
                     weight = weight.drop(labels=[index])

--- a/pyam/_aggregate.py
+++ b/pyam/_aggregate.py
@@ -78,14 +78,14 @@ def _aggregate_recursive(df, variable):
 
 
 def _aggregate_region(
-        df,
-        variable,
-        region,
-        subregions=None,
-        components=False,
-        method="sum",
-        weight=None,
-        drop_negative=True
+    df,
+    variable,
+    region,
+    subregions=None,
+    components=False,
+    method="sum",
+    weight=None,
+    drop_negative=True,
 ):
     """Internal implementation for aggregating data over subregions"""
     if not isstr(variable) and components is not False:
@@ -117,7 +117,7 @@ def _aggregate_region(
             subregion_df._data[rows],
             subregion_df._data[weight_rows],
             method,
-            drop_negative
+            drop_negative,
         )
 
     # if not `components=False`, add components at the `region` level
@@ -193,10 +193,12 @@ def _agg_weight(data, weight, method, drop_negative):
 
     if drop_negative is True:
         if any(i < 0 for i in weight):
-            logger.warning("Some of the weights are negative. "
-                           "All data with negative values will be dropped. "
-                           "If you don't want the values to be dropped "
-                           "please use the keyword drop_negative=False")
+            logger.warning(
+                "Some of the weights are negative. "
+                "All data with negative values will be dropped. "
+                "If you don't want the values to be dropped "
+                "please use the keyword drop_negative=False"
+            )
             # Drop negative weights
             for index, value in weight.items():
                 if value < 0:

--- a/pyam/_aggregate.py
+++ b/pyam/_aggregate.py
@@ -78,14 +78,7 @@ def _aggregate_recursive(df, variable):
 
 
 def _aggregate_region(
-    df,
-    variable,
-    region,
-    subregions=None,
-    components=False,
-    method="sum",
-    weight=None,
-    drop_negative=True,
+    df, variable, region, subregions=None, components=False, method="sum", weight=None
 ):
     """Internal implementation for aggregating data over subregions"""
     if not isstr(variable) and components is not False:
@@ -114,10 +107,7 @@ def _aggregate_region(
     else:
         weight_rows = subregion_df._apply_filters(variable=weight)
         _data = _agg_weight(
-            subregion_df._data[rows],
-            subregion_df._data[weight_rows],
-            method,
-            drop_negative,
+            subregion_df._data[rows], subregion_df._data[weight_rows], method
         )
 
     # if not `components=False`, add components at the `region` level
@@ -179,7 +169,7 @@ def _group_and_agg(df, by, method=np.sum):
     return df.groupby(cols).agg(_get_method_func(method))
 
 
-def _agg_weight(data, weight, method, drop_negative):
+def _agg_weight(data, weight, method):
     """Aggregate `data` by regions with weights, return indexed `pd.Series`"""
 
     # only summation allowed with weights
@@ -190,19 +180,6 @@ def _agg_weight(data, weight, method, drop_negative):
 
     if not data.droplevel(["variable", "unit"]).index.equals(weight.index):
         raise ValueError("Inconsistent index between variable and weight!")
-
-    if drop_negative is True:
-        if any(i < 0 for i in weight):
-            logger.warning(
-                "Some of the weights are negative. "
-                "All data with negative values will be dropped. "
-                "If you don't want the values to be dropped "
-                "please use the keyword drop_negative=False"
-            )
-            # Drop negative weights
-            for index, value in weight.items():
-                if value < 0:
-                    weight = weight.drop(labels=[index])
 
     col1 = data.index.names.difference(["region"])
     col2 = data.index.names.difference(["region", "variable", "unit"])

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1323,6 +1323,7 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         append=False,
+        drop_negative=True
     ):
         """Aggregate a timeseries over a number of subregions
 
@@ -1351,6 +1352,8 @@ class IamDataFrame(object):
         append : bool, default False
             append the aggregate timeseries to `self` and return None,
             else return aggregate timeseries as new :class:`IamDataFrame`
+        drop_negative : bool, default True
+            drops negative weights for aggregation (e.g. emission is negative)
         """
         _df = _aggregate_region(
             self,
@@ -1360,6 +1363,7 @@ class IamDataFrame(object):
             components=components,
             method=method,
             weight=weight,
+            drop_negative=drop_negative,
         )
 
         # else, append to `self` or return as `IamDataFrame`
@@ -1379,6 +1383,7 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         exclude_on_fail=False,
+        drop_negative=True,
         **kwargs,
     ):
         """Check whether a timeseries matches the aggregation across subregions
@@ -1404,12 +1409,14 @@ class IamDataFrame(object):
             (currently only supported with `method='sum'`)
         exclude_on_fail : boolean, optional
             flag scenarios failing validation as `exclude: True`
+        drop_negative : bool, default True
+            drops negative weights for aggregation (e.g. emission is negative)
         kwargs : arguments for comparison of values
             passed to :func:`numpy.isclose`
         """
         # compute aggregate from subregions, return None if no subregions
         df_subregions = _aggregate_region(
-            self, variable, region, subregions, components, method, weight
+            self, variable, region, subregions, components, method, weight, drop_negative
         )
 
         if df_subregions is None:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1323,7 +1323,6 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         append=False,
-        drop_negative=True,
     ):
         """Aggregate a timeseries over a number of subregions
 
@@ -1352,8 +1351,6 @@ class IamDataFrame(object):
         append : bool, default False
             append the aggregate timeseries to `self` and return None,
             else return aggregate timeseries as new :class:`IamDataFrame`
-        drop_negative : bool, default True
-            drops negative weights for aggregation (e.g. emission is negative)
         """
         _df = _aggregate_region(
             self,
@@ -1363,7 +1360,6 @@ class IamDataFrame(object):
             components=components,
             method=method,
             weight=weight,
-            drop_negative=drop_negative,
         )
 
         # else, append to `self` or return as `IamDataFrame`
@@ -1383,7 +1379,6 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         exclude_on_fail=False,
-        drop_negative=True,
         **kwargs,
     ):
         """Check whether a timeseries matches the aggregation across subregions
@@ -1409,21 +1404,12 @@ class IamDataFrame(object):
             (currently only supported with `method='sum'`)
         exclude_on_fail : boolean, optional
             flag scenarios failing validation as `exclude: True`
-        drop_negative : bool, default True
-            drops negative weights for aggregation (e.g. emission is negative)
         kwargs : arguments for comparison of values
             passed to :func:`numpy.isclose`
         """
         # compute aggregate from subregions, return None if no subregions
         df_subregions = _aggregate_region(
-            self,
-            variable,
-            region,
-            subregions,
-            components,
-            method,
-            weight,
-            drop_negative,
+            self, variable, region, subregions, components, method, weight
         )
 
         if df_subregions is None:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1323,6 +1323,7 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         append=False,
+        drop_negative_weights=True,
     ):
         """Aggregate a timeseries over a number of subregions
 
@@ -1333,9 +1334,9 @@ class IamDataFrame(object):
         ----------
         variable : str or list of str
             variable(s) to be aggregated
-        region : str, default 'World'
+        region : str, optional
             region to which data will be aggregated
-        subregions : list of str
+        subregions : list of str, optional
             list of subregions, defaults to all regions other than `region`
         components : bool or list of str, optional
             variables at the `region` level to be included in the aggregation
@@ -1360,6 +1361,7 @@ class IamDataFrame(object):
             components=components,
             method=method,
             weight=weight,
+            drop_negative_weights=drop_negative_weights,
         )
 
         # else, append to `self` or return as `IamDataFrame`
@@ -1379,6 +1381,7 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         exclude_on_fail=False,
+        drop_negative_weights=True,
         **kwargs,
     ):
         """Check whether a timeseries matches the aggregation across subregions
@@ -1387,11 +1390,11 @@ class IamDataFrame(object):
         ----------
         variable : str or list of str
             variable(s) to be checked for matching aggregation of subregions
-        region : str, default 'World'
+        region : str, optional
             region to be checked for matching aggregation of subregions
-        subregions : list of str
+        subregions : list of str, optional
             list of subregions, defaults to all regions other than `region`
-        components : bool or list of str, default False
+        components : bool or list of str, optional
             variables at the `region` level to be included in the aggregation
             (ignored if False); if `True`, use all sub-categories of `variable`
             included in `region` but not in any of the `subregions`;
@@ -1404,12 +1407,21 @@ class IamDataFrame(object):
             (currently only supported with `method='sum'`)
         exclude_on_fail : boolean, optional
             flag scenarios failing validation as `exclude: True`
+        drop_negative_weights : bool, optional
+            removes any aggregated values that are computed using negative weights
         kwargs : arguments for comparison of values
             passed to :func:`numpy.isclose`
         """
         # compute aggregate from subregions, return None if no subregions
         df_subregions = _aggregate_region(
-            self, variable, region, subregions, components, method, weight
+            self,
+            variable,
+            region,
+            subregions,
+            components,
+            method,
+            weight,
+            drop_negative_weights,
         )
 
         if df_subregions is None:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1416,7 +1416,14 @@ class IamDataFrame(object):
         """
         # compute aggregate from subregions, return None if no subregions
         df_subregions = _aggregate_region(
-            self, variable, region, subregions, components, method, weight, drop_negative
+            self,
+            variable,
+            region,
+            subregions,
+            components,
+            method,
+            weight,
+            drop_negative
         )
 
         if df_subregions is None:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1323,7 +1323,7 @@ class IamDataFrame(object):
         method="sum",
         weight=None,
         append=False,
-        drop_negative=True
+        drop_negative=True,
     ):
         """Aggregate a timeseries over a number of subregions
 
@@ -1423,7 +1423,7 @@ class IamDataFrame(object):
             components,
             method,
             weight,
-            drop_negative
+            drop_negative,
         )
 
         if df_subregions is None:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1346,12 +1346,14 @@ class IamDataFrame(object):
         method : func or str, optional
             method to use for aggregation,
             e.g. :func:`numpy.mean`, :func:`numpy.sum`, 'min', 'max'
-        weight : str, default None
+        weight : str, optional
             variable to use as weight for the aggregation
             (currently only supported with `method='sum'`)
-        append : bool, default False
+        append : bool, optional
             append the aggregate timeseries to `self` and return None,
             else return aggregate timeseries as new :class:`IamDataFrame`
+        drop_negative_weights : bool, optional
+            removes any aggregated values that are computed using negative weights
         """
         _df = _aggregate_region(
             self,

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -320,8 +320,10 @@ def test_aggregate_region_with_components(simple_df):
 )
 def test_agg_weight(data, variable, weight):
 
-    test_1 = IamDataFrame(data).aggregate_region(variable, weight=weight, drop_negative=False)._data
-    test_2 = IamDataFrame(data).aggregate_region(variable, weight=weight, drop_negative=True)._data
+    test_1 = IamDataFrame(data)\
+        .aggregate_region(variable, weight=weight, drop_negative=False)._data
+    test_2 = IamDataFrame(data)\
+        .aggregate_region(variable, weight=weight, drop_negative=True)._data
 
     assert not test_1.equals(test_2)
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -314,16 +314,20 @@ def test_aggregate_region_with_components(simple_df):
 
 @pytest.mark.parametrize(
     "data, variable, weight",
-    (
-        (NEG_WEIGHTS_DF, 'Price|Carbon', 'Emissions|CO2'),
-    ),
+    ((NEG_WEIGHTS_DF, "Price|Carbon", "Emissions|CO2"),),
 )
 def test_agg_weight(data, variable, weight):
 
-    test_1 = IamDataFrame(data)\
-        .aggregate_region(variable, weight=weight, drop_negative=False)._data
-    test_2 = IamDataFrame(data)\
-        .aggregate_region(variable, weight=weight, drop_negative=True)._data
+    test_1 = (
+        IamDataFrame(data)
+        .aggregate_region(variable, weight=weight, drop_negative=False)
+        ._data
+    )
+    test_2 = (
+        IamDataFrame(data)
+        .aggregate_region(variable, weight=weight, drop_negative=True)
+        ._data
+    )
 
     assert not test_1.equals(test_2)
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from pyam import check_aggregate, IamDataFrame, IAMC_IDX
 from pyam.testing import assert_iamframe_equal
+
 from conftest import TEST_YEARS, DTS_MAPPING
 
 LONG_IDX = IAMC_IDX + ["year"]
@@ -50,20 +51,6 @@ RECURSIVE_DF = pd.DataFrame(
         ["Secondary Energy|Electricity|Solar", "EJ/yr", np.nan, 2],
     ],
     columns=["variable", "unit"] + TEST_YEARS,
-)
-
-NEG_WEIGHTS_DF = pd.DataFrame(
-    [
-        ["model_a", "scen_a", "reg_a", "Emissions|CO2", "EJ/yr", 2005, -4.0],
-        ["model_a", "scen_a", "reg_a", "Emissions|CO2", "EJ/yr", 2010, 5.0],
-        ["model_a", "scen_a", "reg_b", "Emissions|CO2", "EJ/yr", 2005, 2.0],
-        ["model_a", "scen_a", "reg_b", "Emissions|CO2", "EJ/yr", 2010, 3.0],
-        ["model_a", "scen_a", "reg_a", "Price|Carbon", "USD/tCO2", 2005, 6.0],
-        ["model_a", "scen_a", "reg_a", "Price|Carbon", "USD/tCO2", 2010, 6.0],
-        ["model_a", "scen_a", "reg_b", "Price|Carbon", "USD/tCO2", 2005, 3.0],
-        ["model_a", "scen_a", "reg_b", "Price|Carbon", "USD/tCO2", 2010, 4.0],
-    ],
-    columns=LONG_IDX + ["value"],
 )
 
 
@@ -310,26 +297,6 @@ def test_aggregate_region_with_components(simple_df):
     # rename emissions of bunker to test setting components as list
     _df = simple_df.rename(variable={"Emissions|CO2|Bunkers": "foo"})
     assert _df.check_aggregate_region(v, components=["foo"]) is None
-
-
-@pytest.mark.parametrize(
-    "data, variable, weight",
-    ((NEG_WEIGHTS_DF, "Price|Carbon", "Emissions|CO2"),),
-)
-def test_agg_weight(data, variable, weight):
-
-    test_1 = (
-        IamDataFrame(data)
-        .aggregate_region(variable, weight=weight, drop_negative=False)
-        ._data
-    )
-    test_2 = (
-        IamDataFrame(data)
-        .aggregate_region(variable, weight=weight, drop_negative=True)
-        ._data
-    )
-
-    assert not test_1.equals(test_2)
 
 
 def test_aggregate_region_with_weights(simple_df):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -41,17 +41,6 @@ PRICE_MAX_DF = pd.DataFrame(
     columns=LONG_IDX + ["value"],
 )
 
-RECURSIVE_DF = pd.DataFrame(
-    [
-        ["Secondary Energy|Electricity", "EJ/yr", 5, 19.0],
-        ["Secondary Energy|Electricity|Wind", "EJ/yr", 5, 17],
-        ["Secondary Energy|Electricity|Wind|Offshore", "EJ/yr", 1, 5],
-        ["Secondary Energy|Electricity|Wind|Onshore", "EJ/yr", 4, 12],
-        ["Secondary Energy|Electricity|Solar", "EJ/yr", np.nan, 2],
-    ],
-    columns=["variable", "unit"] + TEST_YEARS,
-)
-
 NEG_WEIGHTS_DF = pd.DataFrame(
     [
         ["model_a", "scen_a", "reg_a", "Emissions|CO2", "EJ/yr", 2005, -4.0],


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

# Description of PR
This PR implements the proposed 8th solution of the issue #446  

> Write a warning when weights are negative and add a keyword-argument whether to drop (default) or not any values aggregated with negative weights.

By default any values with negative weights are getting now dropped. Additionally a warning's is beeing printed: 

![Warning](https://user-images.githubusercontent.com/57132039/118485607-eee4c400-b718-11eb-8c09-8b4373296258.PNG)

With the implemented boolean keyword argument `drop_negative` (default is True) this dropping can be overwritten by setting this keyword to False.

closes #446 