### PR TITLE
Filter IIASA-API index by list

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#699](https://github.com/IAMconsortium/pyam/pull/699) Add filter options to IIASA API `index()`, `meta()` and `properties()` methods
 - [#697](https://github.com/IAMconsortium/pyam/pull/697) Add warning if IIASA API returns empty result
 - [#695](https://github.com/IAMconsortium/pyam/pull/695) Remove unused meta levels during initialization
 - [#688](https://github.com/IAMconsortium/pyam/pull/688) Remove ixmp as optional dependency

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import json
 import logging
 import requests
-from fnmatch import fnmatch
 
 import httpx
 import jwt
@@ -281,7 +280,7 @@ class Connection(object):
             for key, values in kwargs.items():
                 if key not in META_IDX + ["version"]:
                     raise ValueError(f"Invalid filter: '{key}'")
-                keep_col = pd.Series([fnmatch(v, values) for v in runs[key].values])
+                keep_col = pattern_match(pd.Series(runs[key].values), values)
                 keep = np.logical_and(keep, keep_col)
             return runs[keep]
         else:

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -25,6 +25,9 @@ CONN_ENV_REASON = "Requires env variables defined: {} and {}".format(
     TEST_ENV_USER, TEST_ENV_PW
 )
 
+
+FILTER_ARGS = [{}, dict(model="model_a"), dict(model=["model_a"]), dict(model="m*_a")]
+
 VERSION_COLS = ["version", "is_default"]
 META_DF = pd.DataFrame(
     [
@@ -167,7 +170,7 @@ def test_meta_columns(conn):
     npt.assert_array_equal(conn.meta_columns, META_COLS)
 
 
-@pytest.mark.parametrize("kwargs", [{}, dict(model="model_a")])
+@pytest.mark.parametrize("kwargs", FILTER_ARGS)
 @pytest.mark.parametrize("default", [True, False])
 def test_index(conn, kwargs, default):
     # test that connection returns the correct index
@@ -197,7 +200,7 @@ def test_index_illegal_column(conn):
         conn.index(foo="bar")
 
 
-@pytest.mark.parametrize("kwargs", [{}, dict(model="model_a")])
+@pytest.mark.parametrize("kwargs", FILTER_ARGS)
 @pytest.mark.parametrize("default", [True, False])
 def test_meta(conn, kwargs, default):
     # test that connection returns the correct meta dataframe
@@ -216,7 +219,7 @@ def test_meta(conn, kwargs, default):
     pdt.assert_frame_equal(obs, exp, check_dtype=False)
 
 
-@pytest.mark.parametrize("kwargs", [{}, dict(model="model_a")])
+@pytest.mark.parametrize("kwargs", FILTER_ARGS)
 @pytest.mark.parametrize("default", [True, False])
 def test_properties(conn, kwargs, default):
     # test that connection returns the correct properties dataframe


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added~

# Description of PR

#697 introduced the feature to query the IIASA API Connection class methods `index()`, `meta()` and `properties()` with filter arguments. However, the filters fail if the arguments are given as lists. This PR extends the feature (and tests) to cover filtering by lists (and wildcards).
