### PR TITLE
Bump pytest-legacy-dependency versions to 3.7.5

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/pytest-legacy.yml
+++ b/.github/workflows/pytest-legacy.yml
@@ -1,7 +1,7 @@
-# This workflow installs the package and runs the tests with older versions of dependencies
+# This workflow runs the tests with the oldest explicitly supported versions of dependencies
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: pytest-dependency
+name: pytest-legacy
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
     branches: [ '**' ]
 
 jobs:
-  pytest-dependency:
+  pytest-legacy:
 
     runs-on: ubuntu-latest
 
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.5'
 
     - name: Install specific out-dated version of dependencies
       # Update the package requirements when changing minimum dependency versions

--- a/.github/workflows/pytest-legacy.yml
+++ b/.github/workflows/pytest-legacy.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7.5'
 

--- a/.github/workflows/pytest-legacy.yml
+++ b/.github/workflows/pytest-legacy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.5'
+        python-version: '3.7.13'
 
     - name: Install specific out-dated version of dependencies
       # Update the package requirements when changing minimum dependency versions

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
# Description of PR

GitHub Actions workflow fail with Python 3.7.1, trying 3.7.5 instead per https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
