### PR TITLE
Add a unit_mapping attribute to show a variable -> unit dictionary

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
 # Next Release
+
+- [#548](https://github.com/IAMconsortium/pyam/pull/548) Add a `unit_mapping` attribute to show a variable-unit dictionary 
 - [#546](https://github.com/IAMconsortium/pyam/pull/546) Fixed logging for recursive aggregation
 
 # Release v0.12.0

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -369,17 +369,23 @@ class IamDataFrame(object):
     @property
     def unit_mapping(self):
         """Return a dictionary of variable to (list of) correspoding units"""
+
         def list_or_str(x):
             x = list(x.drop_duplicates())
             return x if len(x) > 1 else x[0]
 
-        return pd.DataFrame(
-            zip(
-                self._data.index.get_level_values("variable"),
-                self._data.index.get_level_values("unit"),
-            ),
-            columns=["variable", "unit"],
-        ).groupby("variable").apply(lambda u: list_or_str(u.unit)).to_dict()
+        return (
+            pd.DataFrame(
+                zip(
+                    self._data.index.get_level_values("variable"),
+                    self._data.index.get_level_values("unit"),
+                ),
+                columns=["variable", "unit"],
+            )
+            .groupby("variable")
+            .apply(lambda u: list_or_str(u.unit))
+            .to_dict()
+        )
 
     @property
     def data(self):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -367,6 +367,21 @@ class IamDataFrame(object):
         return get_index_levels(self._data, "unit")
 
     @property
+    def unit_mapping(self):
+        """Return a dictionary of variable to (list of) correspoding units"""
+        def list_or_str(x):
+            x = list(x.drop_duplicates())
+            return x if len(x) > 1 else x[0]
+
+        return pd.DataFrame(
+            zip(
+                self._data.index.get_level_values("variable"),
+                self._data.index.get_level_values("unit"),
+            ),
+            columns=["variable", "unit"],
+        ).groupby("variable").apply(lambda u: list_or_str(u.unit)).to_dict()
+
+    @property
     def data(self):
         """Return the timeseries data as a long :class:`pandas.DataFrame`"""
         if self.empty:  # reset_index fails on empty with `datetime` column

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -368,7 +368,7 @@ class IamDataFrame(object):
 
     @property
     def unit_mapping(self):
-        """Return a dictionary of variable to (list of) correspoding units"""
+        """Return a dictionary of variables to (list of) correspoding units"""
 
         def list_or_str(x):
             x = list(x.drop_duplicates())
@@ -477,6 +477,7 @@ class IamDataFrame(object):
             return pd.Series(get_index_levels(self._data, _var), name=_var)
 
         # else construct dataframe from variable and unit levels
+        deprecation_warning("Use the attribute `unit_mapping` instead.")
         return (
             pd.DataFrame(
                 zip(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -316,6 +316,13 @@ def test_index_attributes_extra_col(test_pd_df):
     assert df.subannual == ["summer", "winter"]
 
 
+def test_unit_mapping(test_pd_df):
+    """assert that the `unit_mapping` returns the expected dictionary"""
+    test_pd_df.loc[2, "unit"] = "foo"  # replace unit of one row of Primary Energy data
+    obs = IamDataFrame(test_pd_df).unit_mapping
+
+    assert obs == {"Primary Energy": ["EJ/yr", "foo"], "Primary Energy|Coal": "EJ/yr"}
+
 def test_model(test_df):
     exp = pd.Series(data=["model_a"], name="model")
     pd.testing.assert_series_equal(test_df.models(), exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,6 +323,7 @@ def test_unit_mapping(test_pd_df):
 
     assert obs == {"Primary Energy": ["EJ/yr", "foo"], "Primary Energy|Coal": "EJ/yr"}
 
+
 def test_model(test_df):
     exp = pd.Series(data=["model_a"], name="model")
     pd.testing.assert_series_equal(test_df.models(), exp)

--- a/tests/test_unfccc.py
+++ b/tests/test_unfccc.py
@@ -4,7 +4,7 @@ from pyam.testing import assert_iamframe_equal
 
 
 UNFCCC_DF = pd.DataFrame(
-    [[1990, 1738.137558], [1991, 1537.282312], [1992, 1499.067572]],
+    [[1990, 1609.25345], [1991, 1434.21149], [1992, 1398.38269]],
     columns=["year", "value"],
 )
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds an attribute `unit_mapping` to return a dictionary `{variable: unit or list of units}`. This is intended to replace the current function `variables(include_units=True)`.

For illustration, the IamDataFrame 

| model | scenario | region | variable | unit | 2005 | 2010 |
| -------- | -------- | ------ | --------------- | ----- | --- | --- | 
| model_a | scen_a | World | Primary Energy | EJ/yr | 1 | 6 |
| model_a | scen_a | World | Primary Energy\\|Coal | EJ/yr | 0.5 | 3 |
| model_a | scen_b | World | Primary Energy | GWh/yr | 2 | 7 |

will return

```python
df.unit_mapping
> {"Primary Energy": ["EJ/yr", "GWh/yr"], "Primary Energy|Coal": "EJ/yr"}
```

## Unique unit for a variable?

Note that it may be preferable to require that an IamDataFrame has a unique unit for each variable (see the related discussion at #338). Currently, several units are allowed, so this PR simply maintains the current behavior.