### PR TITLE
Make `rename()` work with a custom index

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,13 +136,18 @@ TEST_STACKPLOT_DF["scenario"] = "a_scen"
 
 # minimal IamDataFrame with four different time formats
 @pytest.fixture(
-    scope="function", params=[TEST_YEARS, TEST_DTS, TEST_TIME_STR, TEST_TIME_STR_HR]
+    scope="function",
+    params=[
+        # standard IAMC format
+        {},
+        # testing several versions of datetime format
+        dict([(i, j) for i, j in zip(TEST_YEARS, TEST_DTS)]),
+        dict([(i, j) for i, j in zip(TEST_YEARS, TEST_TIME_STR)]),
+        dict([(i, j) for i, j in zip(TEST_YEARS, TEST_TIME_STR_HR)]),
+    ],
 )
 def test_df(request):
-    tdf = TEST_DF.rename(
-        {2005: request.param[0], 2010: request.param[1]}, axis="columns"
-    )
-    df = IamDataFrame(data=tdf)
+    df = IamDataFrame(data=TEST_DF.rename(request.param, axis="columns"))
     for i in META_COLS:
         df.set_meta(META_DF[i])
     yield df


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- ~Description in RELEASE_NOTES.md Added~

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR generalizes the `rename()` function so that it can be used on an **IamDataFrame** with a custom index (ie., other than `["model", "scenario"]`, see [here](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame).

Two use cases of the custom index:
- retrieving scenario data from the IIASA database API using `default=False`, which returns all versions of scenarios instead of just the default, and which then uses the custom index `["model", "scenario", "version"]`, see [here](https://pyam-iamc.readthedocs.io/en/stable/api/iiasa.html#pyam.iiasa.Connection.query)
- the openMODEX project (afaik) developed a data format similar to the IAMC template but uses *source* instead of *model*. for generality

## To-Do

Rather than writing a single test just for this function, I'm thinking about how to redo `test_df` in the pytest-config so that a custom index can be tested across the entire pyam code base.
