### PR TITLE
Migrate utility function `raise_data_error` to logging module

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -51,7 +51,6 @@ from pyam.utils import (
     IAMC_IDX,
     SORT_IDX,
     ILLEGAL_COLS,
-    _raise_data_error,
 )
 from pyam.read_ixmp import read_ix
 from pyam.plotting import PlotAccessor
@@ -74,7 +73,7 @@ from pyam.index import (
 )
 from pyam.time import swap_time_for_year, swap_year_for_time
 from pyam._debiasing import _compute_bias
-from pyam.logging import deprecation_warning
+from pyam.logging import deprecation_warning, raise_data_error
 
 logger = logging.getLogger(__name__)
 
@@ -1089,7 +1088,7 @@ class IamDataFrame(object):
         has_duplicates = any(duplicate_rows)
 
         if has_duplicates and check_duplicates:
-            _raise_data_error(
+            raise_data_error(
                 "Conflicting data rows after renaming "
                 "(use `aggregate()` or `check_duplicates=False` instead)",
                 _data_index[duplicate_rows].to_frame(index=False),

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-from .utils import _raise_data_error, isstr
+from pyam.logging import raise_data_error
 
 
 def get_index_levels(index, level):
@@ -85,7 +85,7 @@ def append_index_col(index, values, name, order=False):
 
 def append_index_level(index, codes, level, name, order=False):
     """Append a level to a pd.MultiIndex"""
-    if isstr(level):
+    if isinstance(level, str):
         level = [level]
         codes = [codes] * len(index.codes[0])
 
@@ -114,6 +114,6 @@ def verify_index_integrity(df):
     if not index.is_unique:
         overlap = index[index.duplicated()].unique()
 
-        _raise_data_error(
+        raise_data_error(
             "Timeseries data has overlapping values", overlap.to_frame(index=False)
         )

--- a/pyam/logging.py
+++ b/pyam/logging.py
@@ -24,6 +24,14 @@ def deprecation_warning(msg, type="This method", stacklevel=3):
     )
 
 
+def raise_data_error(msg, data):
+    """Utils function to format error message from data formatting"""
+    data = data.drop_duplicates()
+    msg = f"{msg}:\n{data.head()}" + ("\n..." if len(data) > 5 else "")
+    logger.error(msg)
+    raise ValueError(msg)
+
+
 class ConfigPseudoHandler(logging.Handler):
     """Pseudo logging handler to defer configuring logging until the first message
 

--- a/pyam/plotting.py
+++ b/pyam/plotting.py
@@ -20,8 +20,8 @@ from pyam.utils import (
     YEAR_IDX,
     isstr,
     to_list,
-    _raise_data_error,
 )
+from pyam.logging import raise_data_error
 from pyam.index import get_index_levels
 
 # TODO: this is a hotfix for changes in pandas 0.25.0, per discussions on the
@@ -235,7 +235,7 @@ def reshape_mpl(df, x, y, idx_cols, **kwargs):
     # check for duplicates
     rows = df[idx_cols].duplicated()
     if any(rows):
-        _raise_data_error("Duplicates in plot data", df.loc[rows, idx_cols])
+        raise_data_error("Duplicates in plot data", df.loc[rows, idx_cols])
 
     # reshape the data
     df = df.set_index(idx_cols)[y].unstack(x).T

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -1,7 +1,7 @@
 import dateutil
 import pandas as pd
 from pyam.index import append_index_col
-from pyam.utils import _raise_data_error
+from pyam.logging import raise_data_error
 
 
 def swap_time_for_year(df, inplace, subannual=False):
@@ -34,7 +34,7 @@ def swap_time_for_year(df, inplace, subannual=False):
     rows = index.duplicated()
     if any(rows):
         error_msg = "Swapping time for year causes duplicates in `data`"
-        _raise_data_error(error_msg, index[rows].to_frame().reset_index(drop=True))
+        raise_data_error(error_msg, index[rows].to_frame().reset_index(drop=True))
 
     # assign data and other attributes
     ret._data.index = index

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -330,7 +330,7 @@ def format_data(df, index, **kwargs):
     # verify that there are no nan's left (in columns)
     null_rows = df.isnull().T.any()
     if null_rows.any():
-        _raise_data_error("Empty cells in `data`", df.loc[null_rows])
+        raise_data_error("Empty cells in `data`", df.loc[null_rows])
     del null_rows
 
     # format the time-column
@@ -342,7 +342,7 @@ def format_data(df, index, **kwargs):
 
     rows = df.index.duplicated()
     if any(rows):
-        _raise_data_error(
+        raise_data_error(
             "Duplicate rows in `data`", df[rows].index.to_frame(index=False)
         )
     del rows

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -8,6 +8,7 @@ import datetime
 import dateutil
 import time
 
+from pyam.logging import raise_data_error
 import numpy as np
 import pandas as pd
 from collections.abc import Iterable
@@ -224,9 +225,7 @@ def format_data(df, index, **kwargs):
     # otherwise, rename columns or concat to IAMC-style or do a fill-by-value
     for col, value in kwargs.items():
         if col in df:
-            raise ValueError(
-                "conflict of kwarg with column `{}` in dataframe!".format(col)
-            )
+            raise ValueError(f"Conflict of kwarg with column `{col}` in dataframe!")
 
         if isstr(value) and value in df:
             df.rename(columns={value: col}, inplace=True)
@@ -236,7 +235,7 @@ def format_data(df, index, **kwargs):
         elif isstr(value):
             df[col] = value
         else:
-            raise ValueError("invalid argument for casting `{}: {}`".format(col, value))
+            raise ValueError(f"Invalid argument for casting `{col}: {value}`")
 
     # all lower case
     str_cols = [c for c in df.columns if isstr(c)]
@@ -360,14 +359,6 @@ def format_time_col(data, time_col):
     elif time_col == "time":
         data["time"] = pd.to_datetime(data["time"])
     return data
-
-
-def _raise_data_error(msg, data):
-    """Utils function to format error message from data formatting"""
-    data = data.drop_duplicates()
-    msg = f"{msg}:\n{data.head()}" + ("\n..." if len(data) > 5 else "")
-    logger.error(msg)
-    raise ValueError(msg)
 
 
 def sort_data(data, cols):


### PR DESCRIPTION
# Description of PR

While working on #580 and doing some benchmarking, I got tangled between the actual performance improvements and some refactoring to prevent circular imports. This PR separates out some pure refactoring and clean-up, moving the `raise_data_error` utility function to the logging module.
