### PR TITLE
Add unit tests for using binary ops with numerical args

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#537](https://github.com/IAMconsortium/pyam/pull/537) Enhance binary ops to support numerical arguments
 - [#533](https://github.com/IAMconsortium/pyam/pull/533) Add an `apply()` function for custom mathematical operations
 - [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe basic mathematical operations `subtract`, `add`, `multiply`, `divide`
 - [#523](https://github.com/IAMconsortium/pyam/pull/523) Add feature to compute weights for de-biasing using count

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -33,7 +33,7 @@ def _op_data(df, method_args, name, method, axis, **kwds):
 
     _value = method(*_args, **kwds)
     if not isinstance(_value, pd.Series):
-        msg = "The value returned by the method cannot be cast to an IamDataFrame"
+        msg = f"Value returned by `{method.__name__}` cannot be cast to an IamDataFrame"
         raise ValueError(f"{msg}: {_value}")
     _value.index = append_index_level(_value.index, codes=0, level=name, name=axis)
 

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -31,6 +31,9 @@ def _op_data(df, method_args, name, method, axis, **kwds):
         kwds[key] = _get_values(df, axis, value, cols)
 
     _value = method(*_args, **kwds)
+    if not isinstance(_value, pd.Series):
+        msg = "The value returned by the method cannot be cast to an IamDataFrame"
+        raise ValueError(f"{msg}: {_value}")
     _value.index = append_index_level(_value.index, codes=0, level=name, name=axis)
 
     return _value

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -41,8 +41,7 @@ def _op_data(df, method_args, name, method, axis, **kwds):
 
 
 def _get_values(df, axis, value, cols):
-    """Return the value of the time series, if value is in axis. Otherwise
-    return values itself.
+    """Return grouped data if value is in axis. Otherwise return value.
 
     Parameters
     ----------

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -12,7 +12,7 @@ KNOWN_OPS = {
 }
 
 
-def _op_data(df, method_args, name, method, axis, **kwds):
+def _op_data(df, name, method, axis, args=(), **kwds):
     """Internal implementation of numerical operations on timeseries"""
 
     if axis not in df._data.index.names:
@@ -26,7 +26,7 @@ def _op_data(df, method_args, name, method, axis, **kwds):
         raise ValueError(f"Unknown method: {method}")
 
     cols = df._data.index.names.difference([axis])
-    _args = [_get_values(df, axis, value, cols) for value in method_args]
+    _args = [_get_values(df, axis, value, cols) for value in args]
 
     for key, value in kwds.items():
         kwds[key] = _get_values(df, axis, value, cols)

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -1,4 +1,5 @@
 import operator
+import pandas as pd
 from pyam.index import append_index_level, get_index_levels
 from pyam.utils import to_list
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1802,7 +1802,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, (a, b), name, "add", axis=axis)
+        _value = _op_data(self, name, "add", axis=axis, args=(a, b))
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1832,7 +1832,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, (a, b), name, "subtract", axis=axis)
+        _value = _op_data(self, name, "subtract", axis=axis, args=(a, b))
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1862,7 +1862,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, (a, b), name, "multiply", axis=axis)
+        _value = _op_data(self, name, "multiply", axis=axis, args=(a, b))
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1892,7 +1892,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, (a, b), name, "divide", axis=axis)
+        _value = _op_data(self, name, "divide", axis=axis, args=(a, b))
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1928,7 +1928,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, args, name, func, axis=axis, **kwds)
+        _value = _op_data(self, name, func, axis=axis, args=args, **kwds)
         if append:
             self.append(_value, inplace=True)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1788,7 +1788,7 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        a, b : str or list of str
+        a, b : str, list of str or a number
             Items to be used for the addition.
         name : str
             Name of the computed timeseries data on the `axis`.
@@ -1818,7 +1818,7 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        a, b : str or list of str
+        a, b : str, list of str or a number
             Items to be used for the subtraction.
         name : str
             Name of the computed timeseries data on the `axis`.
@@ -1848,7 +1848,7 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        a, b : str or list of str
+        a, b : str, list of str or a number
             Items to be used for the division.
         name : str
             Name of the computed timeseries data on the `axis`.
@@ -1878,7 +1878,7 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        a, b : str or list of str
+        a, b : str, list of str or a number
             Items to be used for the division.
         name : str
             Name of the computed timeseries data on the `axis`.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2508,15 +2508,15 @@ def compare(
     """
     ret = pd.concat(
         {
-            right_label: right.data.set_index(right._LONG_IDX),
             left_label: left.data.set_index(left._LONG_IDX),
+            right_label: right.data.set_index(right._LONG_IDX),
         },
         axis=1,
     )
     ret.columns = ret.columns.droplevel(1)
     if drop_close:
         ret = ret[~np.isclose(ret[left_label], ret[right_label], **kwargs)]
-    return ret[[right_label, left_label]]
+    return ret
 
 
 def concat(dfs, ignore_meta_conflict=False, **kwargs):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -264,11 +264,11 @@ def format_data(df, index, **kwargs):
     # check that index and required columns exist
     missing_index = [c for c in index if c not in df.columns]
     if missing_index:
-        raise ValueError(f"Missing index columns `{missing_index}`!")
+        raise ValueError(f"Missing index columns: {missing_index}")
 
     missing_required_col = [c for c in REQUIRED_COLS if c not in df.columns]
     if missing_required_col:
-        raise ValueError(f"Missing required columns `{missing_required_col}`!")
+        raise ValueError(f"Missing required columns: {missing_required_col}")
 
     # check whether data in wide format (IAMC) or long format (`value` column)
     if "value" in df.columns:
@@ -278,8 +278,7 @@ def format_data(df, index, **kwargs):
         elif "time" in df.columns:
             time_col = "time"
         else:
-            msg = "Invalid time format, must have either `year` or `time`!"
-            raise ValueError(msg)
+            raise ValueError("Invalid time format, must have either `year` or `time`!")
         extra_cols = [
             c
             for c in df.columns
@@ -306,8 +305,7 @@ def format_data(df, index, **kwargs):
             time_col = "time"
             melt_cols = time_cols
         else:
-            msg = "invalid column format, must be either years or `datetime`!"
-            raise ValueError(msg)
+            raise ValueError("Invalid time format, must be either years or `datetime`!")
         cols = index + REQUIRED_COLS + extra_cols
         df = pd.melt(
             df,

--- a/tests/test_feature_compare.py
+++ b/tests/test_feature_compare.py
@@ -10,15 +10,15 @@ def test_compare(test_df):
     clone._data.iloc[0] = 2
     clone.rename(variable={"Primary Energy|Coal": "Primary Energy|Gas"}, inplace=True)
 
-    obs = compare(test_df, clone, right_label="test_df", left_label="clone")
+    obs = compare(test_df, clone, left_label="test_df", right_label="clone")
 
     exp = pd.DataFrame(
         [
-            ["Primary Energy", "EJ/yr", dt.datetime(2005, 6, 17), 2, 1],
-            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2005, 6, 17), np.nan, 0.5],
-            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2010, 7, 21), np.nan, 3],
-            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2005, 6, 17), 0.5, np.nan],
-            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2010, 7, 21), 3, np.nan],
+            ["Primary Energy", "EJ/yr", dt.datetime(2005, 6, 17), 1, 2],
+            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2005, 6, 17), 0.5, np.nan],
+            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2010, 7, 21), 3, np.nan],
+            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2005, 6, 17), np.nan, 0.5],
+            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2010, 7, 21), np.nan, 3],
         ],
         columns=["variable", "unit", "time", "test_df", "clone"],
     )

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -8,7 +8,7 @@ from pyam._ops import _op_data
 
 def test_add_raises(test_df_year):
     """Calling an operation with args that don't return an IamDataFrame raises"""
-    match = "The value returned by the method cannot be cast to an IamDataFrame: 5"
+    match = "Value returned by `add` cannot be cast to an IamDataFrame: 5"
     with pytest.raises(ValueError, match=match):
         test_df_year.add(2, 3, "foo")
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -6,27 +6,32 @@ from pyam.testing import assert_iamframe_equal
 from pyam._ops import _op_data
 
 
+@pytest.mark.parametrize(
+    "arg, value",
+    (
+        ("Primary Energy|Coal", ["scen_a", 1 + 0.5, 6 + 3]),
+        (2, [["scen_a", "scen_b"], [1 + 2, 2 + 2], [6 + 2, 7 + 2]]),
+    ),
+)
 @pytest.mark.parametrize("append", (False, True))
-def test_add_variable(test_df_year, append):
+def test_add_variable(test_df_year, arg, value, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    v = ("Primary Energy", "Primary Energy|Coal", "Sum")
     exp = IamDataFrame(
-        pd.DataFrame([1 + 0.5, 6 + 3], index=[2005, 2010]).T,
+        pd.DataFrame(value, index=["scenario", 2005, 2010]).T,
         model="model_a",
-        scenario="scen_a",
         region="World",
-        variable=v[2],
+        variable="Sum",
         unit="EJ/yr",
         meta=test_df_year.meta,
     )
 
     if append:
         obs = test_df_year.copy()
-        obs.add(*v, append=True)
+        obs.add("Primary Energy", arg, "Sum", append=True)
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
-        assert_iamframe_equal(exp, test_df_year.add(*v))
+        assert_iamframe_equal(exp, test_df_year.add("Primary Energy", arg, "Sum"))
 
 
 @pytest.mark.parametrize("append", (False, True))
@@ -52,27 +57,32 @@ def test_add_scenario(test_df_year, append):
         assert_iamframe_equal(exp, obs)
 
 
+@pytest.mark.parametrize(
+    "arg, value",
+    (
+        ("Primary Energy|Coal", ["scen_a", 1 - 0.5, 6 - 3]),
+        (2, [["scen_a", "scen_b"], [1 - 2, 2 - 2], [6 - 2, 7 - 2]]),
+    ),
+)
 @pytest.mark.parametrize("append", (False, True))
-def test_subtract_variable(test_df_year, append):
+def test_subtract_variable(test_df_year, arg, value, append):
     """Verify that in-dataframe subtraction works on the default `variable` axis"""
 
-    v = ("Primary Energy", "Primary Energy|Coal", "Primary Energy|Other")
     exp = IamDataFrame(
-        pd.DataFrame([1 - 0.5, 6 - 3], index=[2005, 2010]).T,
+        pd.DataFrame(value, index=["scenario", 2005, 2010]).T,
         model="model_a",
-        scenario="scen_a",
         region="World",
-        variable=v[2],
+        variable="Diff",
         unit="EJ/yr",
         meta=test_df_year.meta,
     )
 
     if append:
         obs = test_df_year.copy()
-        obs.subtract(*v, append=True)
+        obs.subtract("Primary Energy", arg, "Diff", append=True)
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
-        obs = test_df_year.subtract(*v)
+        obs = test_df_year.subtract("Primary Energy", arg, "Diff")
         assert_iamframe_equal(exp, obs)
 
 
@@ -99,27 +109,33 @@ def test_subtract_scenario(test_df_year, append):
         assert_iamframe_equal(exp, obs)
 
 
+@pytest.mark.parametrize(
+    "arg, value",
+    (
+        ("Primary Energy|Coal", ["scen_a", 1 * 0.5, 6 * 3]),
+        (2, [["scen_a", "scen_b"], [1 * 2, 2 * 2], [6 * 2, 7 * 2]]),
+    ),
+)
 @pytest.mark.parametrize("append", (False, True))
-def test_multiply_variable(test_df_year, append):
+def test_multiply_variable(test_df_year, arg, value, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    v = ("Primary Energy", "Primary Energy|Coal", "Product")
+    v = ("Primary Energy", arg, "Product")
     exp = IamDataFrame(
-        pd.DataFrame([1 * 0.5, 6 * 3], index=[2005, 2010]).T,
+        pd.DataFrame(value, index=["scenario", 2005, 2010]).T,
         model="model_a",
-        scenario="scen_a",
         region="World",
-        variable=v[2],
+        variable="Prod",
         unit="EJ/yr",
         meta=test_df_year.meta,
     )
 
     if append:
         obs = test_df_year.copy()
-        obs.multiply(*v, append=True)
+        obs.multiply("Primary Energy", arg, "Prod", append=True)
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
-        assert_iamframe_equal(exp, test_df_year.multiply(*v))
+        assert_iamframe_equal(exp, test_df_year.multiply("Primary Energy", arg, "Prod"))
 
 
 @pytest.mark.parametrize("append", (False, True))
@@ -145,27 +161,32 @@ def test_multiply_scenario(test_df_year, append):
         assert_iamframe_equal(exp, obs)
 
 
+@pytest.mark.parametrize(
+    "arg, value",
+    (
+        ("Primary Energy|Coal", ["scen_a", 1 / 0.5, 6 / 3]),
+        (2, [["scen_a", "scen_b"], [1 / 2, 2 / 2], [6 / 2, 7 / 2]]),
+    ),
+)
 @pytest.mark.parametrize("append", (False, True))
-def test_divide_variable(test_df_year, append):
+def test_divide_variable(test_df_year, arg, value, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    v = ("Primary Energy", "Primary Energy|Coal", "Ratio")
     exp = IamDataFrame(
-        pd.DataFrame([1 / 0.5, 6 / 3], index=[2005, 2010]).T,
+        pd.DataFrame(value, index=["scenario", 2005, 2010]).T,
         model="model_a",
-        scenario="scen_a",
         region="World",
-        variable=v[2],
+        variable="Ratio",
         unit="EJ/yr",
         meta=test_df_year.meta,
     )
 
     if append:
         obs = test_df_year.copy()
-        obs.divide(*v, append=True)
+        obs.divide("Primary Energy", arg, "Ratio", append=True)
         assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
-        assert_iamframe_equal(exp, test_df_year.divide(*v))
+        assert_iamframe_equal(exp, test_df_year.divide("Primary Energy", arg, "Ratio"))
 
 
 @pytest.mark.parametrize("append", (False, True))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -258,10 +258,10 @@ def test_apply_variable(plot_stackplot_df, append):
 def test_ops_unknown_axis(test_df_year):
     """Using an unknown axis raises an error"""
     with pytest.raises(ValueError, match="Unknown axis: foo"):
-        _op_data(test_df_year, "_", "_", "_", "foo")
+        _op_data(test_df_year, "_", "_", "foo")
 
 
 def test_ops_unknown_method(test_df_year):
     """Using an unknown method raises an error"""
     with pytest.raises(ValueError, match="Unknown method: foo"):
-        _op_data(test_df_year, "_", "_", "foo", "variable")
+        _op_data(test_df_year, "_", "foo", "variable")

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -6,6 +6,13 @@ from pyam.testing import assert_iamframe_equal
 from pyam._ops import _op_data
 
 
+def test_add_raises(test_df_year):
+    """Calling an operation with args that don't return an IamDataFrame raises"""
+    match = "The value returned by the method cannot be cast to an IamDataFrame: 5"
+    with pytest.raises(ValueError, match=match):
+        test_df_year.add(2, 3, "foo")
+
+
 @pytest.mark.parametrize(
     "arg, value",
     (

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -127,7 +127,6 @@ def test_subtract_scenario(test_df_year, append):
 def test_multiply_variable(test_df_year, arg, value, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    v = ("Primary Energy", arg, "Product")
     exp = IamDataFrame(
         pd.DataFrame(value, index=["scenario", 2005, 2010]).T,
         model="model_a",


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

PR #533 implicitly generalized the binary-operation methods to enable using numbers as arguments. This PR adds unit tests to make sure this continues to work as expected, updates the docstrings, and adds a sanity check if a user would do something like `df.add(2, 3, "foo")`, where the return-object cannot be cast to an IamDataFrame.

closes #530
