### PR TITLE
Simplifications with the IIASA API module

### DIFF
--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -42,7 +42,7 @@ def set_config(user, password, file=None):
 
     with open(file, mode="w") as f:
         logger.info(f"Setting IIASA-connection configuration file: {file}")
-        yaml.dump(dict(username=user, password=password), f)
+        yaml.dump(dict(username=user, password=password), f, sort_keys=False)
 
 
 def _get_config(file=None):

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -83,18 +83,12 @@ def _get_token(creds, base_url):
         _check_response(r, "Could not get anonymous token")
         return r.json(), None
 
-    # parse creds, write warning
-    if isinstance(creds, Mapping):
-        user, pw = creds["username"], creds["password"]
-    else:
-        user, pw = creds
-
     # get user token
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
-    data = {"username": user, "password": pw}
     url = "/".join([base_url, "login"])
-    r = requests.post(url, headers=headers, data=json.dumps(data))
-    _check_response(r, "Login failed for user: {}".format(user))
+    r = requests.post(url, headers=headers, data=json.dumps(creds))
+    user = creds["username"]
+    _check_response(r, f"Login failed for user {user}")
     return r.json(), user
 
 

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -8,14 +8,12 @@ from functools import lru_cache
 import numpy as np
 import pandas as pd
 
-from collections.abc import Mapping
 from pyam.core import IamDataFrame
 from pyam.utils import (
     META_IDX,
     IAMC_IDX,
     isstr,
     pattern_match,
-    DEFAULT_META_INDEX,
     islistable,
 )
 
@@ -268,7 +266,7 @@ class Connection(object):
             extra_meta = pd.DataFrame.from_records(df.metadata)
             meta = pd.concat([meta, extra_meta], axis=1)
 
-        return meta.set_index(DEFAULT_META_INDEX + ([] if default else ["version"]))
+        return meta.set_index(META_IDX + ([] if default else ["version"]))
 
     def properties(self, default=True):
         """Return the audit properties of scenarios
@@ -457,7 +455,7 @@ class Connection(object):
                 # 'run_id' is required to determine `_args`, dropped later
                 _meta = _meta[set(meta).union(["version", "run_id"])]
         else:
-            _meta = self._query_index(default=default).set_index(DEFAULT_META_INDEX)
+            _meta = self._query_index(default=default).set_index(META_IDX)
 
         # retrieve data
         _args = json.dumps(self._query_post(_meta, default=default, **kwargs))
@@ -490,13 +488,11 @@ class Connection(object):
 
         # define the index for the IamDataFrame
         if default:
-            index = DEFAULT_META_INDEX
+            index = META_IDX
             data.drop(columns="version", inplace=True)
         else:
-            index = DEFAULT_META_INDEX + ["version"]
-            logger.info(
-                "Initializing an `IamDataFrame` " f"with non-default index {index}"
-            )
+            index = META_IDX + ["version"]
+            logger.info(f"Initializing `IamDataFrame` with non-default index {index}")
 
         # merge meta indicators (if requested) and cast to IamDataFrame
         if meta:

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -58,7 +58,7 @@ def _check_response(r, msg="Error connecting to IIASA database", error=RuntimeEr
         raise error(f"{msg}: {r.text}")
 
 
-def _get_token(creds, base_url):
+def _get_token(creds, auth_url):
     """Parse credentials and get token from IIASA authentication service"""
 
     # try reading default config or parse file
@@ -78,14 +78,14 @@ def _get_token(creds, base_url):
 
     # if (still) no creds, get anonymous auth and return
     if creds is None:
-        url = "/".join([base_url, "anonym"])
+        url = "/".join([auth_url, "anonym"])
         r = requests.get(url)
         _check_response(r, "Could not get anonymous token")
         return r.json(), None
 
     # get user token
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
-    url = "/".join([base_url, "login"])
+    url = "/".join([auth_url, "login"])
     r = requests.post(url, headers=headers, data=json.dumps(creds))
     user = creds["username"]
     _check_response(r, f"Login failed for user {user}")
@@ -106,7 +106,7 @@ class Connection(object):
         were set using :meth:`pyam.iiasa.set_config`.
         Alternatively, you can provide a path to a yaml file
         with entries of 'username' and 'password'.
-    base_url : str, optional
+    auth_url : str, optional
         custom authentication server URL
 
     Notes
@@ -117,7 +117,7 @@ class Connection(object):
 
     def __init__(self, name=None, creds=None, auth_url=_AUTH_URL):
         self._auth_url = auth_url
-        self._token, self._user = _get_token(creds, base_url=self._auth_url)
+        self._token, self._user = _get_token(creds, auth_url=self._auth_url)
 
         # connect if provided a name
         self._connected = None


### PR DESCRIPTION
# Description of PR

While working on the IIASA-API implementation, I noticed a few clean-up steps that make the code slightly more concise.

- Reusable headers as a property
- Clear separation between the url of the services-manager versus the database-API

There are no functional changes in this PR.
