### PR TITLE
Add a `require_data()` method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Bump minimum version of **pandas** to v1.2.0 to support automatic engine selecti
 
 ## Individual updates
 
+- [#715](https://github.com/IAMconsortium/pyam/pull/715)  Add a `require_data()` method
 - [#709](https://github.com/IAMconsortium/pyam/pull/709) Hotfix ops to support `fillna=0`
 - [#708](https://github.com/IAMconsortium/pyam/pull/708) Remove 'xls' as by-default-supported file format
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -14,7 +14,6 @@ from tempfile import TemporaryDirectory
 
 from pyam.slice import IamSlice
 from pyam.filter import filter_by_time_domain, filter_by_year, filter_by_dt_arg
-from pyam.validation import _check_dimensions
 
 try:
     from datapackage import Package

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -437,7 +437,7 @@ class IamDataFrame(object):
 
     @property
     def coordinates(self):
-        """Return the list of `data` coordinates columns (exclude index names)"""
+        """Return the list of `data` coordinates (columns not including index names)"""
         return [i for i in self._data.index.names if i not in self.index.names]
 
     @property

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -436,6 +436,11 @@ class IamDataFrame(object):
         return list(self._data.index.names)
 
     @property
+    def coordinates(self):
+        """Return the list of `data` coordinates columns (exclude index names)"""
+        return [i for i in self._data.index.names if i not in self.index.names]
+
+    @property
     def time_domain(self):
         """Indicator of the time domain: 'year', 'datetime', or 'mixed'"""
         if self._time_domain is None:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -14,6 +14,7 @@ from tempfile import TemporaryDirectory
 
 from pyam.slice import IamSlice
 from pyam.filter import filter_by_time_domain, filter_by_year, filter_by_dt_arg
+from pyam.validation import _check_dimensions
 
 try:
     from datapackage import Package
@@ -932,6 +933,78 @@ class IamDataFrame(object):
             raise ValueError(f"Cannot add a meta column {name}")
         if name not in self.meta:
             self.meta[name] = np.nan
+
+    def require_data(
+        self, region=None, variable=None, unit=None, year=None, exclude_on_fail=False
+    ):
+        """Check whether scenarios have values for all combinations of given elements
+
+        Parameters
+        ----------
+        region : str or list of str, optional
+            Required region(s).
+        variable : str or list of str, optional
+            Required variable(s).
+        unit : str or list of str, optional
+            Required unit(s).
+        year : int or list of int, optional
+            Required year(s).
+        exclude_on_fail : bool, optional
+            Set *meta* indicator for scenarios failing validation as `exclude: True`.
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe of the *index* of scenarios not satisfying the cr
+        """
+
+        # TODO: option to require values in certain ranges, see `_apply_criteria()`
+
+        # create mapping of required dimensions
+        required = {}
+        n = 1  # expected number of rows per scenario
+        for dim, value in [
+            ("region", region),
+            ("variable", variable),
+            ("unit", unit),
+            ("year", year),
+        ]:
+            if value is not None:
+                required[dim] = value
+                n *= len(to_list(value))
+
+        # fast exit if no arguments values are given
+        if not required:
+            return
+
+        # downselect to relevant rows
+        keep = self._apply_filters(**required)
+        rows = self._data.index[keep]
+
+        # identify scenarios that have none of the required values
+        index_none = self.index.difference(
+            rows.droplevel(level=self.coordinates).drop_duplicates()
+        ).to_frame(index=False)
+
+        # identify scenarios that have some but not all required values
+        columns = [i for i in self.coordinates if i not in required]
+        rows = rows.droplevel(level=columns).drop_duplicates()
+        data = (
+            pd.DataFrame(index=rows)
+            .reset_index(level=list(required))
+            .groupby(self.index.names)
+        )
+
+        index_incomplete = pd.DataFrame(
+            [idx for idx, df in data if len(df) != n], columns=self.index.names
+        )
+
+        # merge all scenarios where not all required data is present
+        index_missing_required = pd.concat([index_none, index_incomplete])
+        if not index_missing_required.empty:
+            if exclude_on_fail:
+                self._exclude_on_fail(index_missing_required)
+            return index_missing_required
 
     def require_variable(self, variable, unit=None, year=None, exclude_on_fail=False):
         """Check whether all scenarios have a required variable

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -18,6 +18,29 @@ def test_require_data_pass(test_df_year, kwargs):
     assert test_df_year.require_data(**kwargs) is None
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        dict(variable="Primary Energy|Coal"),
+        dict(variable=["Primary Energy"], year=[2005, 2010]),
+    ),
+)
+@pytest.mark.parametrize("exclude_on_fail", (False, True))
+def test_require_data(test_df_year, kwargs, exclude_on_fail):
+    # check different ways of failing when not all required data is present
+
+    test_df_year._data = test_df_year._data[0:5]  # remove value for scen_b & 2010
+
+    obs = test_df_year.require_data(**kwargs, exclude_on_fail=exclude_on_fail)
+    exp = pd.DataFrame([["model_a", "scen_b"]], columns=["model", "scenario"])
+    pdt.assert_frame_equal(obs, exp)
+
+    if exclude_on_fail:
+        list(test_df_year.meta["exclude"]) == [False, True]
+    else:
+        list(test_df_year.meta["exclude"]) == [False, False]
+
+
 def test_require_variable_pass(test_df):
     # checking that the return-type is correct
     obs = test_df.require_variable(variable="Primary Energy", exclude_on_fail=True)

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -1,6 +1,21 @@
 import pandas as pd
 import pandas.testing as pdt
+import pytest
+
 from pyam import IamDataFrame, validate, categorize, require_variable, META_IDX
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        dict(),
+        dict(variable="Primary Energy"),
+        dict(variable=["Primary Energy"], year=[2005, 2010]),
+    ),
+)
+def test_require_data_pass(test_df_year, kwargs):
+    # check that IamDataFrame with all required data returns None
+    assert test_df_year.require_data(**kwargs) is None
 
 
 def test_require_variable_pass(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a `require_data()` method as a generalized approach to `require_variable()`. The new method returns none if all scenarios have all (combinations) of required values on the dimensions, or it returns a DataFrame of model-scenarios where not all required values are present.

The PR also adds a (data) "coordinates" attribute to quickly access the data columns that are not in the index.

# Question

The existing validation methods like `require_variable()` are very verbose. Here, I have not added any logging output. Any preferences?
