### PR TITLE
Add a feature to `swap_year_for_time`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,8 @@ the attribute `_LONG_IDX` as deprecated. Please use `dimensions` instead.
 
 ## Individual updates
 
-- [#559](https://github.com/IAMconsortium/pyam/pull/559) Add attribute dimensions, fix compatibility with pandas v1.3
+- [#560](https://github.com/IAMconsortium/pyam/pull/560) Add a feature to `swap_year_for_time()`
+- [#559](https://github.com/IAMconsortium/pyam/pull/559) Add attribute `dimensions`, fix compatibility with pandas v1.3
 - [#557](https://github.com/IAMconsortium/pyam/pull/557) Swap time for year keeping subannual resolution
 - [#556](https://github.com/IAMconsortium/pyam/pull/556) Set explicit minimum numpy version (1.19.0)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -324,6 +324,7 @@ texinfo_documents = [
 # Intersphinx configuration.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable", None),

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -10,6 +10,7 @@ from pyam.run_control import *
 from pyam.iiasa import read_iiasa
 from pyam.datareader import read_worldbank
 from pyam.unfccc import read_unfccc
+from pyam.testing import assert_iamframe_equal
 
 from pyam.logging import defer_logging_config
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -632,6 +632,10 @@ class IamDataFrame(object):
         ------
         ValueError
             "time" is not a column of `self.data`
+
+        See Also
+        --------
+        swap_year_for_time
         """
         return swap_time_for_year(self, subannual=subannual, inplace=inplace)
 
@@ -652,6 +656,10 @@ class IamDataFrame(object):
         ------
         ValueError
             "year" or "subannual" are not a column of `self.data`
+
+        See Also
+        --------
+        swap_time_for_year
         """
         return swap_year_for_time(self, inplace=inplace)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -11,9 +11,6 @@ import pandas as pd
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from pyam._debiasing import _compute_bias
-from pyam.time import swap_time_for_year
-
 try:
     from datapackage import Package
 
@@ -24,7 +21,6 @@ except ImportError:
 
 try:
     import ixmp
-
     ixmp.TimeSeries
     has_ix = True
 except (ImportError, AttributeError):
@@ -57,7 +53,7 @@ from pyam.utils import (
     _raise_data_error,
 )
 from pyam.read_ixmp import read_ix
-from pyam.plotting import PlotAccessor, mpl_args_to_meta_cols
+from pyam.plotting import PlotAccessor
 from pyam._compare import _compare
 from pyam.aggregation import (
     _aggregate,
@@ -75,6 +71,8 @@ from pyam.index import (
     verify_index_integrity,
     replace_index_values,
 )
+from pyam.time import swap_time_for_year
+from pyam._debiasing import _compute_bias
 from pyam.logging import deprecation_warning
 
 logger = logging.getLogger(__name__)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -611,14 +611,14 @@ class IamDataFrame(object):
             return ret
 
     def swap_time_for_year(self, subannual=False, inplace=False):
-        """Convert the `time` column to `year` (as integer).
+        """Convert the `time` dimension to `year` (as integer).
 
         Parameters
         ----------
         subannual : bool, str or func, optional
             Merge non-year components of the "time" domain as new column "subannual".
-            Apply `strftime()` on the values of the "time" domain using `subannual`
-            as format (if a string) or using "%m-%d %H:%M%z" (if True).
+            Apply :meth:`strftime() <datetime.date.strftime>` on the values of the
+            "time" domain using `subannual` (if a string) or "%m-%d %H:%M%z" (if True).
             If it is a function, apply the function on the values of the "time" domain.
         inplace : bool, optional
             If True, do operation inplace and return None.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -71,7 +71,7 @@ from pyam.index import (
     verify_index_integrity,
     replace_index_values,
 )
-from pyam.time import swap_time_for_year
+from pyam.time import swap_time_for_year, swap_year_for_time
 from pyam._debiasing import _compute_bias
 from pyam.logging import deprecation_warning
 
@@ -611,7 +611,7 @@ class IamDataFrame(object):
             return ret
 
     def swap_time_for_year(self, subannual=False, inplace=False):
-        """Convert the `time` column to `year`.
+        """Convert the `time` column to `year` (as integer).
 
         Parameters
         ----------
@@ -623,12 +623,37 @@ class IamDataFrame(object):
         inplace : bool, optional
             If True, do operation inplace and return None.
 
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Object with altered time domain or None if `inplace=True`.
+
         Raises
         ------
         ValueError
             "time" is not a column of `self.data`
         """
         return swap_time_for_year(self, subannual=subannual, inplace=inplace)
+
+    def swap_year_for_time(self, inplace=False):
+        """Convert the `year` and `subannual` dimensions to `time` (as datetime).
+
+        Parameters
+        ----------
+        inplace : bool, optional
+            If True, do operation inplace and return None.
+
+        Returns
+        -------
+        :class:`IamDataFrame` or **None**
+            Object with altered time domain or None if `inplace=True`.
+
+        Raises
+        ------
+        ValueError
+            "year" or "subannual" are not a column of `self.data`
+        """
+        return swap_year_for_time(self, inplace=inplace)
 
     def as_pandas(self, meta_cols=True):
         """Return object as a pandas.DataFrame

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -21,6 +21,7 @@ except ImportError:
 
 try:
     import ixmp
+
     ixmp.TimeSeries
     has_ix = True
 except (ImportError, AttributeError):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -637,11 +637,19 @@ class IamDataFrame(object):
         See Also
         --------
         swap_year_for_time
+
         """
         return swap_time_for_year(self, subannual=subannual, inplace=inplace)
 
     def swap_year_for_time(self, inplace=False):
         """Convert the `year` and `subannual` dimensions to `time` (as datetime).
+
+        The method applies :meth:`dateutil.parser.parse` on the combined columns
+        `year` and `subannual`:
+
+        .. code-block:: python
+
+            dateutil.parser.parse([f"{y}-{s}" for y, s in zip(year, subannual)])
 
         Parameters
         ----------
@@ -661,6 +669,7 @@ class IamDataFrame(object):
         See Also
         --------
         swap_time_for_year
+
         """
         return swap_year_for_time(self, inplace=inplace)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -69,10 +69,20 @@ def test_swap_time_to_year_subannual(test_pd_df, columns, subannual, dates, inpl
     """Swap time column for year (int) keeping subannual resolution as extra-column"""
 
     test_pd_df.rename({2005: columns[0], 2010: columns[1]}, axis=1, inplace=True)
-    obs = IamDataFrame(test_pd_df).swap_time_for_year(subannual=subannual)
+
+    # check swapping time for year
+    df = IamDataFrame(test_pd_df)
+    obs = df.swap_time_for_year(subannual=subannual, inplace=inplace)
+
+    if inplace:
+        assert obs is None
+        obs = df
 
     exp = get_subannual_df(dates[0], dates[1])
     assert_iamframe_equal(obs, exp)
+
+    # check that reverting using `swap_year_for_time` yields the original data
+    assert_iamframe_equal(obs.swap_year_for_time(), IamDataFrame(test_pd_df))
 
 
 def test_swap_time_to_year_errors(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR introduces the "inverse" of the `swap_time_for_year()` method. This should facilitate conversion from and to proper `datetime` timeseries and the "subannual" column currently used in the IIASA database infrastructure.

As shown in the tests, if you have an IamDataFrame with datetime format, then

```python
df.swap_time_for_year(subannual=True).swap_year_for_time()
```
will yield an identical object.
