### PR TITLE
Improve error message when  invalid connection

### DIFF
--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -225,7 +225,7 @@ class Connection(object):
         if name not in valid:
             raise ValueError(
                 f"You do not have access to instance '{name}' or it does not exist. "
-                "Use `Connection.valid_connections` for a list of accessible services."
+                "Use `pyam.iiasa.Connection().valid_connections` for a list of accessible services."
             )
 
         # TODO: config will be reimplemented in conjunction with ixmp-server

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -225,7 +225,8 @@ class Connection(object):
         if name not in valid:
             raise ValueError(
                 f"You do not have access to instance '{name}' or it does not exist. "
-                "Use `pyam.iiasa.Connection().valid_connections` for a list of accessible services."
+                "Use `pyam.iiasa.Connection().valid_connections` for a list "
+                "of accessible services."
             )
 
         # TODO: config will be reimplemented in conjunction with ixmp-server


### PR DESCRIPTION
Minor improvement to error message, including add brackets

# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Name of contributors Added to AUTHORS.rst
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Improve error message
`ValueError: You do not have access to instance xxxxx or it does not exist. Use `Connection.valid_connections` for a list of accessible services.`

changed to 
`pyam.iiasa.Connection().valid_connections`