### PR TITLE
Add a proper length attribute

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -117,6 +117,9 @@ class IamSlice(pd.Series):
 
         return super().__getattr__(attr)
 
+    def __len__(self):
+        return sum(self.values)
+
     @property
     def dimensions(self):
         return self.index.names

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -118,7 +118,7 @@ class IamSlice(pd.Series):
         return super().__getattr__(attr)
 
     def __len__(self):
-        return sum(self.values)
+        return self.sum()
 
     @property
     def dimensions(self):

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -1,0 +1,4 @@
+def test_slice_len(test_df_year):
+    """Check the length of a slice"""
+
+    assert len(test_df_year.slice(scenario="scen_a")) == 4


### PR DESCRIPTION
# Description of PR

This PR fixes the `__len__` attribute, which should only count the timeseries data points actually included in the slice.
