### PR TITLE
Use new IIASA-manager API with token refresh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#684](https://github.com/IAMconsortium/pyam/pull/684) Use new IIASA-manager API with token refresh 
 - [#679](https://github.com/IAMconsortium/pyam/pull/679) `set_meta()` now supports pandas.DataFrame as an argument
 - [#674](https://github.com/IAMconsortium/pyam/pull/674) Support filtering data by model-scenario pairs with the `index` argument to `filter()` and `slice()`
 

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # set requests-logger to WARNING only
 logging.getLogger("requests").setLevel(logging.WARNING)
 
-_AUTH_URL = "https://api.manager.ece.iiasa.ac.at/legacy"
+_AUTH_URL = "https://api.manager.ece.iiasa.ac.at"
 _CITE_MSG = """
 You are connected to the {} scenario explorer hosted by IIASA.
  If you use this data in any published format, please cite the
@@ -138,7 +138,7 @@ class Connection(object):
     @property
     @lru_cache()
     def _connection_map(self):
-        url = "/".join([self._auth_url, "applications"])
+        url = "/".join([self._auth_url, "legacy", "applications"])
         r = requests.get(url, headers=self._headers)
         _check_response(r, "Could not get valid connection list")
         aliases = set()
@@ -185,7 +185,7 @@ class Connection(object):
                 "Use `Connection.valid_connections` for a list of accessible services."
             )
 
-        url = "/".join([self._auth_url, "applications", name, "config"])
+        url = "/".join([self._auth_url, "legacy", "applications", name, "config"])
         r = requests.get(url, headers=self._headers)
         _check_response(r, "Could not get application information")
         response = r.json()

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -64,7 +64,7 @@ def _check_response(r, msg="Error connecting to IIASA database", error=RuntimeEr
 
 
 class SceSeAuth(AuthBase):
-    def __init__(self, creds: str=None, auth_url: str=_AUTH_URL):
+    def __init__(self, creds: str = None, auth_url: str = _AUTH_URL):
         """Connection to the Scenario Services Manager AAC service.
 
         Parameters

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -91,6 +91,7 @@ class SceSeAuth(AuthBase):
             )
 
         # if no creds, get anonymous token
+        # TODO: explicit token for anonymous login will not be necessary for ixmp-server
         if self.creds is None:
             r = self.client.get("/legacy/anonym/")
             if r.status_code >= 400:
@@ -182,6 +183,7 @@ class Connection(object):
     @property
     @lru_cache()
     def _connection_map(self):
+        # TODO: application-list will be reimplemented in conjunction with ixmp-server
         url = "/".join([self._auth_url, "legacy", "applications"])
         r = requests.get(url, headers=self.auth())
         _check_response(r, "Could not get valid connection list")
@@ -224,6 +226,7 @@ class Connection(object):
                 "Use `Connection.valid_connections` for a list of accessible services."
             )
 
+        # TODO: config will be reimplemented in conjunction with ixmp-server
         url = "/".join([self._auth_url, "legacy", "applications", name, "config"])
         r = requests.get(url, headers=self.auth())
         _check_response(r, "Could not get application information")

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -52,12 +52,10 @@ def set_config(user, password, file=None):
         yaml.dump(dict(username=user, password=password), f, sort_keys=False)
 
 
-def _get_config(file=None):
+def _read_config(file):
     """Read username and password for IIASA API connection from file"""
-    file = Path(file) if file is not None else DEFAULT_IIASA_CREDS
-    if file.exists():
-        with open(file, "r") as stream:
-            return yaml.safe_load(stream)
+    with open(file, "r") as stream:
+        return yaml.safe_load(stream)
 
 
 def _check_response(r, msg="Error connecting to IIASA database", error=RuntimeError):
@@ -80,11 +78,12 @@ class SceSeAuth(AuthBase):
         self.access_token, self.refresh_token = None, None
 
         if creds is None:
-            self.creds = _get_config(DEFAULT_IIASA_CREDS)
+            if DEFAULT_IIASA_CREDS.exists():
+                self.creds = _read_config(DEFAULT_IIASA_CREDS)
+            else:
+                self.creds = None
         elif isinstance(creds, Path) or isstr(creds):
-            self.creds = _get_config(creds)
-            if self.creds is None:
-                logger.error(f"Could not read credentials from `{creds}`")
+            self.creds = _read_config(creds)
         else:
             raise DeprecationWarning(
                 "Passing credentials as clear-text is not allowed. "

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -86,11 +86,10 @@ class SceSeAuth(AuthBase):
             if self.creds is None:
                 logger.error(f"Could not read credentials from `{creds}`")
         else:
-            msg = (
+            raise DeprecationWarning(
                 "Passing credentials as clear-text is not allowed. "
                 "Please use `pyam.iiasa.set_config(<user>, <password>)` instead!"
             )
-            raise DeprecationWarning(msg)
 
         # if no creds, get anonymous token
         if self.creds is None:
@@ -118,7 +117,9 @@ class SceSeAuth(AuthBase):
     def obtain_jwt(self):
         r = self.client.post("/v1/token/obtain/", json=self.creds)
         if r.status_code == 401:
-            raise ValueError("The provided credentials are not valid.")
+            raise ValueError(
+                "Credentials not valid to connect to https://manager.ece.iiasa.ac.at."
+            )
         elif r.status_code >= 400:
             raise ValueError("Unknown API error: " + r.text)
 
@@ -218,11 +219,6 @@ class Connection(object):
             name = self._connection_map[name]
 
         valid = self._connection_map.values()
-        if len(valid) == 0:
-            raise RuntimeError(
-                "No valid connections found for the provided credentials."
-            )
-
         if name not in valid:
             raise ValueError(
                 f"You do not have access to instance '{name}' or it does not exist. "

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -185,8 +185,9 @@ class Connection(object):
     def _connection_map(self):
         # TODO: application-list will be reimplemented in conjunction with ixmp-server
         url = "/".join([self._auth_url, "legacy", "applications"])
-        r = requests.get(url, headers=self.auth())
-        _check_response(r, "Could not get valid connection list")
+        r = self.auth.client.get("legacy/applications", headers=self.auth())
+        if r.status_code >= 400:
+            raise ValueError("Unknown API error: " + r.text)
         aliases = set()
         conn_map = {}
         for x in r.json():
@@ -227,9 +228,12 @@ class Connection(object):
             )
 
         # TODO: config will be reimplemented in conjunction with ixmp-server
-        url = "/".join([self._auth_url, "legacy", "applications", name, "config"])
-        r = requests.get(url, headers=self.auth())
-        _check_response(r, "Could not get application information")
+        r = self.auth.client.get(
+            f"legacy/applications/{name}/config", headers=self.auth()
+        )
+        if r.status_code >= 400:
+            raise ValueError("Unknown API error: " + r.text)
+
         response = r.json()
         idxs = {x["path"]: i for i, x in enumerate(response)}
 

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -184,10 +184,10 @@ class Connection(object):
     @lru_cache()
     def _connection_map(self):
         # TODO: application-list will be reimplemented in conjunction with ixmp-server
-        url = "/".join([self._auth_url, "legacy", "applications"])
         r = self.auth.client.get("legacy/applications", headers=self.auth())
         if r.status_code >= 400:
             raise ValueError("Unknown API error: " + r.text)
+
         aliases = set()
         conn_map = {}
         for x in r.json():

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ install_requires =
     iam-units >= 2020.4.21
     numpy >= 1.19.0
     requests
+    pyjwt
+    httpx
     openpyxl
     pandas >= 1.1.1
     pint >= 0.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     numpy >= 1.19.0
     requests
     pyjwt
-    httpx[h2]
+    httpx[http2]
     openpyxl
     pandas >= 1.1.1
     pint >= 0.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     numpy >= 1.19.0
     requests
     pyjwt
-    httpx
+    httpx[h2]
     openpyxl
     pandas >= 1.1.1
     pint >= 0.13


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR refactors the IIASA-manager-API authentication to the new (short-lived) token, including automated refresh. The PR also stricter behavior when reading a config file fails, and adds explicit test if arguments are missing from the credentials.

We decided to leave the current legacy-implementation for the anonymous login and application-list, because these features will change with the new ixmp package.