### PR TITLE
Improve performance of IamDataFrame initialization

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ The following persons contributed to the development of the |pyam| framework:
 - Patrick Jürgens `@pjuergens <https://github.com/pjuergens>`_
 - Florian Maczek `@macflo8 <https://github.com/macflo8>`_
 - Laura Wienpahl `@LauWien <https://github.com/LauWien>`_
+- Philip Hackstock `@phackstock <https://github.com/phackstock>`_

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ The dependencies were updated to require `xlrd>=2.0` (previously `<2.0`) and `op
 
 ## Individual updates
 
+- [#579](https://github.com/IAMconsortium/pyam/pull/579) Increase performance of IamDataFrame initialization
 - [#572](https://github.com/IAMconsortium/pyam/pull/572) Unpinned the requirements for xlrd and added openpyxl as a requirement to ensure ongoing support of both `.xlsx` and `.xls` files out of the box
 
 # Release v1.1.0

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -346,7 +346,7 @@ def format_data(df, index, **kwargs):
         _raise_data_error(
             "Duplicate rows in `data`", df[rows].index.to_frame(index=False)
         )
-
+    del rows
     if df.empty:
         logger.warning("Formatted data is empty!")
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -331,19 +331,25 @@ def format_data(df, index, **kwargs):
     # verify that there are no nan's left (in columns)
     null_rows = df.isnull().values
     if null_rows.any():
-        _raise_data_error("empty cells in `data`", df.loc[null_rows])
+        _raise_data_error("Empty cells in `data`", df.loc[null_rows])
 
-    # check for duplicates and empty data
+    # format the time-column
+    df = format_time_col(df, time_col)
+
+    # cast to pd.Series, check for duplicates
     idx_cols = index + REQUIRED_COLS + [time_col] + extra_cols
-    rows = df[idx_cols].duplicated()
+    df = df.set_index(idx_cols).value
+
+    rows = df.index.duplicated()
     if any(rows):
-        _raise_data_error("duplicate rows in `data`", df.loc[rows, idx_cols])
+        _raise_data_error(
+            "Duplicate rows in `data`", df[rows].index.to_frame(index=False)
+        )
 
     if df.empty:
         logger.warning("Formatted data is empty!")
 
-    df = format_time_col(df, time_col)
-    return df.set_index(idx_cols).sort_index().value, index, time_col, extra_cols
+    return df.sort_index(), index, time_col, extra_cols
 
 
 def format_time_col(data, time_col):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -342,8 +342,8 @@ def format_data(df, index, **kwargs):
     if df.empty:
         logger.warning("Formatted data is empty!")
 
-    df = format_time_col(sort_data(df, idx_cols), time_col)
-    return df.set_index(idx_cols).value, index, time_col, extra_cols
+    df = format_time_col(df, time_col)
+    return df.set_index(idx_cols).sort_index().value, index, time_col, extra_cols
 
 
 def format_time_col(data, time_col):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -329,9 +329,10 @@ def format_data(df, index, **kwargs):
     df.loc[df.unit.isnull(), "unit"] = ""
 
     # verify that there are no nan's left (in columns)
-    null_rows = df.isnull().values
+    null_rows = df.isnull().T.any()
     if null_rows.any():
         _raise_data_error("Empty cells in `data`", df.loc[null_rows])
+    del null_rows
 
     # format the time-column
     df = format_time_col(df, time_col)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -80,7 +80,7 @@ def test_init_df_with_float_cols_raises(test_pd_df):
 def test_init_df_with_duplicates_raises(test_df):
     _df = test_df.timeseries()
     _df = _df.append(_df.iloc[0]).reset_index()
-    match = "3  model_a   scen_a  World  Primary Energy  EJ/yr"
+    match = "0  model_a   scen_a  World  Primary Energy  EJ/yr"
     with pytest.raises(ValueError, match=match):
         IamDataFrame(_df)
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~ -> no functional changes, existing tests should cover all cases where something could go wrong
- [x] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR implement faster and less memory-intensive initialization of an IamDataframe by doing the sorting and validation on the indexed pd.Series instead of the DataFrame. Based on memory-profiling work by @phackstock.
