### PR TITLE
Add a citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,52 @@
+cff-version: 1.1.0
+message: "If you use this package, please cite the corresponding manuscript in Open Research Europe."
+title: "pyam: analysis and visualization of integrated-assessment and macro-energy scenarios"
+repository: https://github.com/iamconsortium/pyam
+version: 1.0
+license: Apache-2.0
+journal: Open Research Europe
+doi: 10.12688/openreseurope.13633.1
+authors:
+  - family-names: Huppmann
+    given-names: Daniel
+    orcid: https://orcid.org/0000-0002-7729-7389
+  - family-names: Gidden
+    given-names: Matthew J.
+  - family-names: Nicholls
+    given-names: Zebedee
+  - family-names: Hörsch
+    given-names: Jonas
+  - family-names: Lamboll
+    given-names: Robin
+  - family-names: Kishimoto
+    given-names: Paul Natsuo
+  - family-names: Burandt
+    given-names: Thorsten
+  - family-names: Fricko
+    given-names: Oliver
+  - family-names: Byers
+    given-names: Edward
+  - family-names: Kikstra
+    given-names: Jarmo
+  - family-names: Brinkerink
+    given-names: Maarten
+  - family-names: Budzinski
+    given-names: Maik
+  - family-names: Maczek
+    given-names: Florian
+  - family-names: Zwickl-Bernhard
+    given-names: Sebastian
+  - family-names: Welder
+    given-names: Lara
+  - family-names: Quispe
+    given-names: Erik Francisco Álvarez
+  - family-names: Smith
+    given-names: Christopher J.
+keywords:
+  - integrated assessment
+  - energy systems
+  - macro-energy
+  - modelling
+  - scenario analysis
+  - data visualisation
+  - Python package


### PR DESCRIPTION
# Description of PR

Github just added a new feature to support a recommended citation (via a cff file) that will be displayed on the main overview page (top-right below the license). This PR adds a cff file that refers to the Open Research Europe manuscript.
