### PR TITLE
Remove unused meta levels during initialization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#695](https://github.com/IAMconsortium/pyam/pull/695) Remove unused meta levels during initialization
 - [#688](https://github.com/IAMconsortium/pyam/pull/688) Remove ixmp as optional dependency
 - [#684](https://github.com/IAMconsortium/pyam/pull/684) Use new IIASA-manager API with token refresh 
 - [#679](https://github.com/IAMconsortium/pyam/pull/679) `set_meta()` now supports pandas.DataFrame as an argument

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -810,7 +810,7 @@ class IamDataFrame(object):
             meta = meta.loc[self.meta.index.intersection(meta.index)]
             meta.index = meta.index.remove_unused_levels()
             self.meta = merge_meta(meta, self.meta, ignore_conflict=True)
-            return  # EXIT FUNCTION
+            return
 
         # check that name is valid and doesn't conflict with data columns
         if (name or (hasattr(meta, "name") and meta.name)) in [None, False]:
@@ -832,7 +832,7 @@ class IamDataFrame(object):
         # if no valid index is provided, add meta as new column `name` and exit
         if index is None:
             self.meta[name] = list(meta) if islistable(meta) else meta
-            return  # EXIT FUNCTION
+            return
 
         # use meta.index if index arg is an IamDataFrame
         if isinstance(index, IamDataFrame):
@@ -919,7 +919,7 @@ class IamDataFrame(object):
 
         if len(idx) == 0:
             logger.info("No scenarios satisfy the criteria")
-            return  # EXIT FUNCTION
+            return
 
         # update meta dataframe
         self._new_meta_column(name)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -806,9 +806,11 @@ class IamDataFrame(object):
                 meta = meta.rename(
                     columns={i.capitalize(): i for i in META_IDX}
                 ).set_index(self.meta.index.names)
+
             meta = meta.loc[self.meta.index.intersection(meta.index)]
+            meta.index = meta.index.remove_unused_levels()
             self.meta = merge_meta(meta, self.meta, ignore_conflict=True)
-            return
+            return  # EXIT FUNCTION
 
         # check that name is valid and doesn't conflict with data columns
         if (name or (hasattr(meta, "name") and meta.name)) in [None, False]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -133,10 +133,11 @@ def test_init_df_with_extra_col(test_pd_df):
 
 def test_init_df_with_meta(test_pd_df):
     # pass explicit meta dataframe with a scenario that doesn't exist in data
-    df = IamDataFrame(test_pd_df, meta=META_DF.iloc[[0, 2]][["foo"]])
+    df = IamDataFrame(test_pd_df, meta=META_DF[["foo"]])
 
     # check that scenario not existing in data is removed during initialization
     pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
+    assert df.scenario == ["scen_a", "scen_b"]
 
 
 def test_init_df_with_meta_incompatible_index(test_pd_df):

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -224,10 +224,12 @@ def test_query_year(conn, test_df_year, kwargs):
 
     # test method via Connection
     df = conn.query(model="model_a", **kwargs)
+    assert df.model == ["model_a"]
     assert_iamframe_equal(df, exp.filter(**kwargs))
 
     # test top-level method
     df = read_iiasa(TEST_API, model="model_a", **kwargs)
+    assert df.model == ["model_a"]
     assert_iamframe_equal(df, exp.filter(**kwargs))
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR fixes a bug where the IamDataFrame attributes (model, scenario, ...) where not correctly downselected when initializing an IamDataFrame with a *meta* dataframe that had additional model-scenario combinations.

closes #694