### PR TITLE
Enable renaming of an empty IamDataFrame

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,10 +25,10 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
   
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,10 +27,10 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
   
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pytest-dependency.yml
+++ b/.github/workflows/pytest-dependency.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.7'
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,10 +30,10 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
   
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1107,6 +1107,10 @@ class IamDataFrame(object):
             raise ValueError(f"Conflicting rename args for columns {duplicate}")
         mapping.update(kwargs)
 
+        # return without any changes if self is empty
+        if self.empty:
+            return self if inplace else self.copy()
+
         # determine columns that are not in the meta index
         meta_idx = self.meta.index.names
         data_cols = set(self.dimensions) - set(meta_idx)

--- a/tests/test_feature_rename.py
+++ b/tests/test_feature_rename.py
@@ -6,6 +6,7 @@ import pandas as pd
 from numpy import testing as npt
 
 from pyam import IamDataFrame, META_IDX, IAMC_IDX, compare
+from pyam.testing import assert_iamframe_equal
 
 from .conftest import META_COLS
 
@@ -189,6 +190,12 @@ def test_rename_data_cols_by_mixed():
 def test_rename_conflict(test_df):
     mapping = {"scenario": {"scen_a": "scen_b"}}
     pytest.raises(ValueError, test_df.rename, mapping, **mapping)
+
+
+def test_rename_empty(test_df_year):
+    """Check that renaming an empty IamDataFrame does not raise an error"""
+    empty_df = test_df_year.filter(model="foo")
+    assert_iamframe_equal(empty_df, empty_df.rename(model={"model_a": "model_b"}))
 
 
 def test_rename_index_data_fail(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- ~Description in RELEASE_NOTES.md Added~

# Description of PR

This PR fixes an unexpected error when using `rename()` on an empty IamDataFrame.

Related to https://github.com/IAMconsortium/nomenclature/pull/123

closes #631 
