### PR TITLE
Implement fix to support jupyter-lab notebooks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next release
 
+- [#592](https://github.com/IAMconsortium/pyam/pull/592) Fix for running in jupyter-lab notebooks
 - [#590](https://github.com/IAMconsortium/pyam/pull/590) Update expected figures of plotting tests to use matplotlib 3.5
 - [#586](https://github.com/IAMconsortium/pyam/pull/586) Improve error reporting for non-numeric data in any value column
 

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -35,19 +35,15 @@ except LookupError:
     except PackageNotFoundError:
         __version__ = version("pyam")
 
-# in Jupyter notebooks: disable autoscroll and set-up logging
+# special handling in Jupyter notebooks
 try:
     from ipykernel.zmqshell import ZMQInteractiveShell
     from IPython import get_ipython
 
     shell = get_ipython()
     if isinstance(shell, ZMQInteractiveShell):
-        shell.run_cell_magic(
-            u"javascript",
-            u"",
-            u"IPython.OutputArea.prototype._should_scroll = "
-            u"function(lines) { return false; }",
-        )
+
+        # set up basic logging if running in a notebook
         log_msg = "Running in a notebook, setting up a basic logging at level INFO"
 
         defer_logging_config(
@@ -55,6 +51,15 @@ try:
             log_msg,
             level="INFO",
             format="%(name)s - %(levelname)s: %(message)s",
+        )
+
+        # deactivate in-cell scrolling in a Jupyter notebook
+        shell.run_cell_magic(
+            "javascript",
+            "",
+            "if (typeof IPython !== 'undefined') "
+            "{ IPython.OutputArea.prototype._should_scroll = function(lines)"
+            "{ return false; }}",
         )
 
 except Exception:


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~ (no tests for Jupiter-lab notebooks)
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adapts the special handling when importing pyam in a notebook. As reported by @stefaneidelloth in #591, the deactivation of in-cell scrolling for Jupyter notebooks causes a critical error in jupyter-lab notebooks.

closes #591 
