### PR TITLE
Remove version pin on pint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,7 @@ install_requires =
     requests
     openpyxl
     pandas >= 1.1.1
-    # pinning pint as a quickfix for https://github.com/IAMconsortium/units/pull/37
-    pint >= 0.13, < 0.19
+    pint >= 0.13
     PyYAML
     matplotlib >= 3.2.0
     seaborn


### PR DESCRIPTION
The original cause for constraining with < 0.19 as explained in
https://github.com/IAMconsortium/units/pull/37 has been addressed by
pint version 0.19.2.