### PR TITLE
Add filter by time_domain

### DIFF
--- a/pyam/filter.py
+++ b/pyam/filter.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+
+def filter_by_time_domain(values, levels, codes):
+    """Internal implementation to filter by time domain"""
+
+    if values == "year":
+        matches = [i for (i, label) in enumerate(levels) if isinstance(label, int)]
+    elif values == "datetime":
+        matches = [i for (i, label) in enumerate(levels) if not isinstance(label, int)]
+    else:
+        raise ValueError(f"Filter by `datetime='{values}'` not supported!")
+
+    return np.isin(codes, matches)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,16 @@ def test_df_time():
     yield df
 
 
+# minimal IamDataFrame for specifically testing 'mixed'-time-domain features
+@pytest.fixture(scope="function")
+def test_df_mixed():
+    mapping = dict([(i, j) for i, j in zip(TEST_YEARS, TEST_TIME_MIXED)])
+    df = IamDataFrame(data=TEST_DF.rename(mapping, axis="columns"))
+    for i in META_COLS:
+        df.set_meta(META_DF[i])
+    yield df
+
+
 # minimal test data as pandas.DataFrame (only 'year' time format)
 @pytest.fixture(scope="function")
 def test_pd_df():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -456,6 +456,13 @@ def test_filter_mixed_time_domain(test_df_mixed, arg_year, arg_time):
     pdt.assert_index_equal(obs.time, pd.Int64Index([2005]))
 
 
+def test_filter_time_domain_raises(test_df_year):
+    """Assert that error is raised for invalid time_domain filter value"""
+
+    with pytest.raises(ValueError, match="Filter by `datetime='mixed'` not supported!"):
+        test_df_year.filter(time_domain="mixed")
+
+
 @pytest.mark.parametrize("test_month", [6, "June", "Jun", "jun", ["Jun", "jun"]])
 def test_filter_month(test_df, test_month):
     if test_df.time_col == "year":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -431,20 +431,25 @@ def test_filter_year(test_df):
         pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
-# TODO: merge with previous test once TEST_TIME_MIXED is part of `conftest.py:test_df`
-def test_filter_year_mixed_time_domain(test_pd_df):
-    mapping = dict([(i, j) for i, j in zip(TEST_YEARS, TEST_TIME_MIXED)])
-    df = IamDataFrame(data=test_pd_df.rename(mapping, axis="columns"))
+@pytest.mark.parametrize(
+    "arg_year, arg_time",
+    [
+        (dict(year=2005), dict(year=2010)),
+        (dict(time_domain="year"), dict(time_domain="datetime")),
+    ],
+)
+def test_filter_mixed_time_domain(test_df_mixed, arg_year, arg_time):
+    """Assert that reassigning attributes works for filtering from mixed time domain"""
 
-    assert df.time_domain == "mixed"
+    assert test_df_mixed.time_domain == "mixed"
 
     # filtering to datetime-only works as expected
-    obs = df.filter(year=2010)
+    obs = test_df_mixed.filter(**arg_time)
     assert obs.time_domain == "datetime"
     pdt.assert_index_equal(obs.time, pd.DatetimeIndex(["2010-07-21"]))
 
     # filtering to year-only works as expected including changing of time domain
-    obs = df.filter(year=2005)
+    obs = test_df_mixed.filter(**arg_year)
     assert obs.time_col == "year"
     assert obs.time_domain == "year"
     assert obs.year == [2005]


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added

# Description of PR

**Note**: this PR is targeted to the `feature/year-and-datetime` branch that collects all developments related to #596.

This PR extends the `filter()` method with an option to filter by the `time_domain`.