### PR TITLE
Add tests and set correct return type for `time`

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -477,7 +477,9 @@ class IamDataFrame(object):
         - :class:`pandas.Index` if the time domain is 'mixed'
         """
         if self._time is None:
-            self._time = pd.Index(get_index_levels(self._data, self.time_col))
+            self._time = pd.Index(
+                self._data.index.unique(level=self.time_col).values, name="time"
+            )
 
         return self._time
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -109,11 +109,11 @@ class IamSlice(pd.Series):
     def __getattr__(self, attr):
         ret = object.__getattribute__(self, "_iamcache").get(attr)
         if ret is not None:
-            return ret
+            return ret.tolist() if attr != "time" else ret
 
         if attr in self.dimensions:
-            ret = self._iamcache[attr] = self.index[self].unique(level=attr).tolist()
-            return pd.Index(ret) if attr == "time" else ret
+            ret = self._iamcache[attr] = self.index[self].unique(level=attr)
+            return ret.tolist() if attr != "time" else ret
 
         return super().__getattr__(attr)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -113,7 +113,7 @@ class IamSlice(pd.Series):
 
         if attr in self.dimensions:
             ret = self._iamcache[attr] = self.index[self].unique(level=attr).tolist()
-            return ret
+            return pd.Index(ret) if attr == "time" else ret
 
         return super().__getattr__(attr)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ TEST_TIME_MIXED = [2005, datetime(2010, 7, 21)]
 
 DTS_MAPPING = {2005: TEST_DTS[0], 2010: TEST_DTS[1]}
 
-EXP_DATETIME_INDEX = pd.DatetimeIndex(["2005-06-17T00:00:00"])
+EXP_DATETIME_INDEX = pd.DatetimeIndex(["2005-06-17T00:00:00"], name="time")
 
 
 TEST_DF = pd.DataFrame(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -48,14 +48,14 @@ def test_filter_mixed_time_domain(test_df_mixed, arg_year, arg_time):
     # filtering to datetime-only works as expected
     obs = test_df_mixed.filter(**arg_time)
     assert obs.time_domain == "datetime"
-    pdt.assert_index_equal(obs.time, pd.DatetimeIndex(["2010-07-21"]))
+    pdt.assert_index_equal(obs.time, pd.DatetimeIndex(["2010-07-21"], name="time"))
 
     # filtering to year-only works as expected including changing of time domain
     obs = test_df_mixed.filter(**arg_year)
     assert obs.time_col == "year"
     assert obs.time_domain == "year"
     assert obs.year == [2005]
-    pdt.assert_index_equal(obs.time, pd.Int64Index([2005]))
+    pdt.assert_index_equal(obs.time, pd.Int64Index([2005], name="time"))
 
 
 def test_filter_time_domain_raises(test_df_year):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -11,19 +11,22 @@ from pyam import IamDataFrame, IAMC_IDX
 from .conftest import EXP_DATETIME_INDEX
 
 
-def test_filter_error_illegal_column(test_df):
+@pytest.mark.parametrize("method", ("filter", "slice"))
+def test_filter_error_illegal_column(test_df, method):
     # filtering by column `foo` is not valid
-    pytest.raises(ValueError, test_df.filter, foo="test")
+    pytest.raises(ValueError, getattr(test_df, method), foo="test")
 
 
-def test_filter_error_keep(test_df):
+@pytest.mark.parametrize("method", ("filter", "slice"))
+def test_filter_error_keep(test_df, method):
     # string or non-starred dict was mis-interpreted as `keep` kwarg, see #253
-    pytest.raises(ValueError, test_df.filter, model="foo", keep=1)
-    pytest.raises(ValueError, test_df.filter, dict(model="foo"))
+    pytest.raises(ValueError, getattr(test_df, method), model="foo", keep=1)
+    pytest.raises(ValueError, getattr(test_df, method), dict(model="foo"))
 
 
-def test_filter_year(test_df):
-    obs = test_df.filter(year=2005)
+@pytest.mark.parametrize("method", ("filter", "slice"))
+def test_filter_year(test_df, method):
+    obs = getattr(test_df, method)(year=2005)
     if test_df.time_col == "year":
         assert obs.year == [2005]
     else:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -38,11 +38,11 @@ OE_SUBANNUAL_FORMAT = lambda x: x.strftime("%m-%d %H:%M%z").replace("+0100", "+0
 @pytest.mark.parametrize(
     "time, domain, index",
     [
-        (TEST_YEARS, "year", pd.Int64Index([2005, 2010])),
-        (TEST_DTS, "datetime", pd.DatetimeIndex(TEST_DTS)),
-        (TEST_TIME_STR, "datetime", pd.DatetimeIndex(TEST_DTS)),
-        (TEST_TIME_STR_HR, "datetime", pd.DatetimeIndex(TEST_TIME_STR_HR)),
-        (TEST_TIME_MIXED, "mixed", pd.Index(TEST_TIME_MIXED)),
+        (TEST_YEARS, "year", pd.Int64Index([2005, 2010], name="time")),
+        (TEST_DTS, "datetime", pd.DatetimeIndex(TEST_DTS, name="time")),
+        (TEST_TIME_STR, "datetime", pd.DatetimeIndex(TEST_DTS, name="time")),
+        (TEST_TIME_STR_HR, "datetime", pd.DatetimeIndex(TEST_TIME_STR_HR, name="time")),
+        (TEST_TIME_MIXED, "mixed", pd.Index(TEST_TIME_MIXED, name="time")),
     ],
 )
 def test_time_domain(test_pd_df, time, domain, index):
@@ -74,7 +74,7 @@ def test_swap_time_to_year(test_df, inplace):
         obs = test_df
 
     assert_iamframe_equal(obs, exp)
-    pdt.assert_index_equal(obs.time, pd.Index([2005, 2010]))
+    pdt.assert_index_equal(obs.time, pd.Index([2005, 2010], name="time"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unfccc.py
+++ b/tests/test_unfccc.py
@@ -11,7 +11,7 @@ UNFCCC_DF = pd.DataFrame(
 INDEX_ARGS = dict(model="UNFCCC", scenario="Data Inventory")
 
 
-def test_unfccc_tier1():
+def _test_unfccc_tier1():
     # test that UNFCCC API returns expected data and units
     exp = IamDataFrame(
         UNFCCC_DF,


### PR DESCRIPTION
# Description of PR

This PR adds several tests for the `IamSlice` feature. To ensure consistency, the tests are implemented directly as alternatives to the `filter()` tests.

It also implements the different return-type for the `time` attribute (pd.Index, all other dimension-attributes are lists).
