### PR TITLE
Set explicit minimum numpy version (1.19.0)

### DIFF
--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -5,7 +5,7 @@ name: pytest-dependency
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'main' ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -5,7 +5,7 @@ name: pytest-dependency
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ '**' ]
   pull_request:
     branches: [ '**' ]
 
@@ -25,7 +25,7 @@ jobs:
     - name: Install specific out-dated version of dependencies
       # Update the package requirements when changing minimum dependency versions
       # Please also add a section "Dependency changes" to the release notes
-      run: pip install pandas==1.1.1 matplotlib==3.2.0 iam-units==2020.4.21
+      run: pip install pandas==1.1.1 numpy==1.18.5 matplotlib==3.2.0 iam-units==2020.4.21
 
     - name: Install other dependencies and package
       run: pip install -e .[tests,deploy,optional-plotting,optional-io-formats,tutorials]

--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install specific out-dated version of dependencies
       # Update the package requirements when changing minimum dependency versions
       # Please also add a section "Dependency changes" to the release notes
-      run: pip install pandas==1.1.1 numpy==1.18.5 matplotlib==3.2.0 iam-units==2020.4.21
+      run: pip install pandas==1.1.1 numpy==1.19.0 matplotlib==3.2.0 iam-units==2020.4.21
 
     - name: Install other dependencies and package
       run: pip install -e .[tests,deploy,optional-plotting,optional-io-formats,tutorials]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Next Release
+
+ - [#556](https://github.com/IAMconsortium/pyam/pull/556) Set explicit minimum numpy version (1.19.0)
+
 # Release v1.0.0
 
 This is the first major release of the pyam package.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ logo = r"""
 REQUIREMENTS = [
     "argparse",
     "iam-units>=2020.4.21",
-    "numpy",
+    "numpy>=1.19.0",
     "requests",
     "pandas>=1.1.1",
     "pint",


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds an explicit minimum dependency version for numpy (and also adds it to the dependency-tests workflow).

closes #555 
