### PR TITLE
figure.py: make plotly an optional dependency

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -36,7 +36,7 @@ jobs:
       uses: r-lib/actions/setup-pandoc@v1
 
     - name: Install dependencies and package for building the docs
-      run: pip install -e .[tutorials,docs]
+      run: pip install -e .[tutorials,optional-plotting,docs]
 
     - name: Build the docs
       run: make --directory=doc html

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[tests,deploy,optional-io-formats,tutorials,docs]
+        pip install -e .[tests,deploy,optional-plotting,optional-io-formats,tutorials,docs]
 
     - name: Test with pytest (including Matplotlib)
       run: |

--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -28,7 +28,7 @@ jobs:
       run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.21
 
     - name: Install other dependencies and package
-      run: pip install -e .[tests,deploy,optional-io-formats,tutorials]
+      run: pip install -e .[tests,deploy,optional-plotting,optional-io-formats,tutorials]
 
     - name: Test with pytest
       run: pytest tests --mpl

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies and package
-      run: pip install -e .[tests,deploy,optional-io-formats,tutorials]
+      run: pip install -e .[tests,deploy,optional-plotting,optional-io-formats,tutorials]
 
     - name: Test with pytest
       if: ${{ matrix.python-version != '3.9' }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#549](https://github.com/IAMconsortium/pyam/pull/549) Make `plotly` an optional dependency
 - [#548](https://github.com/IAMconsortium/pyam/pull/548) Add a `unit_mapping` attribute to show a variable-unit dictionary 
 - [#546](https://github.com/IAMconsortium/pyam/pull/546) Fixed logging for recursive aggregation
 

--- a/pyam/figures.py
+++ b/pyam/figures.py
@@ -1,10 +1,17 @@
+from importlib import import_module
 import logging
 
 import pandas as pd
-import plotly.graph_objects as go
 from pyam.index import get_index_levels
 
 logger = logging.getLogger(__name__)
+
+try:
+    go = getattr(import_module("plotly"), "graph_objects")
+except ImportError as err:
+    msg = "Missing optional dependency 'plotly', use pip or conda to install"
+    logger.exception(msg)
+    raise err from None
 
 
 def sankey(df, mapping):

--- a/pyam/figures.py
+++ b/pyam/figures.py
@@ -1,4 +1,3 @@
-from importlib import import_module
 import logging
 
 import pandas as pd
@@ -7,11 +6,12 @@ from pyam.index import get_index_levels
 logger = logging.getLogger(__name__)
 
 try:
-    go = getattr(import_module("plotly"), "graph_objects")
-except ImportError as err:
-    msg = "Missing optional dependency 'plotly', use pip or conda to install"
-    logger.exception(msg)
-    raise err from None
+    import plotly.graph_objects as go
+
+    HAS_PLOTLY = True
+except ImportError:  # pragma: no cover
+    go = None
+    HAS_PLOTLY = False
 
 
 def sankey(df, mapping):
@@ -36,6 +36,10 @@ def sankey(df, mapping):
         -------
         fig : :class:`plotly.graph_objects.Figure`
     """
+    if not HAS_PLOTLY:  # pragma: no cover
+        raise ImportError(
+            "Missing optional dependency `plotly`, use pip or conda to install"
+        )
     # Check for duplicates
     for col in [name for name in df._data.index.names if name != "variable"]:
         levels = get_index_levels(df._data, col)

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,4 +4,4 @@ python:
   install:
   - method: pip
     path: .
-    extra_requirements: [docs,tutorials]
+    extra_requirements: [docs,tutorials,optional-plotting]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ REQUIREMENTS = [
     "requests",
     "pandas>=1.1.1",
     "pint",
-    "plotly",
     "PyYAML",
     "matplotlib>=3.2.0",
     "seaborn",
@@ -32,6 +31,7 @@ REQUIREMENTS = [
 
 EXTRA_REQUIREMENTS = {
     "tests": ["coverage", "coveralls", "pytest<6.0.0", "pytest-cov", "pytest-mpl<0.12"],
+    "optional-plotting": ["plotly"],
     "optional-io-formats": ["datapackage", "pandas-datareader", "unfccc_di_api>=2.0"],
     "deploy": ["twine", "setuptools", "wheel"],
     "tutorials": ["pypandoc", "nbformat", "nbconvert", "jupyter_client", "ipykernel"],


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [X] Description in RELEASE_NOTES.md Added

# Description of PR

With this PR, I am proposing to make `plotly` an optional dependency.

One of the feedbacks I got for [friendly data](https://github.com/sentinel-energy/friendly_data/) (which uses `pyam`) was that there's a version mismatch with `plotly` with their environment, preventing them from using the Python API directly from their analysis code.

I noticed that `plotly` is used only in one place in `figures.py`, so I thought maybe this is an acceptable proposal. Since it's easier to talk in code, I wrote this PR.  If I have misunderstood the importance of that module, please feel free to close this.

Thoughts?