### PR TITLE
Deactivate `unfccc-di-api` unit test

### DIFF
--- a/tests/test_unfccc.py
+++ b/tests/test_unfccc.py
@@ -11,7 +11,8 @@ UNFCCC_DF = pd.DataFrame(
 INDEX_ARGS = dict(model="UNFCCC", scenario="Data Inventory")
 
 
-def test_unfccc_tier1():
+def _test_unfccc_tier1():
+
     # test that UNFCCC API returns expected data and units
     exp = IamDataFrame(
         UNFCCC_DF,

--- a/tests/test_unfccc.py
+++ b/tests/test_unfccc.py
@@ -36,8 +36,6 @@ def _test_unfccc_tier1():
         "Land Use, Land-Use Change and Forestry",
         "Waste",
     ]
-    print([f"Emissions|CH4|{i}" for i in types])
-    print(obs.variable)
     assert obs.variable == [f"Emissions|CH4|{i}" for i in types]
 
     # assert that the unit is merged as expected

--- a/tests/test_unfccc.py
+++ b/tests/test_unfccc.py
@@ -12,6 +12,7 @@ INDEX_ARGS = dict(model="UNFCCC", scenario="Data Inventory")
 
 
 def _test_unfccc_tier1():
+    # deactivated in response to https://github.com/pik-primap/unfccc_di_api/issues/37
 
     # test that UNFCCC API returns expected data and units
     exp = IamDataFrame(


### PR DESCRIPTION
# Description of PR

This is a quickfix to circumvent an issue in the dependency **unfccc-di-api**, see https://github.com/pik-primap/unfccc_di_api/issues/37.
