### PR TITLE
Do not require `py` as a dependency

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -10,7 +10,14 @@ import pandas as pd
 from pandas.api.types import is_integer
 
 from pathlib import Path
-from py._path.local import LocalPath
+try:
+    from py._path.local import LocalPath
+
+    FILE_TYPE = (str, Path, LocalPath)
+except ImportError:
+    FILE_TYPE = (str, Path)
+
+
 from tempfile import TemporaryDirectory
 
 from pyam.filter import filter_by_time_domain, filter_by_year, filter_by_dt_arg
@@ -169,7 +176,7 @@ class IamDataFrame(object):
             _data = read_ix(data, **kwargs)
 
         # read from file
-        elif isinstance(data, (str, LocalPath, Path)):
+        elif isinstance(data, FILE_TYPE):
             data = Path(data)  # casting str or LocalPath to Path
             if not data.is_file():
                 raise FileNotFoundError(f"No such file: '{data}'")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -12,10 +12,12 @@ from pandas.api.types import is_integer
 from pathlib import Path
 
 try:
+    # used by pytest tmpdir
     from py._path.local import LocalPath
 
     FILE_TYPE = (str, Path, LocalPath)
 except ImportError:
+    LocalPath = None
     FILE_TYPE = (str, Path)
 
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pandas.api.types import is_integer
 
 from pathlib import Path
+
 try:
     from py._path.local import LocalPath
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,6 @@ install_requires =
     setuptools_scm
     # required explicitly for Python 3.7
     importlib_metadata
-    # required explicitly for type-checking
-    py
 setup_requires =
     setuptools >= 41
     setuptools_scm


### PR DESCRIPTION
# Description of PR

Remove `py` as a dependency (introduced in #634), only use if installed.
