### PR TITLE
Fix/concat

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2793,6 +2793,8 @@ def concat(objs, ignore_meta_conflict=False, **kwargs):
     The *meta* attributes are merged only for those objects of *objs* that are passed
     as :class:`IamDataFrame` instances.
 
+    The index dimension of the return value is carried over from index of the *meta*
+    indicators.
     """
     if not islistable(objs) or isinstance(objs, pd.DataFrame):
         raise TypeError(f"'{objs.__class__.__name__}' object is not iterable")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2793,8 +2793,8 @@ def concat(objs, ignore_meta_conflict=False, **kwargs):
     The *meta* attributes are merged only for those objects of *objs* that are passed
     as :class:`IamDataFrame` instances.
 
-    The index dimension of the return value is carried over from index of the *meta*
-    indicators.
+    The :attr:`dimensions` and :attr:`index` names of all elements of *dfs* must be
+    identical. The returned IamDataFrame inherits the dimensions and index names.
     """
     if not islistable(objs) or isinstance(objs, pd.DataFrame):
         raise TypeError(f"'{objs.__class__.__name__}' object is not iterable")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2844,7 +2844,11 @@ def concat(objs, ignore_meta_conflict=False, **kwargs):
             )
 
     # return as new IamDataFrame, this will verify integrity as part of `__init__()`
-    return IamDataFrame(pd.concat(ret_data, verify_integrity=False), meta=ret_meta)
+    return IamDataFrame(
+        pd.concat(ret_data, verify_integrity=False),
+        meta=ret_meta,
+        index=ret_meta.index.names,
+    )
 
 
 def read_datapackage(path, data="data", meta="meta"):

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -104,7 +104,7 @@ def test_concat(test_df, reverse, iterable):
     npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
 
 
-def test_concat_non_standard_index():
+def test_concat_non_default_index():
     # Test that merging two IamDataFrames with identical, non-standard index dimensions
     # preserves the index.
 

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -104,6 +104,38 @@ def test_concat(test_df, reverse, iterable):
     npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
 
 
+def test_concat_non_standard_index():
+    # Test that merging two IamDataFrames with identical, non-standard index dimensions
+    # preserves the index.
+
+    df1 = IamDataFrame(
+        pd.DataFrame(
+            [["model_a", "scenario_a", "region_a", "variable_a", "unit", 1, 1]],
+            columns=IAMC_IDX + ["version", 2005],
+        ),
+        index=META_IDX + ["version"],
+    )
+    df2 = IamDataFrame(
+        pd.DataFrame(
+            [["model_a", "scenario_a", "region_a", "variable_a", "unit", 2, 2]],
+            columns=IAMC_IDX + ["version", 2005],
+        ),
+        index=META_IDX + ["version"],
+    )
+    exp = IamDataFrame(
+        pd.DataFrame(
+            [
+                ["model_a", "scenario_a", "region_a", "variable_a", "unit", 1, 1],
+                ["model_a", "scenario_a", "region_a", "variable_a", "unit", 2, 2],
+            ],
+            columns=IAMC_IDX + ["version", 2005],
+        ),
+        index=META_IDX + ["version"],
+    )
+
+    assert_iamframe_equal(exp, concat([df1, df2]))
+
+
 @pytest.mark.parametrize("reverse", (False, True))
 def test_concat_with_pd_dataframe(test_df, reverse):
     other = test_df.filter(scenario="scen_b").rename({"scenario": {"scen_b": "scen_c"}})


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- [x] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

closes #664. 

The `pyam.concat` function now carries over the index of the merged meta table.
Added a unit test to check under `test_feature_append_and_concat.test_concat_non_standard_index`.
For documentation I added an additional line to the `notes` section of the `pyam.concat` function.

One open question from my side would be if there is more documentation than the added docstring required. My hunch would be that it's fine as is since the behavior is not really new but rather more working in line with user expectations. 