### PR TITLE
Add attribute `dimensions`, fix compatibility with pandas v1.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Next Release
 
+## API changes
+
+PR [#559](https://github.com/IAMconsortium/pyam/pull/559) marked
+the attribute `_LONG_IDX` as deprecated. Please use `dimensions` instead. 
+
+## Individual updates
+
+- [#559](https://github.com/IAMconsortium/pyam/pull/559) Add attribute dimensions, fix compatibility with pandas v1.3
 - [#557](https://github.com/IAMconsortium/pyam/pull/557) Swap time for year keeping subannual resolution
 - [#556](https://github.com/IAMconsortium/pyam/pull/556) Set explicit minimum numpy version (1.19.0)
 

--- a/pyam/_ops.py
+++ b/pyam/_ops.py
@@ -47,7 +47,7 @@ KNOWN_OPS = {
 def _op_data(df, name, method, axis, fillna=None, args=(), ignore_units=False, **kwds):
     """Internal implementation of numerical operations on timeseries"""
 
-    if axis not in df._data.index.names:
+    if axis not in df.dimensions:
         raise ValueError(f"Unknown axis: {axis}")
 
     if method in KNOWN_OPS:
@@ -57,7 +57,7 @@ def _op_data(df, name, method, axis, fillna=None, args=(), ignore_units=False, *
     else:
         raise ValueError(f"Unknown method: {method}")
 
-    cols = df._data.index.names.difference([axis])
+    cols = [d for d in df.dimensions if d != axis]
 
     # replace args and and kwds with values of `df._data` if applicable
     # _data_args and _data_kwds track if an argument was replaced by `df._data` values

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -177,7 +177,7 @@ def _aggregate_time(df, variable, column, value, components, method=np.sum):
     # compute aggregate over time
     filter_args = dict(variable=variable)
     filter_args[column] = components
-    index = df._data.index.names.difference([column])
+    index = [d for d in df.dimensions if d != column]
 
     _data = pd.concat(
         [
@@ -191,7 +191,7 @@ def _aggregate_time(df, variable, column, value, components, method=np.sum):
     )
 
     # reset index-level order to original IamDataFrame
-    _data.index = _data.index.reorder_levels(df._LONG_IDX)
+    _data.index = _data.index.reorder_levels(df.dimensions)
 
     return _data
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -393,7 +393,7 @@ class IamDataFrame(object):
     def _LONG_IDX(self):
         """DEPRECATED - please use `IamDataFrame.dimensions`"""
         # TODO: deprecated, remove for release >= 1.2
-        deprecation_warning("Use the attribute `dimensions` instead. This attribute")
+        deprecation_warning("Use the attribute `dimensions` instead.", "This attribute")
         return self.dimensions
 
     def copy(self):

--- a/pyam/figures.py
+++ b/pyam/figures.py
@@ -41,7 +41,7 @@ def sankey(df, mapping):
             "Missing optional dependency `plotly`, use pip or conda to install"
         )
     # Check for duplicates
-    for col in [name for name in df._data.index.names if name != "variable"]:
+    for col in [name for name in df.dimensions if name != "variable"]:
         levels = get_index_levels(df._data, col)
         if len(levels) > 1:
             raise ValueError(f"Non-unique values in column {col}: {levels}")

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -35,7 +35,6 @@ def swap_time_for_year(df, inplace, subannual=False):
         _raise_data_error(error_msg, index[rows].to_frame().reset_index(drop=True))
 
     # assign data and other attributes
-    ret._LONG_IDX = index.names
     ret._data.index = index
     ret.time_col = "year"
     ret._set_attributes()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ logo = r"""
 """
 
 # NOTE TO DEVS
-# If you change a minimum version below, please explicitly set that
+# If you change a minimum version below, please explicitly implement the change
 # in our minimum-reqs test in the file ./.github/workflows/pytest-depedency.yml
 # Please also add a section "Dependency changes" to the release notes
 REQUIREMENTS = [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIREMENTS = [
     "iam-units>=2020.4.21",
     "numpy>=1.19.0",
     "requests",
-    "pandas>=1.1.1,<1.3.0",
+    "pandas>=1.1.1",
     "pint",
     "PyYAML",
     "matplotlib>=3.2.0",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -192,7 +192,7 @@ def test_print(test_df_year):
     exp = "\n".join(
         [
             "<class 'pyam.core.IamDataFrame'>",
-            "Index dimensions:",
+            "Index:",
             " * model    : model_a (1)",
             " * scenario : scen_a, scen_b (2)",
             "Timeseries data coordinates:",
@@ -215,7 +215,7 @@ def test_print_empty(test_df_year):
     exp = "\n".join(
         [
             "<class 'pyam.core.IamDataFrame'>",
-            "Index dimensions:",
+            "Index:",
             " * model    : (0)",
             " * scenario : (0)",
             "Timeseries data coordinates:",
@@ -322,6 +322,12 @@ def test_unit_mapping(test_pd_df):
     obs = IamDataFrame(test_pd_df).unit_mapping
 
     assert obs == {"Primary Energy": ["EJ/yr", "foo"], "Primary Energy|Coal": "EJ/yr"}
+
+
+def test_dimensions(test_df):
+    """Assert that the dimensions attribute works as expected"""
+    assert test_df.dimensions == IAMC_IDX + [test_df.time_col]
+    assert test_df._LONG_IDX == IAMC_IDX + [test_df.time_col]
 
 
 def test_filter_empty_df():
@@ -818,7 +824,7 @@ def _r5_regions_exp(df):
     df = df.filter(region="World", keep=False)
     data = df.data
     data["region"] = "R5MAF"
-    return sort_data(data, df._LONG_IDX)
+    return sort_data(data, df.dimensions)
 
 
 def test_map_regions_r5(reg_df):
@@ -904,7 +910,7 @@ def test_48b():
         )
     )
     obs = df.map_regions("iso", region_col="r5_region").data
-    obs = sort_data(obs[obs.region.isin(["SSD", "SDN"])], df._LONG_IDX)
+    obs = sort_data(obs[obs.region.isin(["SSD", "SDN"])], df.dimensions)
 
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 
@@ -1021,7 +1027,7 @@ def test_concat_incompatible_cols(test_pd_df):
     test_pd_df["extra_col"] = "foo"
     df2 = IamDataFrame(test_pd_df)
 
-    match = "Items have incompatible timeseries data index dimensions!"
+    match = "Items have incompatible timeseries data dimensions!"
     with pytest.raises(ValueError, match=match):
         concat([df1, df2])
 

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -122,14 +122,12 @@ def test_append_extra_col(test_df, shuffle_cols):
     other_data = base_data[base_data["variable"] == "Primary Energy"].copy()
     other_data["variable"] = "Primary Energy|Gas"
     other_df = IamDataFrame(other_data)
-    # cast from FrozenList to list for test
-    other_df._LONG_IDX = list(other_df._LONG_IDX)
 
     if shuffle_cols:
-        c1_idx = other_df._LONG_IDX.index("col_1")
-        c2_idx = other_df._LONG_IDX.index("col_2")
-        other_df._LONG_IDX[c1_idx] = "col_2"
-        other_df._LONG_IDX[c2_idx] = "col_1"
+        c1_idx = other_df.dimensions.index("col_1")
+        c2_idx = other_df.dimensions.index("col_2")
+        other_df.dimensions[c1_idx] = "col_2"
+        other_df.dimensions[c2_idx] = "col_1"
 
     res = base_df.append(other_df)
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR was triggered by release v1.3 of pandas, which changed the `sort_values()` method causing errors.

In the process, I inserted a new attribute `dimensions` to return the list of "columns" of the IAMC-format, following the principles of the SDMX format detailed by @khaeru at https://github.com/IAMconsortium/nomenclature/issues/10. Then, I refactored all occurrences of `_LONG_IDX` and `IamDataFrame._data.index.names` to that attribute and fixed the output of the `print()` statement to reduce ambiguity (i.e., dimensions is the index names plus the timeseries data coordinates).

The attribute `_LONG_IDX` is added explicitly to ensure compatibility with any existing code, but it is marked as deprecated and will be removed in the next (minor) release.