### PR TITLE
Enable filter for mixed year/time domain

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,14 @@
 
 # Release v1.3.0
 
+## API changes
+
+PR [#598](https://github.com/IAMconsortium/pyam/pull/598) added support
+for mixed time-domains.
+As part of the changes, filtering an **IamDataFrame** with yearly data using arguments
+that are only relevant for the datetime-domain (e.g., month, hour, time) returns
+an empty **IamDataFrame**. Previously, this raised an error.
+
 ## Highlights
 
 - Implement a `compute` module for derived timeseries indicators.

--- a/profile/conftest.py
+++ b/profile/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pyam import IAMC_IDX
+from pyam import IamDataFrame, IAMC_IDX
 
 DATA_PATH = Path("data")
 TEST_DF = pd.DataFrame(
@@ -22,3 +22,8 @@ TEST_FRAMES = [TEST_DF] + [
 @pytest.fixture(scope="function", params=TEST_FRAMES)
 def data(request):
     yield request.param
+
+
+@pytest.fixture(scope="function", params=TEST_FRAMES)
+def df(request):
+    yield IamDataFrame(request.param)

--- a/profile/test_profile.py
+++ b/profile/test_profile.py
@@ -3,3 +3,7 @@ from pyam import IamDataFrame
 
 def test_init(data):
     IamDataFrame(data)
+
+
+def test_filter(df):
+    df.filter(year=2010)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1765,12 +1765,14 @@ class IamDataFrame(object):
                 keep_col = _make_index(
                     self._data, cols=self.index.names, unique=False
                 ).isin(cat_idx)
+
             elif col == "year":
-                if self.time_col == "year":
-                    _data = self.get_data_column(col)
-                else:
-                    _data = self.get_data_column("time").apply(lambda x: x.year)
-                keep_col = years_match(_data, values)
+                levels, codes = get_index_levels_codes(self._data, self.time_col)
+                if self.time_col == "time":
+                    levels = [l.year if isinstance(l, pd.Timestamp) else l for l in levels]
+
+                matches = years_match(levels, values)
+                keep_col = get_keep_col(codes, matches)
 
             elif col == "month" and self.time_col == "time":
                 keep_col = month_match(

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1797,7 +1797,11 @@ class IamDataFrame(object):
                 else:
                     keep_col = np.isin(data, values)
 
-            elif col == "day" and self.time_col == "time":
+            elif col == "day":
+                if self.time_col != "time":
+                    logger.warning(f"Filter by `{col}` not supported with yearly data.")
+                    return np.zeros(len(self), dtype=bool)
+
                 if isinstance(values, str):
                     wday = True
                 elif isinstance(values, list) and isinstance(values[0], str):
@@ -1812,7 +1816,11 @@ class IamDataFrame(object):
 
                 keep_col = day_match(days, values)
 
-            elif col == "time" and self.time_col == "time":
+            elif col == "time":
+                if self.time_col != "time":
+                    logger.warning(f"Filter by `{col}` not supported with yearly data.")
+                    return np.zeros(len(self), dtype=bool)
+
                 keep_col = datetime_match(self.get_data_column("time"), values)
 
             elif col in self.dimensions:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -769,7 +769,7 @@ class IamDataFrame(object):
         if iamc_index:
             if self.time_col == "time":
                 raise ValueError(
-                    "Cannot use IAMC-index with 'datetime' time-domain!"
+                    "Cannot use `iamc_index=True` with 'datetime' time-domain!"
                 )
             s = s.droplevel(self.extra_cols)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1828,7 +1828,7 @@ class IamDataFrame(object):
                 keep_col = get_keep_col(codes, matches)
 
             else:
-                _raise_filter_error(col)
+                raise ValueError(f"Filter by `{col}` not supported!")
 
             keep = np.logical_and(keep, keep_col)
 
@@ -2470,11 +2470,6 @@ class IamDataFrame(object):
 def _meta_idx(data):
     """Return the 'META_IDX' from data by index"""
     return data[META_IDX].drop_duplicates().set_index(META_IDX).index
-
-
-def _raise_filter_error(col):
-    """Raise an error if not possible to filter by col"""
-    raise ValueError(f"Filter by `{col}` not supported!")
 
 
 def _check_rows(rows, check, in_range=True, return_test="any"):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1729,6 +1729,14 @@ class IamDataFrame(object):
         ret._data = ret._data[_keep]
         ret._data.index = ret._data.index.remove_unused_levels()
 
+        # swap time for year if downselected to years-only
+        if ret.time_col == "time":
+            time_values = get_index_levels(ret._data, "time")
+            if time_values and all([pd.api.types.is_integer(y) for y in time_values]):
+                ret.swap_time_for_year(inplace=True)
+                msg = "Only yearly data after filtering, change time_domain to 'year'."
+                logger.info(msg)
+
         # downselect `meta` dataframe
         idx = _make_index(ret._data, cols=self.index.names)
         if len(idx) == 0:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1785,7 +1785,7 @@ class IamDataFrame(object):
 
             elif col in ["month", "hour"]:
                 if self.time_col != "time":
-                    logger.warning(f"Filter by `{col}` not supported with yearly data.")
+                    logger.error(f"Filter by `{col}` not supported with yearly data.")
                     return np.zeros(len(self), dtype=bool)
 
                 def time_col(x, col):
@@ -1799,7 +1799,7 @@ class IamDataFrame(object):
 
             elif col == "day":
                 if self.time_col != "time":
-                    logger.warning(f"Filter by `{col}` not supported with yearly data.")
+                    logger.error(f"Filter by `{col}` not supported with yearly data.")
                     return np.zeros(len(self), dtype=bool)
 
                 if isinstance(values, str):
@@ -1818,7 +1818,7 @@ class IamDataFrame(object):
 
             elif col == "time":
                 if self.time_col != "time":
-                    logger.warning(f"Filter by `{col}` not supported with yearly data.")
+                    logger.error(f"Filter by `{col}` not supported with yearly data.")
                     return np.zeros(len(self), dtype=bool)
 
                 keep_col = datetime_match(self.get_data_column("time"), values)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -769,7 +769,7 @@ class IamDataFrame(object):
         if iamc_index:
             if self.time_col == "time":
                 raise ValueError(
-                    "Cannot use IAMC-index with continuous-time data format!"
+                    "Cannot use IAMC-index with 'datetime' time-domain!"
                 )
             s = s.droplevel(self.extra_cols)
 
@@ -1734,7 +1734,7 @@ class IamDataFrame(object):
             time_values = get_index_levels(ret._data, "time")
             if time_values and all([pd.api.types.is_integer(y) for y in time_values]):
                 ret.swap_time_for_year(inplace=True)
-                msg = "Only yearly data after filtering, time_domain changed to 'year'."
+                msg = "Only yearly data after filtering, time-domain changed to 'year'."
                 logger.info(msg)
 
         # downselect `meta` dataframe
@@ -1778,7 +1778,7 @@ class IamDataFrame(object):
                 levels, codes = get_index_levels_codes(self._data, self.time_col)
                 if self.time_col == "time":
                     levels = [
-                        l.year if isinstance(l, pd.Timestamp) else l for l in levels
+                        i.year if isinstance(i, pd.Timestamp) else i for i in levels
                     ]
                 matches = years_match(levels, values)
                 keep_col = get_keep_col(codes, matches)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -39,6 +39,7 @@ from pyam.utils import (
     years_match,
     day_match,
     datetime_match,
+    time_match,
     isstr,
     islistable,
     print_list,
@@ -47,7 +48,8 @@ from pyam.utils import (
     META_IDX,
     IAMC_IDX,
     SORT_IDX,
-    ILLEGAL_COLS, time_match, FILTER_DATETIME_ATTRS,
+    ILLEGAL_COLS,
+    FILTER_DATETIME_ATTRS,
 )
 from pyam.read_ixmp import read_ix
 from pyam.plotting import PlotAccessor
@@ -1783,7 +1785,7 @@ class IamDataFrame(object):
 
             elif col in ["month", "hour"]:
                 if self.time_col != "time":
-                    logger.warning(f"Filter by '{col}' not supported with yearly data.")
+                    logger.warning(f"Filter by `{col}` not supported with yearly data.")
                     return np.zeros(len(self), dtype=bool)
 
                 def time_col(x, col):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -773,9 +773,7 @@ class IamDataFrame(object):
                 )
             s = s.droplevel(self.extra_cols)
 
-        df = s.unstack(level=self.time_col).rename_axis(None, axis=1).sort_index(axis=1)
-
-        return df
+        return s.unstack(level=self.time_col).rename_axis(None, axis=1)
 
     def reset_exclude(self):
         """Reset exclusion assignment for all scenarios to `exclude: False`"""

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -17,12 +17,8 @@ def swap_time_for_year(df, inplace, subannual=False):
     order = [v if v != "time" else "year" for v in index.names]
 
     index = index.droplevel("time")
-    index = append_index_col(
-        index,
-        time.apply(lambda x: x.year if isinstance(x, pd.Timestamp) else x),
-        "year",
-        order=order,
-    )
+    new_index_col =  time.apply(lambda x: x.year if isinstance(x, pd.Timestamp) else x)
+    index = append_index_col(index, new_index_col, "year", order=order)
 
     if subannual:
         # if subannual is True, default to simple datetime format without year

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -17,7 +17,12 @@ def swap_time_for_year(df, inplace, subannual=False):
     order = [v if v != "time" else "year" for v in index.names]
 
     index = index.droplevel("time")
-    index = append_index_col(index, time.apply(lambda x: x.year), "year", order=order)
+    index = append_index_col(
+        index,
+        time.apply(lambda x: x.year if isinstance(x, pd.Timestamp) else x),
+        "year",
+        order=order,
+    )
 
     if subannual:
         # if subannual is True, default to simple datetime format without year

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -12,14 +12,16 @@ def swap_time_for_year(df, inplace, subannual=False):
     ret = df.copy() if not inplace else df
 
     index = ret._data.index
-
     time = pd.Series(index.get_level_values("time"))
     order = [v if v != "time" else "year" for v in index.names]
 
+    # reduce "time" index column to "year"
+    # TODO use `replace_index_values` instead of `append_index_col`
     index = index.droplevel("time")
-    new_index_col =  time.apply(lambda x: x.year if isinstance(x, pd.Timestamp) else x)
+    new_index_col =  time.apply(lambda x: x if isinstance(x, int) else x.year)
     index = append_index_col(index, new_index_col, "year", order=order)
 
+    # if selected, extract the "subannual" info from the "time" index column
     if subannual:
         # if subannual is True, default to simple datetime format without year
         if subannual is True:

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -18,7 +18,7 @@ def swap_time_for_year(df, inplace, subannual=False):
     # reduce "time" index column to "year"
     # TODO use `replace_index_values` instead of `append_index_col`
     index = index.droplevel("time")
-    new_index_col =  time.apply(lambda x: x if isinstance(x, int) else x.year)
+    new_index_col = time.apply(lambda x: x if isinstance(x, int) else x.year)
     index = append_index_col(index, new_index_col, "year", order=order)
 
     # if selected, extract the "subannual" info from the "time" index column

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -522,14 +522,12 @@ def _escape_regexp(s):
     )
 
 
-def years_match(data, years):
+def years_match(levels, years):
     """Return rows where data matches year"""
-    years = [years] if (isinstance(years, (int, np.int64))) else years
-    dt = (datetime.datetime, np.datetime64)
-    if isinstance(years, dt) or isinstance(years[0], dt):
-        error_msg = "Filter by `year` requires integers!"
-        raise TypeError(error_msg)
-    return np.isin(data, years)
+    years = to_list(years)
+    if not all([pd.api.types.is_integer(y) for y in years]):
+        raise TypeError("Filter by `year` requires integers!")
+    return np.isin(levels, years)
 
 
 def month_match(data, months):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -530,10 +530,9 @@ def years_match(levels, years):
     return np.isin(levels, years)
 
 
-def month_match(data, months):
-    """Return rows where data matches months"""
-    return time_match(data, months, ["%b", "%B"], "tm_mon", "months")
-
+FILTER_DATETIME_ATTRS = {
+    "month": (["%b", "%B"], "tm_mon", "months"),
+}
 
 def day_match(data, days):
     """Return rows where data matches days"""
@@ -563,7 +562,7 @@ def time_match(data, times, conv_codes, strptime_attr, name):
         try:
             return res
         except NameError:
-            raise ValueError("Could not convert {} to integer".format(name))
+            raise ValueError(f"Could not convert {name} to integer: {times}")
 
     times = [times] if isinstance(times, (int, str)) else times
     if isinstance(times[0], str):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -534,6 +534,7 @@ FILTER_DATETIME_ATTRS = {
     "month": (["%b", "%B"], "tm_mon", "months"),
 }
 
+
 def day_match(data, days):
     """Return rows where data matches days"""
     return time_match(data, days, ["%a", "%A"], "tm_wday", "days")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,8 @@ TEST_TIME_MIXED = [2005, datetime(2010, 7, 21)]
 
 DTS_MAPPING = {2005: TEST_DTS[0], 2010: TEST_DTS[1]}
 
+EXP_DATETIME_INDEX = pd.DatetimeIndex(["2005-06-17T00:00:00"])
+
 
 TEST_DF = pd.DataFrame(
     [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -435,6 +435,26 @@ def test_filter_year(test_df):
         assert unique_time[0] == expected
 
 
+# TODO: merge with previous test once TEST_TIME_MIXED is part of `conftest.py:test_df`
+def test_filter_year_mixed_time_domain(test_pd_df):
+    mapping = dict([(i, j) for i, j in zip(TEST_YEARS, TEST_TIME_MIXED)])
+    df = IamDataFrame(data=test_pd_df.rename(mapping, axis="columns"))
+
+    df.time_domain == "mixed"
+
+    # filtering to datetime-only works as expected
+    obs = df.filter(year=2010)
+    df.time_domain == "datetime"
+    pdt.assert_index_equal(obs.time, pd.DatetimeIndex(["2010-07-21"]))
+
+    # filtering to year-only works as expected including changing of time domain
+    obs = df.filter(year=2005)
+    assert obs.time_col == "year"
+    assert obs.time_domain == "year"
+    assert obs.year == [2005]
+    pdt.assert_index_equal(obs.time, pd.Int64Index([2005]))
+
+
 @pytest.mark.parametrize("test_month", [6, "June", "Jun", "jun", ["Jun", "jun"]])
 def test_filter_month(test_df, test_month):
     if "year" in test_df.data.columns:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -664,7 +664,7 @@ def test_timeseries_empty_raises(test_df_year):
 
 def test_timeseries_time_iamc_raises(test_df_time):
     """Calling `timeseries(iamc_index=True)` on a continuous-time IamDataFrame raises"""
-    match = "Cannot use IAMC-index with continuous-time data format!"
+    match = "Cannot use IAMC-index with 'datetime' time-domain!"
     with pytest.raises(ValueError, match=match):
         test_df_time.timeseries(iamc_index=True)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -440,11 +440,11 @@ def test_filter_year_mixed_time_domain(test_pd_df):
     mapping = dict([(i, j) for i, j in zip(TEST_YEARS, TEST_TIME_MIXED)])
     df = IamDataFrame(data=test_pd_df.rename(mapping, axis="columns"))
 
-    df.time_domain == "mixed"
+    assert df.time_domain == "mixed"
 
     # filtering to datetime-only works as expected
     obs = df.filter(year=2010)
-    df.time_domain == "datetime"
+    assert obs.time_domain == "datetime"
     pdt.assert_index_equal(obs.time, pd.DatetimeIndex(["2010-07-21"]))
 
     # filtering to year-only works as expected including changing of time domain

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,7 @@ from conftest import (
     TEST_TIME_STR,
     TEST_TIME_STR_HR,
     TEST_TIME_MIXED,
+    EXP_DATETIME_INDEX,
 )
 
 
@@ -425,14 +426,9 @@ def test_filter_error_keep(test_df):
 def test_filter_year(test_df):
     obs = test_df.filter(year=2005)
     if test_df.time_col == "year":
-        npt.assert_equal(obs["year"].unique(), 2005)
+        assert obs.year == [2005]
     else:
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-        unique_time = obs["time"].unique()
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 # TODO: merge with previous test once TEST_TIME_MIXED is part of `conftest.py:test_df`
@@ -462,12 +458,8 @@ def test_filter_month(test_df, test_month):
         assert test_df.filter(month=test_month).empty
     else:
         obs = test_df.filter(month=test_month)
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-        unique_time = obs["time"].unique()
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
+
 
 
 @pytest.mark.parametrize("test_month", [6, "Jun", "jun", ["Jun", "jun"]])
@@ -477,28 +469,17 @@ def test_filter_year_month(test_df, test_month):
         assert test_df.filter(year=2005, month=test_month).empty
     else:
         obs = test_df.filter(year=2005, month=test_month)
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-        unique_time = obs["time"].unique()
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 @pytest.mark.parametrize("test_day", [17, "Fri", "Friday", "friday", ["Fri", "fri"]])
 def test_filter_day(test_df, test_day):
     if test_df.time_col == "year":
-        error_msg = re.escape("Filter by `day` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(day=test_day)
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(day=test_day).empty
     else:
         obs = test_df.filter(day=test_day)
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-        unique_time = obs["time"].unique()
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 def test_filter_with_numpy_64_date_vals(test_df):
@@ -532,12 +513,7 @@ def test_filter_time_exact_match(test_df):
             test_df.filter(year=datetime.datetime(2005, 6, 17))
     else:
         obs = test_df.filter(time=datetime.datetime(2005, 6, 17))
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-        unique_time = np.array(obs["time"].unique(), dtype=np.datetime64)
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 def test_filter_time_range(test_df):
@@ -552,16 +528,9 @@ def test_filter_time_range_year(test_df):
     obs = test_df.filter(year=range(2000, 2008))
 
     if test_df.time_col == "year":
-        unique_time = obs["year"].unique()
-        expected = np.array([2005])
+        assert obs.year == [2005]
     else:
-        unique_time = obs["time"].unique()
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-
-    assert len(unique_time) == 1
-    assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 @pytest.mark.parametrize("month_range", [range(1, 7), "Mar-Jun"])
@@ -571,13 +540,7 @@ def test_filter_time_range_month(test_df, month_range):
         assert test_df.filter(hour=month_range).empty
     else:
         obs = test_df.filter(month=month_range)
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-
-        unique_time = obs["time"].unique()
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 @pytest.mark.parametrize("month_range", [["Mar-Jun", "Nov-Feb"]])
@@ -597,18 +560,11 @@ def test_filter_time_range_round_the_clock_error(test_df, month_range):
 @pytest.mark.parametrize("day_range", [range(14, 20), "Thu-Sat"])
 def test_filter_time_range_day(test_df, day_range):
     if test_df.time_col == "year":
-
-        error_msg = re.escape("Filter by `day` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            test_df.filter(day=day_range)
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(day=day_range).empty
     else:
         obs = test_df.filter(day=day_range)
-        expected = np.array(
-            pd.to_datetime("2005-06-17T00:00:00.0"), dtype=np.datetime64
-        )
-        unique_time = obs["time"].unique()
-        assert len(unique_time) == 1
-        assert unique_time[0] == expected
+        pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
 @pytest.mark.parametrize("hour_range", [range(10, 14)])
@@ -628,9 +584,8 @@ def test_filter_time_range_hour(test_df, hour_range):
 
 def test_filter_time_no_match(test_df):
     if test_df.time_col == "year":
-        error_msg = re.escape("Filter by `year` requires integers!")
-        with pytest.raises(TypeError, match=error_msg):
-            test_df.filter(year=datetime.datetime(2004, 6, 18))
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(time=datetime.datetime(2004, 6, 18)).empty
     else:
         obs = test_df.filter(time=datetime.datetime(2004, 6, 18))
         assert obs.data.empty
@@ -638,8 +593,8 @@ def test_filter_time_no_match(test_df):
 
 def test_filter_time_not_datetime_error(test_df):
     if test_df.time_col == "year":
-        with pytest.raises(ValueError, match=re.escape("`time`")):
-            test_df.filter(time=datetime.datetime(2004, 6, 18))
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(time=2005).empty
     else:
         error_msg = re.escape("`time` can only be filtered by datetimes")
         with pytest.raises(TypeError, match=error_msg):
@@ -650,8 +605,8 @@ def test_filter_time_not_datetime_error(test_df):
 
 def test_filter_time_not_datetime_range_error(test_df):
     if test_df.time_col == "year":
-        with pytest.raises(ValueError, match=re.escape("`time`")):
-            test_df.filter(time=range(2000, 2008))
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(time=range(2000, 2008)).empty
     else:
         error_msg = re.escape("`time` can only be filtered by datetimes")
         with pytest.raises(TypeError, match=error_msg):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -664,7 +664,7 @@ def test_timeseries_empty_raises(test_df_year):
 
 def test_timeseries_time_iamc_raises(test_df_time):
     """Calling `timeseries(iamc_index=True)` on a continuous-time IamDataFrame raises"""
-    match = "Cannot use IAMC-index with 'datetime' time-domain!"
+    match = "Cannot use `iamc_index=True` with 'datetime' time-domain!"
     with pytest.raises(ValueError, match=match):
         test_df_time.timeseries(iamc_index=True)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -424,7 +424,7 @@ def test_filter_error_keep(test_df):
 
 def test_filter_year(test_df):
     obs = test_df.filter(year=2005)
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         npt.assert_equal(obs["year"].unique(), 2005)
     else:
         expected = np.array(
@@ -457,10 +457,9 @@ def test_filter_year_mixed_time_domain(test_pd_df):
 
 @pytest.mark.parametrize("test_month", [6, "June", "Jun", "jun", ["Jun", "jun"]])
 def test_filter_month(test_df, test_month):
-    if "year" in test_df.data.columns:
-        error_msg = re.escape("Filter by `month` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(month=test_month)
+    if test_df.time_col == "year":
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(month=test_month).empty
     else:
         obs = test_df.filter(month=test_month)
         expected = np.array(
@@ -473,10 +472,9 @@ def test_filter_month(test_df, test_month):
 
 @pytest.mark.parametrize("test_month", [6, "Jun", "jun", ["Jun", "jun"]])
 def test_filter_year_month(test_df, test_month):
-    if "year" in test_df.data.columns:
-        error_msg = re.escape("Filter by `month` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(year=2005, month=test_month)
+    if test_df.time_col == "year":
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(year=2005, month=test_month).empty
     else:
         obs = test_df.filter(year=2005, month=test_month)
         expected = np.array(
@@ -489,7 +487,7 @@ def test_filter_year_month(test_df, test_month):
 
 @pytest.mark.parametrize("test_day", [17, "Fri", "Friday", "friday", ["Fri", "fri"]])
 def test_filter_day(test_df, test_day):
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         error_msg = re.escape("Filter by `day` not supported!")
         with pytest.raises(ValueError, match=error_msg):
             obs = test_df.filter(day=test_day)
@@ -514,10 +512,9 @@ def test_filter_with_numpy_64_date_vals(test_df):
 
 @pytest.mark.parametrize("test_hour", [0, 12, [12, 13]])
 def test_filter_hour(test_df, test_hour):
-    if "year" in test_df.data.columns:
-        error_msg = re.escape("Filter by `hour` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            test_df.filter(hour=test_hour)
+    if test_df.time_col == "year":
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(hour=test_hour).empty
     else:
         obs = test_df.filter(hour=test_hour)
         test_hour = [test_hour] if isinstance(test_hour, int) else test_hour
@@ -529,7 +526,7 @@ def test_filter_hour(test_df, test_hour):
 
 
 def test_filter_time_exact_match(test_df):
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         error_msg = re.escape("Filter by `year` requires integers!")
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(year=datetime.datetime(2005, 6, 17))
@@ -554,7 +551,7 @@ def test_filter_time_range(test_df):
 def test_filter_time_range_year(test_df):
     obs = test_df.filter(year=range(2000, 2008))
 
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         unique_time = obs["year"].unique()
         expected = np.array([2005])
     else:
@@ -569,10 +566,9 @@ def test_filter_time_range_year(test_df):
 
 @pytest.mark.parametrize("month_range", [range(1, 7), "Mar-Jun"])
 def test_filter_time_range_month(test_df, month_range):
-    if "year" in test_df.data.columns:
-        error_msg = re.escape("Filter by `month` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(month=month_range)
+    if test_df.time_col == "year":
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(hour=month_range).empty
     else:
         obs = test_df.filter(month=month_range)
         expected = np.array(
@@ -586,10 +582,9 @@ def test_filter_time_range_month(test_df, month_range):
 
 @pytest.mark.parametrize("month_range", [["Mar-Jun", "Nov-Feb"]])
 def test_filter_time_range_round_the_clock_error(test_df, month_range):
-    if "year" in test_df.data.columns:
-        error_msg = re.escape("Filter by `month` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            test_df.filter(month=month_range)
+    if test_df.time_col == "year":
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(month=month_range).empty
     else:
         error_msg = re.escape(
             "string ranges must lead to increasing integer ranges, "
@@ -601,7 +596,8 @@ def test_filter_time_range_round_the_clock_error(test_df, month_range):
 
 @pytest.mark.parametrize("day_range", [range(14, 20), "Thu-Sat"])
 def test_filter_time_range_day(test_df, day_range):
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
+
         error_msg = re.escape("Filter by `day` not supported!")
         with pytest.raises(ValueError, match=error_msg):
             test_df.filter(day=day_range)
@@ -617,10 +613,9 @@ def test_filter_time_range_day(test_df, day_range):
 
 @pytest.mark.parametrize("hour_range", [range(10, 14)])
 def test_filter_time_range_hour(test_df, hour_range):
-    if "year" in test_df.data.columns:
-        error_msg = re.escape("Filter by `hour` not supported!")
-        with pytest.raises(ValueError, match=error_msg):
-            test_df.filter(hour=hour_range)
+    if test_df.time_col == "year":
+        # Filtering data with yearly time domain returns empty
+        assert test_df.filter(hour=hour_range).empty
     else:
         obs = test_df.filter(hour=hour_range)
 
@@ -632,7 +627,7 @@ def test_filter_time_range_hour(test_df, hour_range):
 
 
 def test_filter_time_no_match(test_df):
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         error_msg = re.escape("Filter by `year` requires integers!")
         with pytest.raises(TypeError, match=error_msg):
             test_df.filter(year=datetime.datetime(2004, 6, 18))
@@ -642,7 +637,7 @@ def test_filter_time_no_match(test_df):
 
 
 def test_filter_time_not_datetime_error(test_df):
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         with pytest.raises(ValueError, match=re.escape("`time`")):
             test_df.filter(time=datetime.datetime(2004, 6, 18))
     else:
@@ -654,7 +649,7 @@ def test_filter_time_not_datetime_error(test_df):
 
 
 def test_filter_time_not_datetime_range_error(test_df):
-    if "year" in test_df.data.columns:
+    if test_df.time_col == "year":
         with pytest.raises(ValueError, match=re.escape("`time`")):
             test_df.filter(time=range(2000, 2008))
     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -461,7 +461,6 @@ def test_filter_month(test_df, test_month):
         pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
-
 @pytest.mark.parametrize("test_month", [6, "Jun", "jun", ["Jun", "jun"]])
 def test_filter_year_month(test_df, test_month):
     if test_df.time_col == "year":


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added

# Description of PR

**Note**: this PR is targeted to the `feature/year-and-datetime` branch that collects all developments related to #596.

This PR extends the `filter()` method to work with mixed time domain.
