### PR TITLE
Ensure correct order of `time` attribute

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Next Release
 
+- [#723](https://github.com/IAMconsortium/pyam/pull/723) Ensure correct order of `time` attribute
+
 # Release v1.7.0
 
 ## Highlights

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -402,9 +402,8 @@ class IamDataFrame(object):
         """
         if self._time is None:
             self._time = pd.Index(
-                self._data.index.unique(level=self.time_col).values, name="time"
+                get_index_levels(self._data, self.time_col), name="time"
             )
-
         return self._time
 
     @property

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -46,9 +46,17 @@ META_DF = pd.DataFrame(
 df_empty = pd.DataFrame([], columns=IAMC_IDX + [2005, 2010])
 
 
-def test_init_df_with_index(test_pd_df):
-    df = IamDataFrame(test_pd_df.set_index(META_IDX))
-    pd.testing.assert_frame_equal(df.timeseries().reset_index(), test_pd_df)
+@pytest.mark.parametrize("index", (None, META_IDX, ["model"]))
+def test_init_df(test_pd_df, index):
+    """Casting to IamDataFrame and returning as `timeseries()` yields original frame"""
+
+    # set a value to `nan` to check that timeseries columns are ordered correctly
+    test_pd_df.loc[0, test_pd_df.columns[5]] = np.nan
+
+    # any number of columns can be set as index
+    df = test_pd_df.copy() if index is None else test_pd_df.set_index(index)
+    obs = IamDataFrame(df).timeseries()
+    pdt.assert_frame_equal(obs, test_pd_df.set_index(IAMC_IDX), check_column_type=False)
 
 
 def test_init_from_iamdf(test_df_year):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 from datetime import datetime
@@ -46,7 +47,12 @@ OE_SUBANNUAL_FORMAT = lambda x: x.strftime("%m-%d %H:%M%z").replace("+0100", "+0
     ],
 )
 def test_time_domain(test_pd_df, time, domain, index):
-    # assert that the time-domain and time-index attributes are set correctly
+    # Check that the time-domain and time-index attributes are set correctly
+
+    # set a value to `nan` to check that time domain is ordered correctly
+    # see https://github.com/IAMconsortium/pyam/issues/722
+    test_pd_df.loc[0, test_pd_df.columns[5]] = np.nan
+
     mapping = dict([(i, j) for i, j in zip(TEST_YEARS, time)])
     df = IamDataFrame(data=test_pd_df.rename(mapping, axis="columns"))
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -63,7 +63,7 @@ def test_time_domain(test_pd_df, time, domain, index):
 
 @pytest.mark.parametrize("inplace", [True, False])
 def test_swap_time_to_year(test_df, inplace):
-    """Swap time column for year (int) dropping subannual time resolution (default)"""
+    # Swap time column for year (int) dropping subannual time resolution (default)
 
     if test_df.time_col == "year":
         pytest.skip("IamDataFrame with time domain `year` not relevant for this test.")


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR modifies how the values for the `time` attribute are retrieved, fixing a bug where the order may not have been correct.

Closes #722 