### PR TITLE
Pin pint as a quickfix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ an empty **IamDataFrame**. Previously, this raised an error.
 
 ## Individual updates
 
+- [#651](https://github.com/IAMconsortium/pyam/pull/651) Pin `pint<=0.18` as a quickfix for a regression in the latest release
 - [#647](https://github.com/IAMconsortium/pyam/pull/647) Pin `unfccc-di-api` to latest release
 - [#634](https://github.com/IAMconsortium/pyam/pull/634) Better error message when initializing with invisible columns 
 - [#598](https://github.com/IAMconsortium/pyam/pull/598) Support mixed 'year' and 'datetime' domain

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,8 @@ install_requires =
     requests
     openpyxl
     pandas >= 1.1.1
-    pint >= 0.13
+    # pinning pint as a quickfix for https://github.com/IAMconsortium/units/pull/37
+    pint >= 0.13, < 0.19
     PyYAML
     matplotlib >= 3.2.0
     seaborn


### PR DESCRIPTION
# Description of PR

Pin **pint** as a quickfix in response to an unintended regression, which causes the **iam-units** package to fail the tests, see https://github.com/IAMconsortium/units/pull/37
