### PR TITLE
Time/concat

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -135,8 +135,9 @@ class IamDataFrame(object):
         """Initialize an instance of an IamDataFrame"""
         if isinstance(data, IamDataFrame):
             if kwargs:
-                msg = "Invalid arguments {} for initializing from IamDataFrame"
-                raise ValueError(msg.format(list(kwargs)))
+                raise ValueError(
+                    f"Invalid arguments for initializing from IamDataFrame: {kwargs}"
+                )
             if index != data.index.names:
                 msg = f"Incompatible `index={index}` with {type(data)} "
                 raise ValueError(msg + f"(index={data.index.names})")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2724,7 +2724,7 @@ def concat(dfs, ignore_meta_conflict=False, **kwargs):
         A list of objects castable to :class:`IamDataFrame`
     ignore_meta_conflict : bool, default False
         If False, raise an error if any meta columns present in `dfs` are not identical.
-        If True, values in earlier elements of `dfs` take precendence.
+        If True, values in earlier elements of `dfs` take precedence.
     kwargs
         Passed to :class:`IamDataFrame(other, **kwargs) <IamDataFrame>`
         for any item of `dfs` which isn't already an IamDataFrame.
@@ -2742,7 +2742,7 @@ def concat(dfs, ignore_meta_conflict=False, **kwargs):
     """
     if not islistable(dfs) or isinstance(dfs, pd.DataFrame):
         raise TypeError(
-            f"First argument must be an iterable, "
+            "First argument must be an iterable, "
             f"you passed an object of type '{dfs.__class__.__name__}'!"
         )
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2716,14 +2716,14 @@ def compare(
     return _compare(left, right, left_label, right_label, drop_close=True, **kwargs)
 
 
-def concat(dfs, ignore_meta_conflict=False, **kwargs):
+def concat(objs, ignore_meta_conflict=False, **kwargs):
     """Concatenate a series of IamDataFrame-like objects
 
     Parameters
     ----------
-    dfs : iterable of IamDataFrames
+    objs : iterable of IamDataFrames
         A list of objects castable to :class:`IamDataFrame`
-    ignore_meta_conflict : bool, default False
+    ignore_meta_conflict : bool, optional
         If False, raise an error if any meta columns present in `dfs` are not identical.
         If True, values in earlier elements of `dfs` take precedence.
     kwargs
@@ -2740,40 +2740,60 @@ def concat(dfs, ignore_meta_conflict=False, **kwargs):
         If `dfs` is not a list.
     ValueError
         If time domain or other timeseries data index dimension don't match.
+
+    Notes
+    -----
+    The *meta* attributes are merged only for those objects of *dfs* that are passed
+    as :class:`IamDataFrame` instances.
+
     """
-    if not islistable(dfs) or isinstance(dfs, pd.DataFrame):
-        raise TypeError(
-            "First argument must be an iterable, "
-            f"you passed an object of type '{dfs.__class__.__name__}'!"
-        )
+    if not islistable(objs) or isinstance(objs, pd.DataFrame):
+        raise TypeError(f"'{objs.__class__.__name__}' object is not iterable")
 
-    dfs = list(dfs)
-
-    if len(dfs) < 1:
+    if len(objs) < 1:
         raise ValueError("No objects to concatenate")
 
-    # cast to IamDataFrame if necessary
     def as_iamdataframe(df):
-        return df if isinstance(df, IamDataFrame) else IamDataFrame(df, **kwargs)
+        if isinstance(df, IamDataFrame):
+            return df, True
+        else:
+            return IamDataFrame(df, **kwargs), False
 
-    df = as_iamdataframe(dfs[0])
-    ret_data, ret_meta = [df._data], df.meta
-    index, time_col = df.dimensions, df.time_col
+    # cast first item to IamDataFrame (if necessary)
+    df, _merge_meta = as_iamdataframe(objs[0])
+    extra_cols, time_col = df.extra_cols, df.time_col
 
-    for df in dfs[1:]:
-        # skip merging meta if element is a pd.DataFrame
-        _meta_merge = not isinstance(df, pd.DataFrame)
-        df = as_iamdataframe(df)
+    consistent_time_domain = True
+    iam_dfs = [(df, _merge_meta)]
 
+    # cast all items to IamDataFrame (if necessary) and check consistency of items
+    for df in objs[1:]:
+        df, _merge_meta = as_iamdataframe(df)
+        if df.extra_cols != extra_cols:
+            raise ValueError("Items have incompatible timeseries data dimensions")
         if df.time_col != time_col:
-            raise ValueError("Items have incompatible time format ('year' vs. 'time')!")
+            consistent_time_domain = False
+        iam_dfs.append((df, _merge_meta))
 
-        if df.dimensions != index:
-            raise ValueError("Items have incompatible timeseries data dimensions!")
+    # cast all instances to "time"
+    if not consistent_time_domain:
+        _iam_dfs = []
+        for (df, _merge_meta) in iam_dfs:
+            if df.time_col == "year":
+                df = df.swap_year_for_time()
+            _iam_dfs.append((df, _merge_meta))
+        iam_dfs = _iam_dfs  # replace list of IamDataFrames with consistent list
 
+    # extract timeseries data and meta attributes
+    ret_data, ret_meta = [], None
+    for (df, _merge_meta) in iam_dfs:
         ret_data.append(df._data)
-        if _meta_merge:
-            ret_meta = merge_meta(ret_meta, df.meta, ignore_meta_conflict)
+        if _merge_meta:
+            ret_meta = (
+                df.meta
+                if ret_meta is None
+                else merge_meta(ret_meta, df.meta, ignore_meta_conflict)
+            )
 
     # return as new IamDataFrame, this will verify integrity as part of `__init__()`
     return IamDataFrame(pd.concat(ret_data, verify_integrity=False), meta=ret_meta)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -67,7 +67,7 @@ def test_init_from_iamdf(test_df_year):
 
 def test_init_from_iamdf_raises(test_df_year):
     # casting an IamDataFrame instance again with extra args fails
-    match = "Invalid arguments \['model'\] for initializing from IamDataFrame"
+    match = "Invalid arguments for initializing from IamDataFrame: {'model': 'foo'}"
     with pytest.raises(ValueError, match=match):
         IamDataFrame(test_df_year, model="foo")
 

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -109,6 +109,24 @@ def test_append(test_df):
     npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
 
 
+@pytest.mark.parametrize("time", (datetime(2010, 7, 21), "2010-07-21 00:00:00"))
+def test_concat_time_domain(test_pd_df, test_df_mixed, time):
+
+    df_year = IamDataFrame(test_pd_df[IAMC_IDX + [2005]], meta=test_df_mixed.meta)
+    df_time = IamDataFrame(
+        test_pd_df[IAMC_IDX + [2010]].rename({2010: time}, axis="columns")
+    )
+
+    # concat `df_time` to `df_year`
+    obs = concat([df_year, df_time])
+
+    # assert that original objects were not modified
+    assert df_year.year == [2005]
+    assert df_time.time == pd.Index([datetime(2010, 7, 21)])
+
+    assert_iamframe_equal(obs, test_df_mixed)
+
+
 @pytest.mark.parametrize("other", ("time", "year"))
 @pytest.mark.parametrize("time", (datetime(2010, 7, 21), "2010-07-21 00:00:00"))
 @pytest.mark.parametrize("inplace", (True, False))
@@ -140,13 +158,6 @@ def test_append_time_domain(test_pd_df, test_df_mixed, other, time, inplace):
             assert df_time.time == pd.Index([datetime(2010, 7, 21)])
 
     assert_iamframe_equal(obs, test_df_mixed)
-
-
-def test_concat_incompatible_time(test_df_year, test_df_time):
-    """Check that calling concat with incompatible time formats raises"""
-    match = re.escape("Items have incompatible time format ('year' vs. 'time')!")
-    with pytest.raises(ValueError, match=match):
-        concat([test_df_year, test_df_time])
 
 
 def test_append_reconstructed_time(test_df):

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 from numpy import testing as npt
 import pandas as pd
-import re
 from datetime import datetime
 
 from pyam import IamDataFrame, IAMC_IDX, META_IDX, assert_iamframe_equal, concat
@@ -27,12 +26,20 @@ def test_concat_single_item(test_df):
     assert_iamframe_equal(obs, test_df)
 
 
+@pytest.mark.parametrize("arg", (None, []))
+def test_concat_fails_iterable(arg):
+    """Check that calling concat with empty or none raises"""
+    match = "No objects to concatenate"
+    with pytest.raises(TypeError, match=match):
+        concat(arg)
+
+
 @pytest.mark.parametrize(
     "arg, msg", ((1, "int"), ("foo", "str"), (TEST_DF, "DataFrame"))
 )
 def test_concat_fails_iterable(arg, msg):
     """Check that calling concat with a non-iterable raises"""
-    match = f"First argument must be an iterable, you passed an object of type '{msg}'!"
+    match = f"'{msg}' object is not iterable"
     with pytest.raises(TypeError, match=match):
         concat(arg)
 
@@ -43,7 +50,7 @@ def test_concat_incompatible_cols(test_pd_df):
     test_pd_df["extra_col"] = "foo"
     df2 = IamDataFrame(test_pd_df)
 
-    match = "Items have incompatible timeseries data dimensions!"
+    match = "Items have incompatible timeseries data dimensions"
     with pytest.raises(ValueError, match=match):
         concat([df1, df2])
 

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from pyam import IamDataFrame, IAMC_IDX, META_IDX, assert_iamframe_equal, concat
 
-from .conftest import META_COLS
+from .conftest import TEST_DF, META_COLS
 
 
 # assert that merging of meta works as expected
@@ -27,13 +27,14 @@ def test_concat_single_item(test_df):
     assert_iamframe_equal(obs, test_df)
 
 
-def test_concat_fails_iterable(test_pd_df):
+@pytest.mark.parametrize(
+    "arg, msg", ((1, "int"), ("foo", "str"), (TEST_DF, "DataFrame"))
+)
+def test_concat_fails_iterable(arg, msg):
     """Check that calling concat with a non-iterable raises"""
-    msg = "First argument must be an iterable, you passed an object of type '{}'!"
-
-    for dfs, type_ in [(1, "int"), ("foo", "str"), (test_pd_df, "DataFrame")]:
-        with pytest.raises(TypeError, match=msg.format(type_)):
-            concat(dfs)
+    match = f"First argument must be an iterable, you passed an object of type '{msg}'!"
+    with pytest.raises(TypeError, match=match):
+        concat(arg)
 
 
 def test_concat_incompatible_cols(test_pd_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added

# Description of PR

**Note**: this PR is targeted to the `feature/year-and-datetime` branch that collects all developments related to #596.

This PR extends the `concat()` function in case several IamDataFrame instances have inconsistent time domains.