### PR TITLE
adds iam-units to dependency check

### DIFF
--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -22,12 +22,13 @@ jobs:
       with:
         python-version: '3.7'
 
+    - name: Install specific out-dated version of dependencies
+      # Update the corresponding package requirements when changing
+      # minimum dependency versions
+      run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.12
+
     - name: Install other dependencies and package
       run: pip install -e .[tests,deploy,optional-io-formats,tutorials]
-
-    - name: Install specific out-dated version of dependencies
-      run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.12
-      # Update the corresponding package requirements when changing dependency versions
 
     - name: Test with pytest
       run: pytest tests --mpl

--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -22,12 +22,12 @@ jobs:
       with:
         python-version: '3.7'
 
-    - name: Install specific out-dated version of dependencies
-      run: pip install pandas==1.1.1 matplotlib==3.2.0
-      # Update the corresponding package requirements when changing dependency versions
-
     - name: Install other dependencies and package
       run: pip install -e .[tests,deploy,optional-io-formats,tutorials]
+
+    - name: Install specific out-dated version of dependencies
+      run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.12
+      # Update the corresponding package requirements when changing dependency versions
 
     - name: Test with pytest
       run: pytest tests --mpl

--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install specific out-dated version of dependencies
       # Update the corresponding package requirements when changing
       # minimum dependency versions
-      run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.12
+      run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.21
 
     - name: Install other dependencies and package
       run: pip install -e .[tests,deploy,optional-io-formats,tutorials]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ logo = r"""
 # ./.github/workflows/pytest-depedency.yml
 REQUIREMENTS = [
     "argparse",
-    "iam-units>=2020.4.12",
+    "iam-units>=2020.4.21",
     "numpy",
     "requests",
     "pandas>=1.1.1",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,10 @@ logo = r"""
   \/_/     \/_____/   \/_/\/_/   \/_/  \/_/
 """
 
+# NOTE TO DEVS
+# If you change a minimum version below, please explicitly set that
+# in our minimum-reqs test in the file
+# ./.github/workflows/pytest-depedency.yml
 REQUIREMENTS = [
     "argparse",
     "iam-units>=2020.4.12",


### PR DESCRIPTION
Small hotfix building on #531 which adds a bit of documentation to `setup.py` and includes `iam-units` in dependencies which are kept up to date in the new workflow.