### PR TITLE
Add documentation to `IamDataFrame.rename` for region aggregation use

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1010,6 +1010,11 @@ class IamDataFrame(object):
         columns given in `mapping`. Renaming can only be applied to the `model`
         and `scenario` columns, or to other data coordinates simultaneously.
 
+        This function can also be used to compute region aggregations. This is
+        done by renaming several constituent regions to the same name of a
+        common aggregation region and then applying groupby and sum(). Note that
+        for this use case check_duplicates **must be** set to False.
+
         Parameters
         ----------
         mapping : dict or kwargs


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] ~~Tests Added~~
- [x] Documentation Added
- [ ] ~~Name of contributors Added to AUTHORS.rst~~
- [ ] ~~Description in RELEASE_NOTES.md Added~~

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Add to the docstring of `IamDataFrame.rename` to make the fact that this can be used for region aggregation by renaming a number to regions to the same and then summing over them more obvious to the untrained eye. I had to read through the entire code to figure out the connection between renaming and region aggregation.
