### PR TITLE
Add warning if IIASA API returns empty

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#697](https://github.com/IAMconsortium/pyam/pull/697) Add warning if IIASA API returns empty result
 - [#695](https://github.com/IAMconsortium/pyam/pull/695) Remove unused meta levels during initialization
 - [#688](https://github.com/IAMconsortium/pyam/pull/688) Remove ixmp as optional dependency
 - [#684](https://github.com/IAMconsortium/pyam/pull/684) Use new IIASA-manager API with token refresh 

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -220,7 +220,7 @@ def test_meta(conn, kwargs, default):
 @pytest.mark.parametrize("default", [True, False])
 def test_properties(conn, kwargs, default):
     # test that connection returns the correct properties dataframe
-    obs = conn.properties(default=default, **kwargs)
+    obs = conn.properties(default, **kwargs)
 
     if default:
         exp_cols = ["version"]

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -167,39 +167,71 @@ def test_meta_columns(conn):
     npt.assert_array_equal(conn.meta_columns, META_COLS)
 
 
+@pytest.mark.parametrize("kwargs", [{}, dict(model="model_a")])
 @pytest.mark.parametrize("default", [True, False])
-def test_index(conn, default):
+def test_index(conn, kwargs, default):
     # test that connection returns the correct index
+    obs = conn.index(default=default, **kwargs)
+
     if default:
         exp = META_DF.loc[META_DF.is_default, ["version"]]
+        if kwargs:
+            exp = exp.iloc[0:2]
     else:
         exp = META_DF[VERSION_COLS]
+        if kwargs:
+            exp = exp.iloc[0:3]
 
-    pdt.assert_frame_equal(conn.index(default=default), exp, check_dtype=False)
+    pdt.assert_frame_equal(obs, exp, check_dtype=False)
 
 
+def test_index_empty(conn):
+    # test that an empty filter does not yield an error
+    # solves https://github.com/IAMconsortium/pyam/issues/676
+    conn.index(model="foo").empty
+
+
+def test_index_illegal_column(conn):
+    # test that filtering by an illegal column raises an error
+    with pytest.raises(ValueError, match="Invalid filter: 'foo'"):
+        conn.index(foo="bar")
+
+
+@pytest.mark.parametrize("kwargs", [{}, dict(model="model_a")])
 @pytest.mark.parametrize("default", [True, False])
-def test_meta(conn, default):
+def test_meta(conn, kwargs, default):
     # test that connection returns the correct meta dataframe
+    obs = conn.meta(default=default, **kwargs)
+
     v = "version"
     if default:
         exp = META_DF.loc[META_DF.is_default, [v] + META_COLS]
+        if kwargs:
+            exp = exp.iloc[0:2]
     else:
         exp = META_DF[VERSION_COLS + META_COLS].set_index(v, append=True)
+        if kwargs:
+            exp = exp.iloc[0:3]
 
-    pdt.assert_frame_equal(conn.meta(default=default), exp, check_dtype=False)
+    pdt.assert_frame_equal(obs, exp, check_dtype=False)
 
 
+@pytest.mark.parametrize("kwargs", [{}, dict(model="model_a")])
 @pytest.mark.parametrize("default", [True, False])
-def test_properties(conn, default):
+def test_properties(conn, kwargs, default):
     # test that connection returns the correct properties dataframe
-    obs = conn.properties(default=default)
+    obs = conn.properties(default=default, **kwargs)
+
     if default:
         exp_cols = ["version"]
         exp = META_DF.loc[META_DF.is_default, exp_cols]
+        if kwargs:
+            exp = exp.iloc[0:2]
     else:
         exp_cols = VERSION_COLS
         exp = META_DF[exp_cols]
+        if kwargs:
+            exp = exp.iloc[0:3]
 
     # assert that the expected audit columns are included
     for col in ["create_user", "create_date", "update_user", "update_date"]:


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR fixes an unexpected error when querying data via the IIASA API from a database that is empty. It also adds the option to filter `index()`, `meta()` and `properties()`.

closes #676
