### PR TITLE
Add scipy explicitly as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     httpx[http2]
     openpyxl
     pandas >= 1.1.1
+    scipy
     pint >= 0.13
     PyYAML
     matplotlib >= 3.2.0


### PR DESCRIPTION
# Description of PR

This is in response to a failing nightly test, where (it seems) **scipy** (which is required for the interpolation feature) was removed as a dependency by anyother package.
