### PR TITLE
Remove `cloud_sptheme` dependency

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -328,7 +328,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable", None),
     "ixmp": ("https://docs.messageix.org/projects/ixmp/en/stable/", None),
-    "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
     "plotly": ("https://plotly.com/python-api-reference/", None),
     "pandas_datareader": ("https://pandas-datareader.readthedocs.io/en/stable", None),
     "unfccc_di_api": ("https://unfccc-di-api.readthedocs.io/en/stable", None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,6 @@ extensions = [
     "sphinxcontrib.programoutput",
     "nbsphinx",
     "sphinx_gallery.gen_gallery",
-    "cloud_sptheme.ext.table_styling",
     "autodocsumm",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ docs =
     sphinx
     nbsphinx
     sphinx-gallery
-    cloud_sptheme
     pillow
     sphinxcontrib-bibtex < 2.0
     sphinxcontrib-programoutput


### PR DESCRIPTION
# Description of PR

Alterted by the failing nightly GitHub Action ([link](https://github.com/IAMconsortium/pyam/actions/runs/2056519098), indicating that the docs cannot be built), this PR remove the **cloud_sptheme** dependency.
