### PR TITLE
add offset method to compute offsets relative to base-year values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next release
 
+- [#659](https://github.com/IAMconsortium/pyam/pull/659) Add an `offset` method
 - [#657](https://github.com/IAMconsortium/pyam/pull/657) Add an `IamSlice` class
 
 # Release v1.4.0

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1269,6 +1269,46 @@ class IamDataFrame(object):
         if not inplace:
             return ret
 
+    def offset(self, padding=0, inplace=False, **kwargs):
+        """Compute new data which is offset from a specific data point
+
+        For example, offsetting from `year=2005` will provide data
+        *relative* to `year=2005` such that the value in 2005 is 0 and 
+        all other values `value[year] - value[2005]`.
+
+        Conceptually this operation performs as:
+        ```
+        df - df.filter(**kwargs) + padding
+        ```
+
+        Note: Currently only supports normalizing to a specific time.
+
+        Parameters
+        ----------
+        padding : float, optional
+            an additional offset padding
+        inplace : bool, optional
+            if :obj:`True`, do operation inplace and return None
+        kwargs
+            the column and value on which to offset (e.g., `year=2005`)
+        """
+        if len(kwargs) > 1 or self.time_col not in kwargs:
+            raise ValueError("Only time(year)-based normalization supported")
+        ret = self.copy() if not inplace else self
+        df = ret.data
+        # change all below if supporting more in the future
+        cols = self.time_col
+        value = kwargs[self.time_col]
+        x = df.set_index(IAMC_IDX)
+        x["value"] -= x[x[cols] == value]["value"]
+        x["value"] += padding
+
+        x = x.reset_index()
+        ret._data = x.set_index(self.dimensions).value
+
+        if not inplace:
+            return ret
+
     def aggregate(
         self,
         variable,

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1273,7 +1273,7 @@ class IamDataFrame(object):
         """Compute new data which is offset from a specific data point
 
         For example, offsetting from `year=2005` will provide data
-        *relative* to `year=2005` such that the value in 2005 is 0 and 
+        *relative* to `year=2005` such that the value in 2005 is 0 and
         all other values `value[year] - value[2005]`.
 
         Conceptually this operation performs as:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1295,16 +1295,10 @@ class IamDataFrame(object):
         if len(kwargs) > 1 or self.time_col not in kwargs:
             raise ValueError("Only time(year)-based normalization supported")
         ret = self.copy() if not inplace else self
-        df = ret.data
-        # change all below if supporting more in the future
-        cols = self.time_col
+        data = ret._data
         value = kwargs[self.time_col]
-        x = df.set_index(IAMC_IDX)
-        x["value"] -= x[x[cols] == value]["value"]
-        x["value"] += padding
-
-        x = x.reset_index()
-        ret._data = x.set_index(self.dimensions).value
+        base_value = data.loc[data.index.isin([value], level=self.time_col)].droplevel(self.time_col)
+        ret._data = data - base_value + padding
 
         if not inplace:
             return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1269,7 +1269,7 @@ class IamDataFrame(object):
         if not inplace:
             return ret
 
-    def offset(self, padding=0, inplace=False, **kwargs):
+    def offset(self, padding=0, fill_value=None, inplace=False, **kwargs):
         """Compute new data which is offset from a specific data point
 
         For example, offsetting from `year=2005` will provide data
@@ -1287,6 +1287,9 @@ class IamDataFrame(object):
         ----------
         padding : float, optional
             an additional offset padding
+        fill_value : float or None, optional
+            Applied on subtraction. Fills exisiting missing (NaN) values.
+            See https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.subtract.html
         inplace : bool, optional
             if :obj:`True`, do operation inplace and return None
         kwargs
@@ -1297,8 +1300,10 @@ class IamDataFrame(object):
         ret = self.copy() if not inplace else self
         data = ret._data
         value = kwargs[self.time_col]
-        base_value = data.loc[data.index.isin([value], level=self.time_col)].droplevel(self.time_col)
-        ret._data = data - base_value + padding
+        base_value = data.loc[data.index.isin([value], level=self.time_col)].droplevel(
+            self.time_col
+        )
+        ret._data = data.subtract(base_value, fill_value=fill_value) + padding
 
         if not inplace:
             return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1288,8 +1288,8 @@ class IamDataFrame(object):
         padding : float, optional
             an additional offset padding
         fill_value : float or None, optional
-            Applied on subtraction. Fills exisiting missing (NaN) values.
-            See https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.subtract.html
+            Applied on subtraction. Fills exisiting missing (NaN) values. See
+            https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.subtract.html
         inplace : bool, optional
             if :obj:`True`, do operation inplace and return None
         kwargs

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -789,3 +789,22 @@ def test_normalize(test_df):
 def test_normalize_not_time(test_df):
     pytest.raises(ValueError, test_df.normalize, variable="foo")
     pytest.raises(ValueError, test_df.normalize, year=2015, variable="foo")
+
+@pytest.mark.parametrize("padding", [0, 2])
+def test_offset(test_df, padding):
+    exp = test_df.data.copy().reset_index(drop=True)
+    exp.loc[1::2, "value"] -= exp["value"][::2].values - padding
+    exp.loc[::2, "value"] -= exp["value"][::2].values - padding
+    # only call with kwarg if padding != 0 (the default)
+    kwargs = {'padding': padding} if padding else {} 
+    if "year" in test_df.data:
+        obs = test_df.offset(year=2005, **kwargs).data.reset_index(drop=True)
+    else:
+        obs = test_df.offset(time=datetime.datetime(2005, 6, 17), **kwargs).data.reset_index(
+            drop=True
+        )
+    pd.testing.assert_frame_equal(obs, exp)
+
+def test_offset_not_time(test_df):
+    pytest.raises(ValueError, test_df.offset, variable="foo")
+    pytest.raises(ValueError, test_df.offset, year=2015, variable="foo")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -790,20 +790,22 @@ def test_normalize_not_time(test_df):
     pytest.raises(ValueError, test_df.normalize, variable="foo")
     pytest.raises(ValueError, test_df.normalize, year=2015, variable="foo")
 
+
 @pytest.mark.parametrize("padding", [0, 2])
 def test_offset(test_df, padding):
     exp = test_df.data.copy().reset_index(drop=True)
     exp.loc[1::2, "value"] -= exp["value"][::2].values - padding
     exp.loc[::2, "value"] -= exp["value"][::2].values - padding
     # only call with kwarg if padding != 0 (the default)
-    kwargs = {'padding': padding} if padding else {} 
+    kwargs = {"padding": padding} if padding else {}
     if "year" in test_df.data:
         obs = test_df.offset(year=2005, **kwargs).data.reset_index(drop=True)
     else:
-        obs = test_df.offset(time=datetime.datetime(2005, 6, 17), **kwargs).data.reset_index(
-            drop=True
-        )
+        obs = test_df.offset(
+            time=datetime.datetime(2005, 6, 17), **kwargs
+        ).data.reset_index(drop=True)
     pd.testing.assert_frame_equal(obs, exp)
+
 
 def test_offset_not_time(test_df):
     pytest.raises(ValueError, test_df.offset, variable="foo")


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR introduces an `offset()` method which allows a user to compute offsets relative to base-time-periods in the same style as `normalize()`.

        For example, offsetting from `year=2005` will provide data
        *relative* to `year=2005` such that the value in 2005 is 0 and 
        all other values `value[year] - value[2005]`.

        Conceptually this operation performs as:
        ```
        df - df.filter(**kwargs) + padding
        ```