### PR TITLE
Accept data sheets starting with "Data" by default

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -116,7 +116,7 @@ class IamDataFrame(object):
     R-style integer column headers (i.e., `X2015`) are acceptable.
 
     When initializing an :class:`IamDataFrame` from an xlsx file,
-    |pyam| will per default parse all sheets starting with 'data'
+    |pyam| will per default parse all sheets starting with 'data' or 'Data'
     for timeseries and a sheet 'meta' to populate the respective table.
     Sheet names can be specified with kwargs :code:`sheet_name` ('data')
     and :code:`meta_sheet_name` ('meta'), where

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -139,7 +139,7 @@ def write_sheet(writer, name, df, index=False):
             pass
 
 
-def read_pandas(path, sheet_name="data*", *args, **kwargs):
+def read_pandas(path, sheet_name=["data*", "Data*"], *args, **kwargs):
     """Read a file and return a pandas.DataFrame"""
     if isinstance(path, Path) and path.suffix == ".csv":
         return pd.read_csv(path, *args, **kwargs)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -71,6 +71,7 @@ def test_io_xlsx(test_df, meta_args, tmpdir):
 @pytest.mark.parametrize(
     "sheets, sheetname",
     [
+        [["data1", "Data2"], {}],
         [["data1", "data2"], dict(sheet_name="data*")],
         [["data1", "foo"], dict(sheet_name=["data*", "foo"])],
     ],


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- ~Description in RELEASE_NOTES.md Added~

# Description of PR

Accept data sheets starting with "Data" by default, per a snafu in the EMF37 template instructions.
