### PR TITLE
Implement `append` with inconsistent time domain

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -541,16 +541,19 @@ class IamDataFrame(object):
             other = IamDataFrame(other, **kwargs)
             ignore_meta_conflict = True
 
-        if self.time_col != other.time_col:
-            raise ValueError("Incompatible time format (`year` vs. `time`)")
-
-        if self.dimensions != other.dimensions:
+        if self.extra_cols != other.extra_cols:
             raise ValueError("Incompatible timeseries data index dimensions")
 
         if other.empty:
             return None if inplace else self.copy()
 
         ret = self.copy() if not inplace else self
+
+        if ret.time_col != other.time_col:
+            if ret.time_col == "year":
+                ret.swap_year_for_time(inplace=True)
+            else:
+                other = other.swap_year_for_time(inplace=False)
 
         # merge `meta` tables
         ret.meta = merge_meta(ret.meta, other.meta, ignore_meta_conflict)

--- a/pyam/time.py
+++ b/pyam/time.py
@@ -53,23 +53,25 @@ def swap_year_for_time(df, inplace):
 
     if not df.time_col == "year":
         raise ValueError("Time domain must be 'year' to use this method")
-    if "subannual" not in df.extra_cols:
-        raise ValueError("Data must have a dimension 'subannual' to use this method")
 
     ret = df.copy() if not inplace else df
     index = ret._data.index
-    order = [v if v != "year" else "time" for v in index.names].remove("subannual")
 
-    time_cols = ["year", "subannual"]
-    time_values = zip(*[index.get_level_values(c) for c in time_cols])
-    time = list(map(dateutil.parser.parse, [f"{y}-{s}" for y, s in time_values]))
+    order = [v if v != "year" else "time" for v in index.names]
 
-    index = index.droplevel(["year", "subannual"])
+    if "subannual" in df.extra_cols:
+        order = order.remove("subannual")
+        time_values = zip(*[index.get_level_values(c) for c in ["year", "subannual"]])
+        time = list(map(dateutil.parser.parse, [f"{y}-{s}" for y, s in time_values]))
+        index = index.droplevel(["year", "subannual"])
+        ret.extra_cols.remove("subannual")
+    else:
+        time = index.get_level_values("year")
+        index = index.droplevel(["year"])
+
+    # add new index column, assign data and other attributes
     index = append_index_col(index, time, "time", order=order)
-
-    # assign data and other attributes
     ret._data.index = index
-    ret.extra_cols.remove("subannual")
     ret.time_col = "time"
     ret._set_attributes()
     delattr(ret, "year")

--- a/tests/test_feature_append.py
+++ b/tests/test_feature_append.py
@@ -2,8 +2,9 @@ import pytest
 import numpy as np
 import pandas as pd
 from numpy import testing as npt
+from datetime import datetime
 
-from pyam import IamDataFrame
+from pyam import IamDataFrame, IAMC_IDX, assert_iamframe_equal
 
 from .conftest import META_COLS
 
@@ -40,6 +41,39 @@ def test_append_other_scenario(test_df):
     # assert that appending data works as expected
     ts = df.timeseries()
     npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
+
+
+@pytest.mark.parametrize("other", ("time", "time"))
+@pytest.mark.parametrize("time", (datetime(2010, 7, 21), "2010-07-21 00:00:00"))
+@pytest.mark.parametrize("inplace", (True, False))
+def test_append_time_domain(test_pd_df, test_df_mixed, other, time, inplace):
+
+    df_year = IamDataFrame(test_pd_df[IAMC_IDX + [2005]], meta=test_df_mixed.meta)
+    df_time = IamDataFrame(
+        test_pd_df[IAMC_IDX + [2010]].rename({2010: time}, axis="columns")
+    )
+
+    # append df_time to df_year
+    if other == "time":
+        if inplace:
+            obs = df_year.copy()
+            obs.append(df_time, inplace=True)
+        else:
+            obs = df_year.append(df_time)
+            # assert that original object was not modified
+            assert df_year.year == [2005]
+
+    # append df_year to df_time
+    else:
+        if inplace:
+            obs = df_time.copy()
+            obs.append(df_year, inplace=True)
+        else:
+            obs = df_time.append(df_year)
+            # assert that original object was not modified
+            assert df_time.time == pd.Index(datetime(2010, 7, 21))
+
+    assert_iamframe_equal(obs, test_df_mixed)
 
 
 def test_append_reconstructed_time(test_df):

--- a/tests/test_feature_append.py
+++ b/tests/test_feature_append.py
@@ -43,7 +43,7 @@ def test_append_other_scenario(test_df):
     npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
 
 
-@pytest.mark.parametrize("other", ("time", "time"))
+@pytest.mark.parametrize("other", ("time", "year"))
 @pytest.mark.parametrize("time", (datetime(2010, 7, 21), "2010-07-21 00:00:00"))
 @pytest.mark.parametrize("inplace", (True, False))
 def test_append_time_domain(test_pd_df, test_df_mixed, other, time, inplace):
@@ -53,7 +53,7 @@ def test_append_time_domain(test_pd_df, test_df_mixed, other, time, inplace):
         test_pd_df[IAMC_IDX + [2010]].rename({2010: time}, axis="columns")
     )
 
-    # append df_time to df_year
+    # append `df_time` to `df_year`
     if other == "time":
         if inplace:
             obs = df_year.copy()
@@ -63,7 +63,7 @@ def test_append_time_domain(test_pd_df, test_df_mixed, other, time, inplace):
             # assert that original object was not modified
             assert df_year.year == [2005]
 
-    # append df_year to df_time
+    # append `df_year` to `df_time`
     else:
         if inplace:
             obs = df_time.copy()
@@ -71,7 +71,7 @@ def test_append_time_domain(test_pd_df, test_df_mixed, other, time, inplace):
         else:
             obs = df_time.append(df_year)
             # assert that original object was not modified
-            assert df_time.time == pd.Index(datetime(2010, 7, 21))
+            assert df_time.time == pd.Index([datetime(2010, 7, 21)])
 
     assert_iamframe_equal(obs, test_df_mixed)
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added

# Description of PR

**Note**: this PR is targeted to the `feature/year-and-datetime` branch that collects all developments related to #596.

This PR extends the `append()` method in case two IamDataFrame instances have inconsistent time domains.