### PR TITLE
Add an "annualized growth rate" feature

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next release
 
+- [#604](https://github.com/IAMconsortium/pyam/pull/604) Add an annualized-growth-rate method
 - [#602](https://github.com/IAMconsortium/pyam/pull/602) Add a `compute` module/accessor and a learning-rate method 
 - [#600](https://github.com/IAMconsortium/pyam/pull/600) Add a `diff()` method
 - [#592](https://github.com/IAMconsortium/pyam/pull/592) Fix for running in jupyter-lab notebooks

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -14,9 +14,9 @@ and methods.
    api/iamdataframe
    api/database
    api/filtering
+   api/compute
    api/plotting
    api/iiasa
-   api/compute
    api/statistics
    api/timeseries
    api/variables

--- a/doc/source/api/compute.rst
+++ b/doc/source/api/compute.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: pyam
 
-Computing indicators
-====================
+Advanced timeseries indicators
+==============================
 
 .. autoclass:: IamComputeAccessor
    :members:

--- a/doc/source/api/compute.rst
+++ b/doc/source/api/compute.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: pyam
 
-Advanced timeseries indicators
-==============================
+Derived timeseries data
+=======================
 
 .. autoclass:: IamComputeAccessor
    :members:

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -49,6 +49,11 @@ class IamComputeAccessor:
         ------
         ValueError
             Math domain error when timeseries crosses 0.
+
+        See Also
+        --------
+        pyam.timeseries.growth_rate
+
         """
         value = (
             self._df._data[self._df._apply_filters(variable=mapping)]

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -59,8 +59,8 @@ class IamComputeAccessor:
             value = empty_series(remove_from_list(self._df.dimensions, "unit"))
         else:
             # drop level "unit" and reinsert below, replace "variable"
-            value.index = (
-                replace_index_values(value.index.droplevel("unit"), "variable", mapping)
+            value.index = replace_index_values(
+                value.index.droplevel("unit"), "variable", mapping
             )
 
         return self._df._finalize(value, append=append, unit="")

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -125,12 +125,7 @@ def _compute_learning_rate(x, performance, experience):
 
     # return empty pd.Series if not all relevant variables exist
     if not all([v in x.index for v in [performance, experience]]):
-        names = remove_from_list(x.index.names, "variable")
-        empty_list = [[]] * len(names)
-        return pd.Series(
-            index=pd.MultiIndex(levels=empty_list, codes=empty_list, names=names),
-            dtype="float64",
-        )
+        return empty_series(remove_from_list(x.index.names, "variable"))
 
     # compute the "experience parameter" (slope of experience curve on double-log scale)
     b = (x[performance] - x[performance].shift(periods=-1)) / (
@@ -139,3 +134,12 @@ def _compute_learning_rate(x, performance, experience):
 
     # translate to "learning rate" (e.g., cost reduction per doubling of capacity)
     return b.apply(lambda y: 1 - math.pow(2, y))
+
+
+def empty_series(names):
+    """Return an empty pd.Series with correct index names"""
+    empty_list = [[]] * len(names)
+    return pd.Series(
+        index=pd.MultiIndex(levels=empty_list, codes=empty_list, names=names),
+        dtype="float64",
+    )

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -44,6 +44,11 @@ class IamComputeAccessor:
         -------
         :class:`IamDataFrame` or **None**
             Computed timeseries data or None if `append=True`.
+
+        Raises
+        ------
+        ValueError
+            Math domain error when timeseries crosses 0.
         """
         value = (
             self._df._data[self._df._apply_filters(variable=mapping)]

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -35,7 +35,7 @@ class IamComputeAccessor:
 
             .. code-block:: python
 
-               {"current variable": "name of growth-rate variable", ...}
+               {"variable": "name of growth-rate variable", ...}
 
         append : bool, optional
             Whether to append computed timeseries data to this instance.

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -58,7 +58,7 @@ class IamComputeAccessor:
                 replace_index_values(value.index.droplevel("unit"), "variable", mapping)
             )
 
-        return self._finalize(value, append=append, unit="")
+        return self._df._finalize(value, append=append, unit="")
 
     def learning_rate(self, name, performance, experience, append=False):
         """Compute the implicit learning rate from timeseries data

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -50,9 +50,15 @@ class IamComputeAccessor:
             .groupby(remove_from_list(self._df.dimensions, ["year"]), group_keys=False)
             .apply(growth_rate)
         )
-        value.index = replace_index_values(value.index, "variable", mapping)
+        if value.empty:
+            value = empty_series(remove_from_list(self._df.dimensions, "unit"))
+        else:
+            # drop level "unit" and reinsert below, replace "variable"
+            value.index = (
+                replace_index_values(value.index.droplevel("unit"), "variable", mapping)
+            )
 
-        return self._finalize(value, append=append)
+        return self._finalize(value, append=append, unit="")
 
     def learning_rate(self, name, performance, experience, append=False):
         """Compute the implicit learning rate from timeseries data

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2141,7 +2141,7 @@ class IamDataFrame(object):
             Periods to shift for calculating difference, accepts negative values;
             passed to :meth:`pandas.DataFrame.diff`.
         append : bool, optional
-            Whether to append aggregated timeseries data to this instance.
+            Whether to append computed timeseries data to this instance.
 
         Returns
         -------

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -150,6 +150,11 @@ def growth_rate(x):
     ------
     ValueError
         Math domain error when timeseries crosses 0.
+
+    See Also
+    --------
+    pyam.IamComputeAccessor.growth_rate
+
     """
 
     if not (all([v > 0 for v in x.values]) or all([v < 0 for v in x.values])):

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -134,8 +134,8 @@ def cross_threshold(
 def growth_rate(x):
     """Compute the annualized growth rate from timeseries data
 
-    The annualized growth rate parameter in period *t* is computed based on the changes
-    from period *t* to period *t+1*.
+    The annualized growth rate parameter in period *t* is computed assuming exponential
+    growth based on the changes from period *t* to period *t+1*.
 
     Parameters
     ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numpy >= 1.19.0
     requests
     openpyxl
-    pandas >= 1.1.1
+    pandas >= 1.1.1, < 1.4
     pint <= 0.17
     PyYAML
     matplotlib >= 3.2.0

--- a/tests/test_feature_growth_rate.py
+++ b/tests/test_feature_growth_rate.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from pyam import IamDataFrame, IAMC_IDX
+from pyam.testing import assert_iamframe_equal
+import pytest
+
+from conftest import META_DF
+
+
+EXP_DF = IamDataFrame(
+    pd.DataFrame(
+        [
+            ["model_a", "scen_a", "World", "Growth Rate", "", 0.430969],
+            ["model_a", "scen_b", "World", "Growth Rate", "", 0.284735],
+        ],
+        columns=IAMC_IDX + [2005],
+    ),
+    meta=META_DF,
+)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_learning_rate(test_df_year, append):
+    """Check computing the growth rate from an IamDataFrame"""
+
+    if append:
+        obs = test_df_year.copy()
+        obs.compute.growth_rate({"Primary Energy": "Growth Rate"}, append=True)
+        assert_iamframe_equal(test_df_year.append(EXP_DF), obs)
+    else:
+        obs = test_df_year.compute.growth_rate({"Primary Energy": "Growth Rate"})
+        assert_iamframe_equal(EXP_DF, obs)
+
+
+@pytest.mark.parametrize("append", (False, True))
+def test_learning_rate_empty(test_df_year, append):
+    """Assert that computing the growth rate with invalid variables returns empty"""
+
+    if append:
+        obs = test_df_year.copy()
+        obs.compute.growth_rate({"foo": "bar"}, append=True)
+        assert_iamframe_equal(test_df_year, obs)  # assert that no data was added
+    else:
+        obs = test_df_year.compute.growth_rate({"foo": "bar"})
+        assert obs.empty

--- a/tests/test_feature_growth_rate.py
+++ b/tests/test_feature_growth_rate.py
@@ -66,4 +66,4 @@ def test_growth_rate_timeseries_fails(value):
     """Check that a timeseries reaching/crossing 0 raises"""
 
     with pytest.raises(ValueError, match="Cannot compute growth rate when*."):
-        growth_rate(pd.Series([1., value]))
+        growth_rate(pd.Series([1.0, value]))

--- a/tests/test_feature_growth_rate.py
+++ b/tests/test_feature_growth_rate.py
@@ -59,3 +59,11 @@ def test_growth_rate_timeseries(x2010, rates):
         growth_rate(pd.Series([x2010, x2013, x2017], index=[2010, 2013, 2017])),
         pd.Series(rates, index=[2010, 2013]),
     )
+
+
+@pytest.mark.parametrize("value", (0, -1))
+def test_growth_rate_timeseries_fails(value):
+    """Check that a timeseries reaching/crossing 0 raises"""
+
+    with pytest.raises(ValueError, match="Cannot compute growth rate when*."):
+        growth_rate(pd.Series([1., value]))


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a `growth_rate()` method to the `timeseries` and `compute` modules so it can be called as

```python
df.compute.growth_rate({"Primary Energy|Wind": "Growth rate of Wind"})
```
where *df* is an IamDataFrame, or

```python
pyam.timeseries.growth_rate(x)
```
where *x* is a pd.Series indexed over an (integer) time domain.