### PR TITLE
Support units in binary operations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#541](https://github.com/IAMconsortium/pyam/pull/541) Support units in binary operations
 - [#538](https://github.com/IAMconsortium/pyam/pull/538) Add option to set defaults in binary operations
 - [#537](https://github.com/IAMconsortium/pyam/pull/537) Enhance binary ops to support numerical arguments
 - [#533](https://github.com/IAMconsortium/pyam/pull/533) Add an `apply()` function for custom mathematical operations

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -1,6 +1,6 @@
 import operator
 import pandas as pd
-from pyam.index import append_index_level, get_index_levels
+from pyam.index import append_index_level, get_index_levels, replace_index_values
 from pyam.utils import to_list
 from iam_units import registry
 from pint import Quantity
@@ -118,12 +118,12 @@ def _op_data(df, name, method, axis, fillna=None, args=(), ignore_units=False, *
 
     # separate pint quantities into numerical value and unit (as index)
     if ignore_units is False:
-        rename_args = ("dimensionless", "")
         _value = pd.DataFrame(
-            [[i.magnitude, str(i.units).replace(*rename_args)] for i in result.values],
+            [[i.magnitude, '{:~}'.format(i.units)] for i in result.values],
             columns=["value", "unit"],
             index=result.index,
         ).set_index("unit", append=True)
+        _value.index = replace_index_values(_value, "unit", {"dimensionless": ""})
 
     # otherwise, set unit (as index) to "unknown" or the value given by "ignore_units"
     else:

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -119,7 +119,7 @@ def _op_data(df, name, method, axis, fillna=None, args=(), ignore_units=False, *
     # separate pint quantities into numerical value and unit (as index)
     if ignore_units is False:
         _value = pd.DataFrame(
-            [[i.magnitude, '{:~}'.format(i.units)] for i in result.values],
+            [[i.magnitude, "{:~}".format(i.units)] for i in result.values],
             columns=["value", "unit"],
             index=result.index,
         ).set_index("unit", append=True)

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -74,7 +74,7 @@ def _op_data(df, name, method, axis, fillna=None, args=(), ignore_units=False, *
             df, axis, value, cols, key
         )
 
-    # fast-pass on units: override pint for some methods if all kwds have same the unit
+    # fast-pass on units: override pint for some methods if all kwds have the same unit
     if (
         method in [add, subtract, divide]
         and ignore_units is False

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -170,16 +170,13 @@ def _get_values(df, axis, value, cols, name):
      - Bool whether first item was derived from `df.data`
 
     """
-    # try selecting from `df.data`
-    try:
-        if any(v in get_index_levels(df._data, axis) for v in to_list(value)):
-            _df = df.filter(**{axis: value})
-            return _df._data.groupby(cols).sum().rename(index=name), _df.unit, True
-    except:
-        pass
-    # else, check if `value` is a `pint.Quantity` and return unit specifically
+    # check if `value` is a `pint.Quantity` and return unit specifically
     if isinstance(value, Quantity):
         return value, [value.units], False
+    # try selecting from `df.data`
+    if any(v in get_index_levels(df._data, axis) for v in to_list(value)):
+        _df = df.filter(**{axis: value})
+        return _df._data.groupby(cols).sum().rename(index=name), _df.unit, True
     # else, return value
     return value, [], False
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1233,6 +1233,11 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Aggregated timeseries data or None if `append=True`.
 
+        See Also
+        --------
+        add : Add timeseries data items along an `axis`.
+        aggregate_region : Aggregate timeseries data along the `region` dimension.
+
         Notes
         -----
         The aggregation function interprets any missing values (:any:`numpy.nan`)
@@ -1351,6 +1356,16 @@ class IamDataFrame(object):
         append : bool, default False
             append the aggregate timeseries to `self` and return None,
             else return aggregate timeseries as new :class:`IamDataFrame`
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Aggregated timeseries data or None if `append=True`.
+
+        See Also
+        --------
+        add : Add timeseries data items `a` and `b` along an `axis`
+        aggregate : Aggregate timeseries data along the `variable` hierarchy.
         """
         _df = _aggregate_region(
             self,
@@ -1781,7 +1796,7 @@ class IamDataFrame(object):
     def add(
         self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
     ):
-        """Compute the addition of timeseries data between `a` and `b` along an `axis`
+        """Add timeseries data items `a` and `b` along an `axis`
 
         This function computes `a + b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
@@ -1810,6 +1825,13 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
 
+        See Also
+        --------
+        subtract, multiply, divide
+        apply : Apply a custom function on the timeseries data along any axis.
+        aggregate : Aggregate timeseries data along the `variable` hierarchy.
+        aggregate_region : Aggregate timeseries data along the `region` dimension.
+
         Notes
         -----
         This function uses the :mod:`pint` package and the :mod:`iam-units` registry
@@ -1832,7 +1854,7 @@ class IamDataFrame(object):
     def subtract(
         self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
     ):
-        """Compute the difference of timeseries data between `a` and `b` along an `axis`
+        """Compute the difference of timeseries data items `a` and `b` along an `axis`
 
         This function computes `a - b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
@@ -1861,6 +1883,11 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
 
+        See Also
+        --------
+        add, multiply, divide
+        apply : Apply a custom function on the timeseries data along any axis.
+
         Notes
         -----
         This function uses the :mod:`pint` package and the :mod:`iam-units` registry
@@ -1883,7 +1910,7 @@ class IamDataFrame(object):
     def multiply(
         self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
     ):
-        """Compute the product of timeseries data between `a` and `b` along an `axis`
+        """Multiply timeseries data items `a` and `b` along an `axis`
 
         This function computes `a * b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
@@ -1912,6 +1939,11 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
 
+        See Also
+        --------
+        add, subtract, divide
+        apply : Apply a custom function on the timeseries data along any axis.
+
         Notes
         -----
         This function uses the :mod:`pint` package and the :mod:`iam-units` registry
@@ -1934,7 +1966,7 @@ class IamDataFrame(object):
     def divide(
         self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
     ):
-        """Compute the division of timeseries data between `a` and `b` along an `axis`
+        """Divide the timeseries data items `a` and `b` along an `axis`
 
         This function computes `a / b`. If `a` or `b` are lists, the method applies
         :meth:`pandas.groupby().sum() <pandas.core.groupby.GroupBy.sum>` on each group.
@@ -1962,6 +1994,11 @@ class IamDataFrame(object):
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        See Also
+        --------
+        add, subtract, multiply
+        apply : Apply a custom function on the timeseries data along any axis.
 
         Notes
         -----

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1778,7 +1778,9 @@ class IamDataFrame(object):
         else:
             self.meta[col] = self.meta[col].apply(func, *args, **kwargs)
 
-    def add(self, a, b, name, axis="variable", fillna=None, append=False):
+    def add(
+        self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
+    ):
         """Compute the addition of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a + b`. If `a` or `b` are lists, the method applies
@@ -1797,6 +1799,9 @@ class IamDataFrame(object):
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
             Can be a scalar or a dictionary of the form :code:`{arg: default}`.
+        ignore_units : bool or str, optional
+            Perform operation on values without considering units. Set units of returned
+            data to `unknown` (if True) or the value of `ignore_units` (if str).
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1805,13 +1810,16 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "add", axis=axis, fillna=fillna, a=a, b=b)
+        kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
+        _value = _op_data(self, name, "add", **kwds, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def subtract(self, a, b, name, axis="variable", fillna=None, append=False):
+    def subtract(
+        self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
+    ):
         """Compute the difference of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a - b`. If `a` or `b` are lists, the method applies
@@ -1830,6 +1838,9 @@ class IamDataFrame(object):
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
             Can be a scalar or a dictionary of the form :code:`{arg: default}`.
+        ignore_units : bool or str, optional
+            Perform operation on values without considering units. Set units of returned
+            data to `unknown` (if True) or the value of `ignore_units` (if str).
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1838,13 +1849,16 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "subtract", axis=axis, fillna=fillna, a=a, b=b)
+        kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
+        _value = _op_data(self, name, "subtract", **kwds, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def multiply(self, a, b, name, axis="variable", fillna=None, append=False):
+    def multiply(
+        self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
+    ):
         """Compute the product of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a * b`. If `a` or `b` are lists, the method applies
@@ -1863,6 +1877,9 @@ class IamDataFrame(object):
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
             Can be a scalar or a dictionary of the form :code:`{arg: default}`.
+        ignore_units : bool or str, optional
+            Perform operation on values without considering units. Set units of returned
+            data to `unknown` (if True) or the value of `ignore_units` (if str).
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1871,13 +1888,16 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "multiply", axis=axis, fillna=fillna, a=a, b=b)
+        kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
+        _value = _op_data(self, name, "multiply", **kwds, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:
             return IamDataFrame(_value, meta=self.meta)
 
-    def divide(self, a, b, name, axis="variable", fillna=None, append=False):
+    def divide(
+        self, a, b, name, axis="variable", fillna=None, ignore_units=False, append=False
+    ):
         """Compute the division of timeseries data between `a` and `b` along an `axis`
 
         This function computes `a / b`. If `a` or `b` are lists, the method applies
@@ -1896,6 +1916,9 @@ class IamDataFrame(object):
         fillna : dict or scalar, optional
             Value to fill holes when rows are not defined for either `a` or `b`.
             Can be a scalar or a dictionary of the form :code:`{arg: default}`.
+        ignore_units : bool or str, optional
+            Perform operation on values without considering units. Set units of returned
+            data to `unknown` (if True) or the value of `ignore_units` (if str).
         append : bool, optional
             Whether to append aggregated timeseries data to this instance.
 
@@ -1904,7 +1927,8 @@ class IamDataFrame(object):
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
         """
-        _value = _op_data(self, name, "divide", axis=axis, fillna=fillna, a=a, b=b)
+        kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
+        _value = _op_data(self, name, "divide", **kwds, a=a, b=b)
         if append:
             self.append(_value, inplace=True)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1809,6 +1809,18 @@ class IamDataFrame(object):
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        Notes
+        -----
+        This function uses the :mod:`pint` package and the :mod:`iam-units` registry
+        (`read the docs <https://github.com/IAMconsortium/units>`_) to handle units.
+        :mod:`pyam` will keep notation consistent with the input format (if possible)
+        and otherwise uses abbreviated units :code:`'{:~}'.format(u)` (see
+        `here <https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting>`_
+        for more information).
+
+        As a result, the notation of returned units may differ from the input format.
+        For example, the unit :code:`EJ/yr` may be reformatted to :code:`EJ / a`.
         """
         kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
         _value = _op_data(self, name, "add", **kwds, a=a, b=b)
@@ -1848,6 +1860,18 @@ class IamDataFrame(object):
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        Notes
+        -----
+        This function uses the :mod:`pint` package and the :mod:`iam-units` registry
+        (`read the docs <https://github.com/IAMconsortium/units>`_) to handle units.
+        :mod:`pyam` will keep notation consistent with the input format (if possible)
+        and otherwise uses abbreviated units :code:`'{:~}'.format(u)` (see
+        `here <https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting>`_
+        for more information).
+
+        As a result, the notation of returned units may differ from the input format.
+        For example, the unit :code:`EJ/yr` may be reformatted to :code:`EJ / a`.
         """
         kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
         _value = _op_data(self, name, "subtract", **kwds, a=a, b=b)
@@ -1887,6 +1911,18 @@ class IamDataFrame(object):
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        Notes
+        -----
+        This function uses the :mod:`pint` package and the :mod:`iam-units` registry
+        (`read the docs <https://github.com/IAMconsortium/units>`_) to handle units.
+        :mod:`pyam` will keep notation consistent with the input format (if possible)
+        and otherwise uses abbreviated units :code:`'{:~}'.format(u)` (see
+        `here <https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting>`_
+        for more information).
+
+        As a result, the notation of returned units may differ from the input format.
+        For example, the unit :code:`EJ/yr` may be reformatted to :code:`EJ / a`.
         """
         kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
         _value = _op_data(self, name, "multiply", **kwds, a=a, b=b)
@@ -1926,6 +1962,18 @@ class IamDataFrame(object):
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        Notes
+        -----
+        This function uses the :mod:`pint` package and the :mod:`iam-units` registry
+        (`read the docs <https://github.com/IAMconsortium/units>`_) to handle units.
+        :mod:`pyam` will keep notation consistent with the input format (if possible)
+        and otherwise uses abbreviated units :code:`'{:~}'.format(u)` (see
+        `here <https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting>`_
+        for more information).
+
+        As a result, the notation of returned units may differ from the input format.
+        For example, the unit :code:`EJ/yr` may be reformatted to :code:`EJ / a`.
         """
         kwds = dict(axis=axis, fillna=fillna, ignore_units=ignore_units)
         _value = _op_data(self, name, "divide", **kwds, a=a, b=b)
@@ -1968,6 +2016,17 @@ class IamDataFrame(object):
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        Notes
+        -----
+        This function uses the :mod:`pint` package and the :mod:`iam-units` registry
+        (`read the docs <https://github.com/IAMconsortium/units>`_) to handle units.
+        :mod:`pyam` uses abbreviated units :code:`'{:~}'.format(u)` (see
+        `here <https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting>`_
+        for more information).
+
+        As a result, the notation of returned units may differ from the input format.
+        For example, the unit :code:`EJ/yr` may be reformatted to :code:`EJ / a`.
         """
         _value = _op_data(self, name, func, axis=axis, fillna=fillna, args=args, **kwds)
         if append:

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -36,7 +36,7 @@ def convert_unit(
     # Make versions without -equiv
     _current, _to = [i.replace("-equiv", "") for i in [current, to]]
     # Pair of (magnitude, unit)
-    qty = [ret.data.loc[where, "value"].values, _current]
+    qty = [ret._data.loc[where].values, _current]
 
     try:
         # Create a vector pint.Quantity and convert it ordinarily

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -56,7 +56,7 @@ def test_add_raises(test_df_year):
 def test_add_variable(test_df_year, arg, df_func, fillna, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    exp = df_func(operator.add, "Sum", unit="EJ/yr", meta=test_df_year.meta)
+    exp = df_func(operator.add, "Sum", unit="exajoule / year", meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Sum")
     if append:
@@ -78,7 +78,7 @@ def test_add_scenario(test_df_year, append):
         scenario=v[2],
         region="World",
         variable="Primary Energy",
-        unit="EJ/yr",
+        unit="exajoule / year",
     )
 
     if append:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -110,16 +110,18 @@ def test_add_scenario(test_df_year, append):
     "arg, df_func, fillna, ignore_units",
     (
         ("Primary Energy|Coal", df_ops_variable, None, False),
-        # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
-        # ("Primary Energy|Coal", df_ops_variable_default, 5),
-        # (2, df_ops_variable_number, None),
+        ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}, "foo"),
+        ("Primary Energy|Coal", df_ops_variable_default, 5, "foo"),
+        (registry.Quantity(2, "EJ/yr"), df_ops_variable_number, None, False),
+        (2, df_ops_variable_number, None, "foo"),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
 def test_subtract_variable(test_df_year, arg, df_func, fillna, append, ignore_units):
     """Verify that in-dataframe subtraction works on the default `variable` axis"""
 
-    exp = df_func(operator.sub, "Diff", unit=UNIT_EJ, meta=test_df_year.meta)
+    unit = UNIT_EJ if ignore_units is False else ignore_units
+    exp = df_func(operator.sub, "Diff", unit=unit, meta=test_df_year.meta)
 
     kwds = dict(ignore_units=ignore_units, fillna=fillna)
     if append:
@@ -160,7 +162,7 @@ def test_subtract_scenario(test_df_year, append):
         ("Primary Energy|Coal", df_ops_variable, None, UNIT_EJ_SQ, False),
         # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}, UNIT_EJ),
         # ("Primary Energy|Coal", df_ops_variable_default, 5, UNIT_EJ),
-        # (2, df_ops_variable_number, None, UNIT_EJ),
+        (2, df_ops_variable_number, None, UNIT_EJ, False),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
@@ -208,14 +210,16 @@ def test_multiply_scenario(test_df_year, append):
         ("Primary Energy|Coal", df_ops_variable, None, False),
         # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
         # ("Primary Energy|Coal", df_ops_variable_default, 5),
-        # (2, df_ops_variable_number, None),
+        (registry.Quantity(2, "EJ/yr"), df_ops_variable_number, None, False),
+        (2, df_ops_variable_number, None, False),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
 def test_divide_variable(test_df_year, arg, df_func, fillna, append, ignore_units):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    exp = df_func(operator.truediv, "Ratio", unit="", meta=test_df_year.meta)
+    unit = UNIT_EJ if isinstance(arg, int) else ""
+    exp = df_func(operator.truediv, "Ratio", unit=unit, meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Ratio")
     kwds = dict(ignore_units=ignore_units, fillna=fillna)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -12,6 +12,10 @@ DF_INDEX = ["scenario", 2005, 2010]
 DF_ARGS = dict(model="model_a", region="World")
 
 
+UNIT_EJ = "exajoule / year"
+UNIT_EJ_SQ = "exajoule ** 2 / year ** 2"
+
+
 def df_ops_variable(func, variable, unit, meta):
     """Return IamDataFrame when performing operation on test_df without default"""
     _data = pd.DataFrame(["scen_a", func(1, 0.5), func(6, 3)], index=DF_INDEX)
@@ -47,16 +51,16 @@ def test_add_raises(test_df_year):
     "arg, df_func, fillna",
     (
         ("Primary Energy|Coal", df_ops_variable, None),
-        ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
-        ("Primary Energy|Coal", df_ops_variable_default, 5),
-        (2, df_ops_variable_number, None),
+        # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
+        # ("Primary Energy|Coal", df_ops_variable_default, 5),
+        # (2, df_ops_variable_number, None),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
 def test_add_variable(test_df_year, arg, df_func, fillna, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    exp = df_func(operator.add, "Sum", unit="exajoule / year", meta=test_df_year.meta)
+    exp = df_func(operator.add, "Sum", unit=UNIT_EJ, meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Sum")
     if append:
@@ -78,7 +82,7 @@ def test_add_scenario(test_df_year, append):
         scenario=v[2],
         region="World",
         variable="Primary Energy",
-        unit="exajoule / year",
+        unit=UNIT_EJ,
     )
 
     if append:
@@ -94,16 +98,16 @@ def test_add_scenario(test_df_year, append):
     "arg, df_func, fillna",
     (
         ("Primary Energy|Coal", df_ops_variable, None),
-        ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
-        ("Primary Energy|Coal", df_ops_variable_default, 5),
-        (2, df_ops_variable_number, None),
+        # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
+        # ("Primary Energy|Coal", df_ops_variable_default, 5),
+        # (2, df_ops_variable_number, None),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
 def test_subtract_variable(test_df_year, arg, df_func, fillna, append):
     """Verify that in-dataframe subtraction works on the default `variable` axis"""
 
-    exp = df_func(operator.sub, "Diff", unit="EJ/yr", meta=test_df_year.meta)
+    exp = df_func(operator.sub, "Diff", unit=UNIT_EJ, meta=test_df_year.meta)
 
     if append:
         obs = test_df_year.copy()
@@ -125,7 +129,7 @@ def test_subtract_scenario(test_df_year, append):
         scenario=v[2],
         region="World",
         variable="Primary Energy",
-        unit="EJ/yr",
+        unit=UNIT_EJ,
     )
 
     if append:
@@ -138,19 +142,19 @@ def test_subtract_scenario(test_df_year, append):
 
 
 @pytest.mark.parametrize(
-    "arg, df_func, fillna",
+    "arg, df_func, fillna, unit",
     (
-        ("Primary Energy|Coal", df_ops_variable, None),
-        ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
-        ("Primary Energy|Coal", df_ops_variable_default, 5),
-        (2, df_ops_variable_number, None),
+        ("Primary Energy|Coal", df_ops_variable, None, UNIT_EJ_SQ),
+        # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}, UNIT_EJ),
+        # ("Primary Energy|Coal", df_ops_variable_default, 5, UNIT_EJ),
+        # (2, df_ops_variable_number, None, UNIT_EJ),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
-def test_multiply_variable(test_df_year, arg, df_func, fillna, append):
+def test_multiply_variable(test_df_year, arg, df_func, fillna, append, unit):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    exp = df_func(operator.mul, "Prod", unit="EJ/yr", meta=test_df_year.meta)
+    exp = df_func(operator.mul, "Prod", unit=unit, meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Prod")
     if append:
@@ -172,7 +176,7 @@ def test_multiply_scenario(test_df_year, append):
         scenario=v[2],
         region="World",
         variable="Primary Energy",
-        unit="EJ/yr",
+        unit=UNIT_EJ_SQ,
     )
 
     if append:
@@ -188,16 +192,16 @@ def test_multiply_scenario(test_df_year, append):
     "arg, df_func, fillna",
     (
         ("Primary Energy|Coal", df_ops_variable, None),
-        ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
-        ("Primary Energy|Coal", df_ops_variable_default, 5),
-        (2, df_ops_variable_number, None),
+        # ("Primary Energy|Coal", df_ops_variable_default, {"c": 7, "b": 5}),
+        # ("Primary Energy|Coal", df_ops_variable_default, 5),
+        # (2, df_ops_variable_number, None),
     ),
 )
 @pytest.mark.parametrize("append", (False, True))
 def test_divide_variable(test_df_year, arg, df_func, fillna, append):
     """Verify that in-dataframe addition works on the default `variable` axis"""
 
-    exp = df_func(operator.truediv, "Ratio", unit="EJ/yr", meta=test_df_year.meta)
+    exp = df_func(operator.truediv, "Ratio", unit="", meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Ratio")
     if append:
@@ -219,7 +223,7 @@ def test_divide_scenario(test_df_year, append):
         scenario=v[2],
         region="World",
         variable="Primary Energy",
-        unit="EJ/yr",
+        unit="",
     )
 
     if append:
@@ -232,39 +236,34 @@ def test_divide_scenario(test_df_year, append):
 
 
 @pytest.mark.parametrize("append", (False, True))
-def test_apply_variable(plot_stackplot_df, append):
+def test_apply_variable(test_df_year, append):
     """Verify that in-dataframe apply works on the default `variable` axis"""
 
-    def custom_func(a, b, c, d, e):
-        return a / c + b / d + e
+    def custom_func(a, b, c, d):
+        return a * b + c * d
 
-    args = ["Emissions|CO2|Tar", "Emissions|CO2|Cars", "Emissions|CO2|LUC"]
-    kwds = {"d": "Emissions|CO2|Agg", "e": 5}
+    v = "new variable"
+
     exp = IamDataFrame(
         pd.DataFrame(
-            [
-                0.3 / (-0.3) + 1.6 / 0.5 + 5,
-                0.35 / (-0.6) + 3.8 / (-0.1) + 5,
-                0.35 / (-1.2) + 3.0 / (-0.5) + 5,
-                0.33 / (-1.0) + 2.5 / (-0.7) + 5,
-            ],
-            index=[2005, 2010, 2015, 2020],
+            [custom_func(1, 2, 0.5, 3), custom_func(6, 2, 3, 3)], index=[2005, 2010]
         ).T,
-        model="IMG",
-        scenario="a_scen",
-        region="World",
-        variable="new variable",
-        unit="Mt CO2/yr",
+        **DF_ARGS,
+        scenario="scen_a",
+        variable=v,
+        unit=UNIT_EJ,
+        meta=test_df_year.meta
     )
 
+    args = ["Primary Energy", 2]
+    kwds = dict(d=3, c="Primary Energy|Coal")
+
     if append:
-        obs = plot_stackplot_df.copy()
+        obs = test_df_year.copy()
         obs.apply(custom_func, name="new variable", append=True, args=args, **kwds)
-        assert_iamframe_equal(plot_stackplot_df.append(exp), obs)
+        assert_iamframe_equal(test_df_year.append(exp), obs)
     else:
-        obs = plot_stackplot_df.apply(
-            custom_func, name="new variable", args=args, **kwds
-        )
+        obs = test_df_year.apply(custom_func, name=v, args=args, **kwds)
         assert_iamframe_equal(exp, obs)
 
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -13,8 +13,6 @@ DF_INDEX = ["scenario", 2005, 2010]
 # dictionary with common IamDataFrame args for all tests operating on variable
 DF_ARGS = dict(model="model_a", region="World")
 
-UNIT_EJ_SQ = "exajoule ** 2 / year ** 2"
-
 
 def df_ops_variable(func, variable, unit, meta):
     """Return IamDataFrame when performing operation on test_df without default"""
@@ -174,7 +172,7 @@ def test_multiply_variable(test_df_year, arg, df_func, fillna, ignore_units, app
     if ignore_units:
         unit = ignore_units
     else:
-        unit = "exajoule / year" if isinstance(arg, int) else UNIT_EJ_SQ
+        unit = "EJ / a" if isinstance(arg, int) else "EJ ** 2 / a ** 2"
     exp = df_func(operator.mul, "Prod", unit=unit, meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Prod")
@@ -203,7 +201,7 @@ def test_multiply_scenario(test_df_year, append):
         scenario=v[2],
         region="World",
         variable="Primary Energy",
-        unit=UNIT_EJ_SQ,
+        unit="EJ ** 2 / a ** 2",
     )
 
     if append:
@@ -233,7 +231,7 @@ def test_divide_variable(test_df_year, arg, df_func, fillna, append, ignore_unit
     if ignore_units:
         unit = ignore_units
     else:
-        unit = "exajoule / year" if isinstance(arg, int) else ""
+        unit = "EJ / a" if isinstance(arg, int) else ""
     exp = df_func(operator.truediv, "Ratio", unit=unit, meta=test_df_year.meta)
 
     args = ("Primary Energy", arg, "Ratio")
@@ -290,7 +288,7 @@ def test_apply_variable(test_df_year, append):
         **DF_ARGS,
         scenario="scen_a",
         variable=v,
-        unit="exajoule / year",  # applying operations with pint reformats the unit
+        unit="EJ / a",  # applying operations with pint reformats the unit
         meta=test_df_year.meta,
     )
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR changes the implementation of the binary ops to support units (via iam-units and pint).

Default behaviour:
 - Cast values and units to a `pint.Quantity` using the **iam-units** registry and perform operations with pint unit handling (`ignore_units=False`)
    **Warning**: By casting units to pints and then performing operations, the return-format may look different.
   In some of the tests, `EJ/yr` is transformed to `exajoule / year` (in full format) or `EJ / a` (in compact format, implemented here). This is over-ridden for some methods (addition, multiplication, division) if all units are identical.
 - Passing a pint quantity as argument will work, e.g, `df.add("Primary Energy", Quantity(2, "EJ/yr"), "new")`.
 - **pint** will raise appropriate errors if it doesn't know how to handle the units.
 - In line with common practice in the IAM community, a dimensionless quantity is marked as unit `""` (empty string) rather than the word `dimensionless` (this works in a round-trip to-from-to pint).

Alternative over-ride:
 - A user can set `ignore_units=True`, in which case the operations will work just on the values and set `unit` to "unknown" (per suggestion by @znicholls in https://github.com/IAMconsortium/pyam/issues/536#issuecomment-847569955) or to the value of `ignore_units` (if it's a string).

Known issues:
- pandas fillna does not work with non-numeric values (in particular not with pint.Quantity).

Side note:
 - I simplified the test for the `apply()` function.

To-dos in later PRs (it's already quite a beast):
 - Make the fillna feature work with pint.
 - Add `ignore_units` to the `apply()` function.
 - Support custom pint registry instances.
 - Pass unit formatting options to pint as kwargs.

closes #537 
closes #535 
