### PR TITLE
Loosen xlrd requirement

### DIFF
--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install specific out-dated version of dependencies
       # Update the package requirements when changing minimum dependency versions
       # Please also add a section "Dependency changes" to the release notes
-      run: pip install pandas==1.1.1 numpy==1.19.0 matplotlib==3.2.0 iam-units==2020.4.21
+      run: pip install pandas==1.1.1 numpy==1.19.0 matplotlib==3.2.0 iam-units==2020.4.21 xlrd==2.0
 
     - name: Install other dependencies and package
       run: pip install -e .[tests,deploy,optional-plotting,optional-io-formats,tutorials]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## Individual updates
+
+PR [#572](https://github.com/IAMconsortium/pyam/pull/572) unpinned the requirements for xlrd and added openpyxl as a requirement to ensure ongoing support of both `.xlsx` and `.xls` files out of the box
+
 # Release v1.1.0
 
 ## Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
+# Next Release
+
+## Dependency changes
+
+The dependencies were updated to require `xlrd>=2.0` (previously `<2.0`) and `openpyxl` was added as a dependency.
+
 ## Individual updates
 
-PR [#572](https://github.com/IAMconsortium/pyam/pull/572) unpinned the requirements for xlrd and added openpyxl as a requirement to ensure ongoing support of both `.xlsx` and `.xls` files out of the box
+- [#572](https://github.com/IAMconsortium/pyam/pull/572) Unpinned the requirements for xlrd and added openpyxl as a requirement to ensure ongoing support of both `.xlsx` and `.xls` files out of the box
 
 # Release v1.1.0
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -194,7 +194,7 @@ class IamDataFrame(object):
 
         # if initializing from xlsx, try to load `meta` table from file
         if meta_sheet and isinstance(data, Path) and data.suffix == ".xlsx":
-            excel_file = pd.ExcelFile(data)
+            excel_file = pd.ExcelFile(data, engine="openpyxl")
             if meta_sheet in excel_file.sheet_names:
                 self.load_meta(excel_file, sheet_name=meta_sheet, ignore_conflict=True)
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -138,7 +138,14 @@ def read_pandas(path, sheet_name="data*", *args, **kwargs):
     if isinstance(path, Path) and path.suffix == ".csv":
         return pd.read_csv(path, *args, **kwargs)
     else:
-        xl = pd.ExcelFile(path)
+        if isinstance(path, pd.ExcelFile):
+            xl = path
+        else:
+            xl = pd.ExcelFile(
+                path,
+                engine="xlrd" if path.suffix == ".xls" else "openpyxl"
+            )
+
         sheet_names = pd.Series(xl.sheet_names)
 
         # reading multiple sheets
@@ -153,7 +160,7 @@ def read_pandas(path, sheet_name="data*", *args, **kwargs):
 
         # read single sheet (if only one exists in file) ignoring sheet name
         else:
-            df = pd.read_excel(path, *args, **kwargs)
+            df = pd.read_excel(xl, *args, **kwargs)
 
         # remove unnamed and empty columns, and rows were all values are nan
         def is_empty(name, s):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -142,8 +142,7 @@ def read_pandas(path, sheet_name="data*", *args, **kwargs):
             xl = path
         else:
             xl = pd.ExcelFile(
-                path,
-                engine="xlrd" if path.suffix == ".xls" else "openpyxl"
+                path, engine="xlrd" if path.suffix == ".xls" else "openpyxl"
             )
 
         sheet_names = pd.Series(xl.sheet_names)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ EXTRA_REQUIREMENTS = {
         "sphinxcontrib-bibtex<2.0",
         "sphinxcontrib-programoutput",
         "numpydoc",
-        "openpyxl",
         "kaleido",
     ]  # docs requires 'tutorials'
     # GitHub Actions requires pandoc explicitly to build the docs

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,21 @@ logo = r"""
 
 # NOTE TO DEVS
 # If you change a minimum version below, please explicitly implement the change
-# in our minimum-reqs test in the file ./.github/workflows/pytest-depedency.yml
+# in our minimum-reqs test in the file ./.github/workflows/pytest-dependency.yml
 # Please also add a section "Dependency changes" to the release notes
 REQUIREMENTS = [
     "argparse",
     "iam-units>=2020.4.21",
     "numpy>=1.19.0",
     "requests",
+    "openpyxl",
     "pandas>=1.1.1",
     "pint",
     "PyYAML",
     "matplotlib>=3.2.0",
     "seaborn",
     "six",
-    "xlrd<2.0",
+    "xlrd>=2.0",
 ]
 
 EXTRA_REQUIREMENTS = {

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -106,7 +106,7 @@ def test_init_df_with_na_unit(test_pd_df, tmpdir):
 
     file = tmpdir / "na_unit.xlsx"
     df.to_excel(file)
-    df_excel = pd.read_excel(file)
+    df_excel = pd.read_excel(file, engine="openpyxl")
     assert np.isnan(df_excel.loc[1, "Unit"])
     IamDataFrame(file)  # reading from file as IamDataFrame works
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added (N/A)
- [x] Documentation Added (N/A)
- [x] Name of contributors Added to AUTHORS.rst (N/A)
- [x] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Loosen the pinning of xlrd. The pin isn't needed and it's causing issues for downstream users (e.g. attempts to make openscm-runner a conda package https://github.com/conda-forge/staged-recipes/pull/15573#issuecomment-898890003). It would be great if these changes could be propagated to conda and pypi fairly quickly as a bug fix.
