### PR TITLE
Add option to set defaults in binary operations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#538](https://github.com/IAMconsortium/pyam/pull/538) Add option to set defaults in binary operations
 - [#537](https://github.com/IAMconsortium/pyam/pull/537) Enhance binary ops to support numerical arguments
 - [#533](https://github.com/IAMconsortium/pyam/pull/533) Add an `apply()` function for custom mathematical operations
 - [#527](https://github.com/IAMconsortium/pyam/pull/527) Add an in-dataframe basic mathematical operations `subtract`, `add`, `multiply`, `divide`

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -4,11 +4,28 @@ from pyam.index import append_index_level, get_index_levels
 from pyam.utils import to_list
 
 
+# these functions have to be defined explicitly to allow calling them with keyword args
+def add(a, b):
+    return operator.add(a, b)
+
+
+def subtract(a, b):
+    return operator.sub(a, b)
+
+
+def multiply(a, b):
+    return operator.mul(a, b)
+
+
+def divide(a, b):
+    return operator.truediv(a, b)
+
+
 KNOWN_OPS = {
-    "add": operator.add,
-    "subtract": operator.sub,
-    "multiply": operator.mul,
-    "divide": operator.truediv,
+    "add": add,
+    "subtract": subtract,
+    "multiply": multiply,
+    "divide": divide,
 }
 
 

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -43,21 +43,43 @@ def _op_data(df, name, method, axis, fillna=None, args=(), **kwds):
         raise ValueError(f"Unknown method: {method}")
 
     cols = df._data.index.names.difference([axis])
-    _args = [_get_values(df, axis, value, cols) for value in args]
 
-    for key, value in kwds.items():
-        kwds[key] = _get_values(df, axis, value, cols)
+    # replace args and and kwds with values of `df._data` if applicable
+    _args, _data_args = [None] * len(args), [False] * len(args)
+    for i, value in enumerate(args):
+        _args[i], _data_args[i] = _get_values(df, axis, value, cols, f"_arg{i}")
 
+    _data_kwds = {}
+    for i, (key, value) in enumerate(kwds.items()):
+        kwds[key], _data_kwds[key] = _get_values(df, axis, value, cols, key)
+
+    # merge all args and kwds that are based on `df._data` to apply fillna
+    if fillna:
+        _data_cols = [_args[i] for i, is_data in enumerate(_data_args) if is_data]
+        _data_cols += [kwds[key] for key, is_data in _data_kwds.items() if is_data]
+        _data = pd.merge(*_data_cols, how="outer", left_index=True, right_index=True)
+
+        _data.fillna(fillna, inplace=True)
+
+        for i, is_data in enumerate(_data_args):
+            if is_data:
+                _args[i] = _data[f"_arg{i}"]
+        for key, is_data in _data_kwds.items():
+            if is_data:
+                kwds[key] = _data[key]
+
+    # apply method and check that returned object is valid
     _value = method(*_args, **kwds)
     if not isinstance(_value, pd.Series):
         msg = f"Value returned by `{method.__name__}` cannot be cast to an IamDataFrame"
         raise ValueError(f"{msg}: {_value}")
+
+    # insert the index level and reset the series name
     _value.index = append_index_level(_value.index, codes=0, level=name, name=axis)
+    return _value.rename(index=None)
 
-    return _value
 
-
-def _get_values(df, axis, value, cols):
+def _get_values(df, axis, value, cols, name):
     """Return grouped data if value is in axis. Otherwise return value.
 
     Parameters
@@ -70,6 +92,8 @@ def _get_values(df, axis, value, cols):
         Either str or list of str in axis or anything else.
     cols : list
         Columns in df that are not `axis`.
+    name : str
+        Name of the returned pd.Series.
 
     Returns
     -------
@@ -77,6 +101,7 @@ def _get_values(df, axis, value, cols):
 
     """
     if any(v in get_index_levels(df._data, axis) for v in to_list(value)):
-        return df.filter(**{axis: value})._data.groupby(cols).sum()
+        _data = df.filter(**{axis: value})._data.groupby(cols).sum().rename(index=name)
+        return _data, True
     else:
-        return value
+        return value, False

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -45,6 +45,7 @@ def _op_data(df, name, method, axis, fillna=None, args=(), **kwds):
     cols = df._data.index.names.difference([axis])
 
     # replace args and and kwds with values of `df._data` if applicable
+    # _data_args and _data_kwds track if an argument was replaced by `df._data` values
     _args, _data_args = [None] * len(args), [False] * len(args)
     for i, value in enumerate(args):
         _args[i], _data_args[i] = _get_values(df, axis, value, cols, f"_arg{i}")

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -29,7 +29,7 @@ KNOWN_OPS = {
 }
 
 
-def _op_data(df, name, method, axis, args=(), **kwds):
+def _op_data(df, name, method, axis, fillna=None, args=(), **kwds):
     """Internal implementation of numerical operations on timeseries"""
 
     if axis not in df._data.index.names:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1796,7 +1796,7 @@ class IamDataFrame(object):
             Axis along which to compute.
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
-            Can be a scalar or a dictionary of the form :code:`{item: default}`.
+            Can be a scalar or a dictionary of the form :code:`{arg: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1829,7 +1829,7 @@ class IamDataFrame(object):
             Axis along which to compute.
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
-            Can be a scalar or a dictionary of the form :code:`{item: default}`.
+            Can be a scalar or a dictionary of the form :code:`{arg: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1862,7 +1862,7 @@ class IamDataFrame(object):
             Axis along which to compute.
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
-            Can be a scalar or a dictionary of the form :code:`{item: default}`.
+            Can be a scalar or a dictionary of the form :code:`{arg: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1895,7 +1895,7 @@ class IamDataFrame(object):
             Axis along which to compute.
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
-            Can be a scalar or a dictionary of the form :code:`{item: default}`.
+            Can be a scalar or a dictionary of the form :code:`{arg: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1778,13 +1778,13 @@ class IamDataFrame(object):
         else:
             self.meta[col] = self.meta[col].apply(func, *args, **kwargs)
 
-    def add(self, a, b, name, axis="variable", append=False):
+    def add(self, a, b, name, axis="variable", fillna=None, append=False):
         """Compute the addition of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a + b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
-        If either `a` or `b` are not defined for a row, no value is computed
-        for that row.
+        If either `a` or `b` are not defined for a row and `fillna` is not specified,
+        no value is computed for that row.
 
         Parameters
         ----------
@@ -1794,6 +1794,9 @@ class IamDataFrame(object):
             Name of the computed timeseries data on the `axis`.
         axis : str, optional
             Axis along which to compute.
+        fillna : dict or scalar, optional
+            Value to fill holes when rows are not defined for either `a` or `b`.
+            Can be a scalar or a dictionary of the form :code:`{item: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1802,19 +1805,19 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "add", axis=axis, a=a, b=b)
+        _value = _op_data(self, name, "add", axis=axis, fillna=fillna, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def subtract(self, a, b, name, axis="variable", append=False):
+    def subtract(self, a, b, name, axis="variable", fillna=None, append=False):
         """Compute the difference of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a - b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
-        If either `a` or `b` are not defined for a row, no value is computed
-        for that row.
+        If either `a` or `b` are not defined for a row and `fillna` is not specified,
+        no value is computed for that row.
 
         Parameters
         ----------
@@ -1824,6 +1827,9 @@ class IamDataFrame(object):
             Name of the computed timeseries data on the `axis`.
         axis : str, optional
             Axis along which to compute.
+        fillna : dict or scalar, optional
+            Value to fill holes when rows are not defined for either `a` or `b`.
+            Can be a scalar or a dictionary of the form :code:`{item: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1832,19 +1838,19 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "subtract", axis=axis, a=a, b=b)
+        _value = _op_data(self, name, "subtract", axis=axis, fillna=fillna, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def multiply(self, a, b, name, axis="variable", append=False):
-        """Compute the division of timeseries data between `a` and `b` along an `axis`
+    def multiply(self, a, b, name, axis="variable", fillna=None, append=False):
+        """Compute the product of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a * b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
-        If either `a` or `b` are not defined for a row, no value is computed
-        for that row.
+        If either `a` or `b` are not defined for a row and `fillna` is not specified,
+        no value is computed for that row.
 
         Parameters
         ----------
@@ -1854,6 +1860,9 @@ class IamDataFrame(object):
             Name of the computed timeseries data on the `axis`.
         axis : str, optional
             Axis along which to compute.
+        fillna : dict or scalar, optional
+            Value to fill holes when rows are not defined for either `a` or `b`.
+            Can be a scalar or a dictionary of the form :code:`{item: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1862,19 +1871,19 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "multiply", axis=axis, a=a, b=b)
+        _value = _op_data(self, name, "multiply", axis=axis, fillna=fillna, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def divide(self, a, b, name, axis="variable", append=False):
+    def divide(self, a, b, name, axis="variable", fillna=None, append=False):
         """Compute the division of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a / b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
-        If either `a` or `b` are not defined for a row, no value is computed
-        for that row.
+        If either `a` or `b` are not defined for a row and `fillna` is not specified,
+        no value is computed for that row.
 
         Parameters
         ----------
@@ -1884,6 +1893,9 @@ class IamDataFrame(object):
             Name of the computed timeseries data on the `axis`.
         axis : str, optional
             Axis along which to compute.
+        fillna : dict or scalar, optional
+            Value to fill holes when rows are not defined for either `a` or `b`.
+            Can be a scalar or a dictionary of the form :code:`{item: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1892,13 +1904,15 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "divide", axis=axis, a=a, b=b)
+        _value = _op_data(self, name, "divide", axis=axis, fillna=fillna, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def apply(self, func, name, axis="variable", append=False, args=(), **kwds):
+    def apply(
+        self, func, name, axis="variable", fillna=None, append=False, args=(), **kwds
+    ):
         """Apply a function to components of timeseries data along an `axis`
 
         This function computes a function `func` using timeseries data selected
@@ -1914,6 +1928,9 @@ class IamDataFrame(object):
             Name of the computed timeseries data on the `axis`.
         axis : str, optional
             Axis along which to compute.
+        fillna : dict or scalar, optional
+            Value to fill holes when rows are not defined for items in `args` or `kwds`.
+            Can be a scalar or a dictionary of the form :code:`{kwd: default}`.
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
         args : tuple or list of str
@@ -1928,7 +1945,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, func, axis=axis, args=args, **kwds)
+        _value = _op_data(self, name, func, axis=axis, fillna=fillna, args=args, **kwds)
         if append:
             self.append(_value, inplace=True)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1802,7 +1802,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "add", axis=axis, args=(a, b))
+        _value = _op_data(self, name, "add", axis=axis, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1832,7 +1832,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "subtract", axis=axis, args=(a, b))
+        _value = _op_data(self, name, "subtract", axis=axis, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1862,7 +1862,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "multiply", axis=axis, args=(a, b))
+        _value = _op_data(self, name, "multiply", axis=axis, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
@@ -1892,7 +1892,7 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "divide", axis=axis, args=(a, b))
+        _value = _op_data(self, name, "divide", axis=axis, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a keyword argument to set default values in the binary operations if either `a` or `b` (or any keyword argument for `apply()`) are not defined. This can be used either as `fillna=5` or `fillna=dict(a=5}`. 
