### PR TITLE
Migrate `compute_bias()` to `compute` module

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Individual updates
 
+- [#702](https://github.com/IAMconsortium/pyam/pull/702) Migrate `compute_bias()` to `compute` module
 - [#699](https://github.com/IAMconsortium/pyam/pull/699) Add filter options to IIASA API `index()`, `meta()` and `properties()` methods
 - [#697](https://github.com/IAMconsortium/pyam/pull/697) Add warning if IIASA API returns empty result
 - [#695](https://github.com/IAMconsortium/pyam/pull/695) Remove unused meta levels during initialization

--- a/pyam/compute.py
+++ b/pyam/compute.py
@@ -2,6 +2,7 @@ import math
 import pandas as pd
 from pyam.index import replace_index_values
 from pyam.timeseries import growth_rate
+from pyam._debiasing import _compute_bias
 from pyam.utils import remove_from_list
 
 
@@ -112,6 +113,52 @@ class IamComputeAccessor:
         )
 
         return self._df._finalize(value, append=append, variable=name, unit="")
+
+    def bias(self, name, method, axis):
+        """Compute the bias weights and add to 'meta'
+
+        Parameters
+        ----------
+        name : str
+           Column name in the 'meta' dataframe
+        method : str
+            Method to compute the bias weights, see the notes
+        axis : str
+            Index dimensions on which to apply the `method`
+
+        Notes
+        -----
+
+        The following methods are implemented:
+
+        - "count": use the inverse of the number of scenarios grouped by `axis` names.
+
+          Using the following method on an IamDataFrame with three scenarios
+
+          .. code-block:: python
+
+              df.compute.bias(name="bias-weight", method="count", axis="scenario")
+
+          results in the following column to be added to *df.meta*:
+
+          .. list-table::
+             :header-rows: 1
+
+             * - model
+               - scenario
+               - bias-weight
+             * - model_a
+               - scen_a
+               - 0.5
+             * - model_a
+               - scen_b
+               - 1
+             * - model_b
+               - scen_a
+               - 0.5
+
+        """
+        _compute_bias(self._df, name, method, axis)
 
 
 def _compute_learning_rate(x, performance, experience):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -77,8 +77,7 @@ from pyam.index import (
     replace_index_values,
 )
 from pyam.time import swap_time_for_year, swap_year_for_time
-from pyam._debiasing import _compute_bias
-from pyam.logging import raise_data_error
+from pyam.logging import raise_data_error, deprecation_warning
 
 logger = logging.getLogger(__name__)
 
@@ -1012,50 +1011,10 @@ class IamDataFrame(object):
             return df.reset_index()
 
     def compute_bias(self, name, method, axis):
-        """Compute the bias weights and add to 'meta'
-
-        Parameters
-        ----------
-        name : str
-           Column name in the 'meta' dataframe
-        method : str
-            Method to compute the bias weights, see the notes
-        axis : str
-            Index dimensions on which to apply the `method`
-
-        Notes
-        -----
-
-        The following methods are implemented:
-
-        - "count": use the inverse of the number of scenarios grouped by `axis` names.
-
-          Using the following method on an IamDataFrame with three scenarios
-
-          .. code-block:: python
-
-              df.compute_bias(name="bias-weight", method="count", axis="scenario")
-
-          results in the following column to be added to *df.meta*:
-
-          .. list-table::
-             :header-rows: 1
-
-             * - model
-               - scenario
-               - bias-weight
-             * - model_a
-               - scen_a
-               - 0.5
-             * - model_a
-               - scen_b
-               - 1
-             * - model_b
-               - scen_a
-               - 0.5
-
-        """
-        _compute_bias(self, name, method, axis)
+        """DEPRECATED - please use :meth:`IamDataFrame.compute.bias()`"""
+        # TODO: deprecated, remove for release >= 1.7
+        deprecation_warning("Use `df.compute.bias()` instead.")
+        self.compute.bias(name, method, axis)
 
     def rename(
         self, mapping=None, inplace=False, append=False, check_duplicates=True, **kwargs

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -3,8 +3,6 @@ import re
 
 import iam_units
 import pint
-
-from pyam.logging import deprecation_warning
 from pyam.index import replace_index_values
 
 logger = logging.getLogger(__name__)

--- a/tests/test_feature_debiasing.py
+++ b/tests/test_feature_debiasing.py
@@ -13,7 +13,7 @@ def test_debiasing_count(test_pd_df, axis, exp):
     # modify the default test data to have three distinct scenarios
     test_pd_df.loc[1, "model"] = "model_b"
     df = IamDataFrame(test_pd_df)
-    df.compute_bias(method="count", name="bias", axis=axis)
+    df.compute.bias(method="count", name="bias", axis=axis)
 
     assert_array_equal(df["bias"].values, exp)
 
@@ -22,4 +22,4 @@ def test_debiasing_unknown_method(test_df_year):
     """Check computing bias weights counting the number of scenarios by scenario name"""
     msg = "Unknown method foo for computing bias weights!"
     with pytest.raises(ValueError, match=msg):
-        test_df_year.compute_bias(method="foo", name="bias", axis="scenario")
+        test_df_year.compute.bias(method="foo", name="bias", axis="scenario")


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

To remove clutter from the core module, this PR moves the method `compute_bias()` to `compute` module (with a deprecation-warning until the next release).
