### PR TITLE
Add a to_xarray converter

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -45,6 +45,7 @@ from pyam.utils import (
     isstr,
     islistable,
     print_list,
+    to_xarray,
     s,
     DEFAULT_META_INDEX,
     META_IDX,
@@ -2259,6 +2260,8 @@ class IamDataFrame(object):
 
         # return the package (needs to reloaded because `tmp` was deleted)
         return Package(path)
+
+    to_xarray = to_xarray
 
     def load_meta(
         self, path, sheet_name="meta", ignore_conflict=False, *args, **kwargs

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ optional_io_formats =
     datapackage
     pandas-datareader
     unfccc_di_api >= 2.0
+    xarray
 tutorials =
     pypandoc
     nbformat


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Name of contributors Added to AUTHORS.rst
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Add a simple utility method to convert a pyam dataframe into a xarray DataArray with a
configurable set of stacked dimensions (so as not to add too many nan's).

This is a draft to get feedback on the judged utility of having something like this.

Possible points for improvement:

- [ ] Units could use pint-xarray
- [ ] Meta data handling would be nice.
- [ ] IamDataFrame.from_xarray classmethod or IamDataFrame.__init__ code path for DataArray

