### PR TITLE
Swap time for year keeping subannual resolution

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Next Release
 
- - [#556](https://github.com/IAMconsortium/pyam/pull/556) Set explicit minimum numpy version (1.19.0)
+- [#557](https://github.com/IAMconsortium/pyam/pull/557) Swap time for year keeping subannual resolution
+- [#556](https://github.com/IAMconsortium/pyam/pull/556) Set explicit minimum numpy version (1.19.0)
 
 # Release v1.0.0
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -602,20 +602,25 @@ class IamDataFrame(object):
         if not inplace:
             return ret
 
-    def swap_time_for_year(self, inplace=False):
+    def swap_time_for_year(self, subannual=False, inplace=False):
         """Convert the `time` column to `year`.
 
         Parameters
         ----------
-        inplace : bool, default False
-            if True, do operation inplace and return None
+        subannual : bool, str or func, optional
+            Merge non-year components of the "time" domain as new column "subannual".
+            Apply `strftime()` on the values of the "time" domain using `subannual`
+            as format (if a string) or using "%m-%d %H:%M%z" (if True).
+            If it is a function, apply the function on the values of the "time" domain.
+        inplace : bool, optional
+            If True, do operation inplace and return None.
 
         Raises
         ------
         ValueError
             "time" is not a column of `self.data`
         """
-        return swap_time_for_year(self, inplace=inplace)
+        return swap_time_for_year(self, subannual=subannual, inplace=inplace)
 
     def as_pandas(self, meta_cols=True):
         """Return object as a pandas.DataFrame

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -75,6 +75,14 @@ def replace_index_values(df, level, mapping, rows=None):
     return index.set_codes(_codes, n).set_levels(_unique_levels, n)
 
 
+def append_index_col(index, values, name, order=False):
+    """Append a list of `values` as a new column (level) to an `index`"""
+    levels = pd.Index(values).unique()
+    codes = levels.get_indexer(values)
+
+    return append_index_level(index, codes, levels, name, order)
+
+
 def append_index_level(index, codes, level, name, order=False):
     """Append a level to a pd.MultiIndex"""
     if isstr(level):

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -3,7 +3,7 @@ from pyam.index import get_index_levels, append_index_col
 from pyam.utils import _raise_data_error
 
 
-def swap_time_for_year(df, inplace):
+def swap_time_for_year(df, inplace, subannual=False):
     """Internal implementation to swap 'time' domain to 'year' (as int)"""
     if not df.time_col == "time":
         raise ValueError("Time domain must be datetime to use this method")
@@ -18,10 +18,21 @@ def swap_time_for_year(df, inplace):
     index = index.droplevel("time")
     index = append_index_col(index, time.apply(lambda x: x.year), "year", order=order)
 
+    if subannual:
+        # if subannual is True, default to simple datetime format without year
+        if subannual is True:
+            subannual = "%m-%d %H:%M%z"
+        if isinstance(subannual, str):
+            _subannual = time.apply(lambda x: x.strftime(subannual))
+        else:
+            _subannual = time.apply(subannual)
+
+        index = append_index_col(index, _subannual, "subannual")
+
     rows = index.duplicated()
     if any(rows):
         error_msg = "Swapping time for year causes duplicates in `data`"
-        _raise_data_error(error_msg, index.to_frame().reset_index(drop=True))
+        _raise_data_error(error_msg, index[rows].to_frame().reset_index(drop=True))
 
     # assign data and other attributes
     ret._LONG_IDX = index.names

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from pyam.index import get_index_levels, append_index_col
+from pyam.index import append_index_col
 from pyam.utils import _raise_data_error
 
 

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -1,0 +1,29 @@
+from pyam.utils import _raise_data_error
+
+
+def swap_time_for_year(df, inplace):
+    """Internal implementation to swap 'time' domain to 'year' (as int)"""
+    if not df.time_col == "time":
+        raise ValueError("Time domain must be datetime to use this method")
+
+    ret = df.copy() if not inplace else df
+
+    _data = ret.data
+    _data["year"] = _data["time"].apply(lambda x: x.year)
+    _data = _data.drop("time", axis="columns")
+    _index = [v if v != "time" else "year" for v in ret._LONG_IDX]
+
+    rows = _data[_index].duplicated()
+    if any(rows):
+        error_msg = "Swapping time for year causes duplicates in `data`"
+        _raise_data_error(error_msg, _data[_index])
+
+    # assign data and other attributes
+    ret._LONG_IDX = _index
+    ret._data = _data.set_index(ret._LONG_IDX).value
+    ret.time_col = "year"
+    ret._set_attributes()
+    delattr(ret, "time")
+
+    if not inplace:
+        return ret

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIREMENTS = [
     "iam-units>=2020.4.21",
     "numpy>=1.19.0",
     "requests",
-    "pandas>=1.1.1",
+    "pandas>=1.1.1,<1.3.0",
     "pint",
     "PyYAML",
     "matplotlib>=3.2.0",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1059,39 +1059,3 @@ def test_normalize(test_df):
 def test_normalize_not_time(test_df):
     pytest.raises(ValueError, test_df.normalize, variable="foo")
     pytest.raises(ValueError, test_df.normalize, year=2015, variable="foo")
-
-
-@pytest.mark.parametrize("inplace", [True, False])
-def test_swap_time_to_year(test_df, inplace):
-    if "year" in test_df.data:
-        return  # year df not relevant for this test
-
-    exp = test_df.data.copy()
-    exp["year"] = exp["time"].apply(lambda x: x.year)
-    exp = exp.drop("time", axis="columns")
-    exp = IamDataFrame(exp)
-
-    obs = test_df.swap_time_for_year(inplace=inplace)
-
-    if inplace:
-        assert obs is None
-        obs = test_df
-
-    assert compare(obs, exp).empty
-    assert obs.year == [2005, 2010]
-    with pytest.raises(AttributeError):
-        obs.time
-
-
-@pytest.mark.parametrize("inplace", [True, False])
-def test_swap_time_to_year_errors(test_df, inplace):
-    if "year" in test_df.data:
-        with pytest.raises(ValueError):
-            test_df.swap_time_for_year(inplace=inplace)
-        return
-
-    tdf = test_df.data.copy()
-    tdf["time"] = tdf["time"].apply(lambda x: datetime.datetime(2005, x.month, x.day))
-
-    with pytest.raises(ValueError):
-        IamDataFrame(tdf).swap_time_for_year(inplace=inplace)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -32,7 +32,7 @@ def test_swap_time_to_year(test_df, inplace):
     """Swap time column for year (int) dropping subannual time resolution (default)"""
 
     if test_df.time_col == "year":
-        return  # IamDataFrame with time domain `year` not relevant for this test
+        pytest.skip("IamDataFrame with time domain `year` not relevant for this test.")
 
     exp = test_df.data
     exp["year"] = exp["time"].apply(lambda x: x.year)
@@ -83,11 +83,11 @@ def test_swap_time_to_year_errors(test_df):
         match = "Time domain must be datetime to use this method"
         with pytest.raises(ValueError, match=match):
             test_df.swap_time_for_year()
-        return
 
-    # set time column to same year so that dropping month/day leads to duplicates
-    tdf = test_df.data
-    tdf["time"] = tdf["time"].apply(lambda x: datetime(2005, x.month, x.day))
+    else:
+        # set time column to same year so that dropping month/day leads to duplicates
+        tdf = test_df.data
+        tdf["time"] = tdf["time"].apply(lambda x: datetime(2005, x.month, x.day))
 
-    with pytest.raises(ValueError, match="Swapping time for year causes duplicates in"):
-        IamDataFrame(tdf).swap_time_for_year()
+        with pytest.raises(ValueError, match="Swapping time for year causes duplicate"):
+            IamDataFrame(tdf).swap_time_for_year()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,10 +5,10 @@ from pyam import IamDataFrame, compare
 
 @pytest.mark.parametrize("inplace", [True, False])
 def test_swap_time_to_year(test_df, inplace):
-    if "year" in test_df.data:
+    if test_df.time_col == "year":
         return  # year df not relevant for this test
 
-    exp = test_df.data.copy()
+    exp = test_df.data
     exp["year"] = exp["time"].apply(lambda x: x.year)
     exp = exp.drop("time", axis="columns")
     exp = IamDataFrame(exp)
@@ -27,12 +27,12 @@ def test_swap_time_to_year(test_df, inplace):
 
 @pytest.mark.parametrize("inplace", [True, False])
 def test_swap_time_to_year_errors(test_df, inplace):
-    if "year" in test_df.data:
+    if test_df.time_col == "year":
         with pytest.raises(ValueError):
             test_df.swap_time_for_year(inplace=inplace)
         return
 
-    tdf = test_df.data.copy()
+    tdf = test_df.data
     tdf["time"] = tdf["time"].apply(lambda x: datetime(2005, x.month, x.day))
 
     with pytest.raises(ValueError):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,11 +1,36 @@
 import pytest
+import pandas as pd
 from datetime import datetime
-from pyam import IamDataFrame, compare
+from pyam import IamDataFrame, IAMC_IDX
+from pyam.testing import assert_iamframe_equal
+
+from conftest import TEST_DTS, TEST_TIME_STR, TEST_TIME_STR_HR
+
+
+def get_subannual_df(date1, date2):
+    df = pd.DataFrame(
+        [
+            ["scen_a", "Primary Energy", 2005, date1, 1.0],
+            ["scen_a", "Primary Energy", 2010, date2, 6.0],
+            ["scen_a", "Primary Energy|Coal", 2005, date1, 0.5],
+            ["scen_a", "Primary Energy|Coal", 2010, date2, 3],
+            ["scen_b", "Primary Energy", 2005, date1, 2],
+            ["scen_b", "Primary Energy", 2010, date2, 7],
+        ],
+        columns=["scenario", "variable", "year", "subannual", "value"],
+    )
+    return IamDataFrame(df, model="model_a", region="World", unit="EJ/yr")
+
+
+# this is the subannual column format used in the openENTRANCE project
+OE_DATETIME = ["2005-10-01 23:15+01:00", "2010-10-02 23:15+01:00"]
+OE_SUBANNUAL_FORMAT = lambda x: x.strftime("%m-%d %H:%M%z").replace("+0100", "+01:00")
 
 
 @pytest.mark.parametrize("inplace", [True, False])
 def test_swap_time_to_year(test_df, inplace):
-    """Swap time column for year (int) using the default"""
+    """Swap time column for year (int) dropping subannual time resolution (default)"""
+
     if test_df.time_col == "year":
         return  # IamDataFrame with time domain `year` not relevant for this test
 
@@ -21,19 +46,48 @@ def test_swap_time_to_year(test_df, inplace):
         obs = test_df
 
     assert_iamframe_equal(obs, exp)
-    with pytest.raises(AttributeError):
+    match = "'IamDataFrame' object has no attribute 'time'"
+    with pytest.raises(AttributeError, match=match):
         obs.time
 
 
+@pytest.mark.parametrize(
+    "columns, subannual, dates",
+    [
+        # use the default datetime format without `year`
+        [TEST_DTS, True, ["06-17 00:00", "07-21 00:00"]],
+        [TEST_TIME_STR, True, ["06-17 00:00", "07-21 00:00"]],
+        [TEST_TIME_STR_HR, True, ["06-17 00:00", "07-21 12:00"]],
+        # apply formatting for strftime as str
+        [TEST_DTS, "%m-%d", ["06-17", "07-21"]],
+        # apply openENTRANCE formatting with timezone
+        [OE_DATETIME, OE_SUBANNUAL_FORMAT, ["10-01 23:15+01:00", "10-02 23:15+01:00"]],
+    ],
+)
 @pytest.mark.parametrize("inplace", [True, False])
-def test_swap_time_to_year_errors(test_df, inplace):
+def test_swap_time_to_year_subannual(test_pd_df, columns, subannual, dates, inplace):
+    """Swap time column for year (int) keeping subannual resolution as extra-column"""
+
+    test_pd_df.rename({2005: columns[0], 2010: columns[1]}, axis=1, inplace=True)
+    obs = IamDataFrame(test_pd_df).swap_time_for_year(subannual=subannual)
+
+    exp = get_subannual_df(dates[0], dates[1])
+    assert_iamframe_equal(obs, exp)
+
+
+def test_swap_time_to_year_errors(test_df):
+    """Assert that swapping time column for year (int) raises the expected errors"""
+
+    # swapping time to year raises when the IamDataFrame has time domain `year`
     if test_df.time_col == "year":
-        with pytest.raises(ValueError):
-            test_df.swap_time_for_year(inplace=inplace)
+        match = "Time domain must be datetime to use this method"
+        with pytest.raises(ValueError, match=match):
+            test_df.swap_time_for_year()
         return
 
+    # set time column to same year so that dropping month/day leads to duplicates
     tdf = test_df.data
     tdf["time"] = tdf["time"].apply(lambda x: datetime(2005, x.month, x.day))
 
-    with pytest.raises(ValueError):
-        IamDataFrame(tdf).swap_time_for_year(inplace=inplace)
+    with pytest.raises(ValueError, match="Swapping time for year causes duplicates in"):
+        IamDataFrame(tdf).swap_time_for_year()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 from datetime import datetime
-from pyam import IamDataFrame, IAMC_IDX
+from pyam import IamDataFrame
 from pyam.testing import assert_iamframe_equal
 
 from conftest import TEST_DTS, TEST_TIME_STR, TEST_TIME_STR_HR

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,13 +5,14 @@ from pyam import IamDataFrame, compare
 
 @pytest.mark.parametrize("inplace", [True, False])
 def test_swap_time_to_year(test_df, inplace):
+    """Swap time column for year (int) using the default"""
     if test_df.time_col == "year":
-        return  # year df not relevant for this test
+        return  # IamDataFrame with time domain `year` not relevant for this test
 
     exp = test_df.data
     exp["year"] = exp["time"].apply(lambda x: x.year)
     exp = exp.drop("time", axis="columns")
-    exp = IamDataFrame(exp)
+    exp = IamDataFrame(exp, meta=test_df.meta)
 
     obs = test_df.swap_time_for_year(inplace=inplace)
 
@@ -19,8 +20,7 @@ def test_swap_time_to_year(test_df, inplace):
         assert obs is None
         obs = test_df
 
-    assert compare(obs, exp).empty
-    assert obs.year == [2005, 2010]
+    assert_iamframe_equal(obs, exp)
     with pytest.raises(AttributeError):
         obs.time
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,39 @@
+import pytest
+from datetime import datetime
+from pyam import IamDataFrame, compare
+
+
+@pytest.mark.parametrize("inplace", [True, False])
+def test_swap_time_to_year(test_df, inplace):
+    if "year" in test_df.data:
+        return  # year df not relevant for this test
+
+    exp = test_df.data.copy()
+    exp["year"] = exp["time"].apply(lambda x: x.year)
+    exp = exp.drop("time", axis="columns")
+    exp = IamDataFrame(exp)
+
+    obs = test_df.swap_time_for_year(inplace=inplace)
+
+    if inplace:
+        assert obs is None
+        obs = test_df
+
+    assert compare(obs, exp).empty
+    assert obs.year == [2005, 2010]
+    with pytest.raises(AttributeError):
+        obs.time
+
+
+@pytest.mark.parametrize("inplace", [True, False])
+def test_swap_time_to_year_errors(test_df, inplace):
+    if "year" in test_df.data:
+        with pytest.raises(ValueError):
+            test_df.swap_time_for_year(inplace=inplace)
+        return
+
+    tdf = test_df.data.copy()
+    tdf["time"] = tdf["time"].apply(lambda x: datetime(2005, x.month, x.day))
+
+    with pytest.raises(ValueError):
+        IamDataFrame(tdf).swap_time_for_year(inplace=inplace)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR migrates a feature first developed in https://github.com/openENTRANCE/nomenclature to split out the "time" column of an IamDataFrame into a year column (as int) plus keeping the information on the sub-annual resolution as a new extra-column "subannual".