### PR TITLE
Improve performance of `format_data()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#729](https://github.com/IAMconsortium/pyam/pull/729) Improve performance at initialization
 - [#723](https://github.com/IAMconsortium/pyam/pull/723) Ensure correct order of `time` attribute
 
 # Release v1.7.0

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -380,6 +380,7 @@ def _validate_complete_index(df):
         )
     del null_rows
 
+
 def sort_data(data, cols):
     """Sort data rows and order columns by cols"""
     return data.sort_values(cols)[cols + ["value"]].reset_index(drop=True)

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -378,7 +378,6 @@ def _validate_complete_index(df):
         raise_data_error(
             f"Empty cells in `data` (columns: '{cols}')", df.loc[null_rows]
         )
-    del null_rows
 
 
 def sort_data(data, cols):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -341,7 +341,7 @@ def format_data(df, index, **kwargs):
         df.name = "value"
         df.index.names = df.index.names[:-1] + [time_col]
 
-    # cast value column to numeric and drop nan
+    # cast value column to numeric
     try:
         df = pd.to_numeric(df)
     except ValueError as e:

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -371,10 +371,10 @@ def format_data(df, index, **kwargs):
 def _validate_complete_index(df):
     """Validate that there are no nan's in the (index) columns"""
     null_cells = df.isnull()
-    null_rows = null_cells.T.any()
+    null_rows = null_cells.any(axis=1)
     if null_rows.any():
         null_cols = null_cells.any()
-        cols = ", ".join(null_cols[null_cols].index)
+        cols = ", ".join(null_cols.index[null_cols])
         raise_data_error(
             f"Empty cells in `data` (columns: '{cols}')", df.loc[null_rows]
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -102,7 +102,6 @@ def test_init_df_with_illegal_values_raises(test_pd_df, illegal_value):
         f'.*string "{illegal_value}" in `data`:'
         r"(\n.*){2}model_a.*scen_a.*World.*Primary Energy.*EJ/yr.*2005"
     )
-
     with pytest.raises(ValueError, match=msg):
         IamDataFrame(test_pd_df)
 
@@ -110,7 +109,13 @@ def test_init_df_with_illegal_values_raises(test_pd_df, illegal_value):
 def test_init_df_with_na_scenario(test_pd_df):
     # missing values in an index dimension raises an error
     test_pd_df.loc[1, "scenario"] = np.nan
-    pytest.raises(ValueError, IamDataFrame, data=test_pd_df)
+    msg = (
+        "Empty cells in `data` \(columns: 'scenario'\):"
+        r"(\n.*){2}model_a.*NaN.*World.*Primary Energy|Coal.*EJ/yr.*2005.*"
+    )
+    with pytest.raises(ValueError, match=msg):
+        IamDataFrame(test_pd_df)
+
 
 
 def test_init_df_with_float_cols(test_pd_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -117,7 +117,6 @@ def test_init_df_with_na_scenario(test_pd_df):
         IamDataFrame(test_pd_df)
 
 
-
 def test_init_df_with_float_cols(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005.0, 2010: 2010.0})
     obs = IamDataFrame(_test_df).timeseries().reset_index()


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR is an alternative approach to #726 & #727 only focusing on performance improvements in `format_data()` by switching from `pd.melt()` to `stack()`.

## Performance improvements

Current implementation

```
      ITEM_PATH      ITEM_VARIANT  TOTAL_TIME  CPU_USAGE    MEM_USAGE
0  test_profile  test_init[data0]    0.673276   0.203255    -1.433594
1  test_profile  test_init[data1]    9.140325   0.931676  1389.832031
2  test_profile  test_init[data2]   29.698939   0.932599  3407.539062
```

New implementation

```
      ITEM_PATH      ITEM_VARIANT  TOTAL_TIME  CPU_USAGE    MEM_USAGE
0  test_profile  test_init[data0]    0.786510   0.167053    -0.167969
1  test_profile  test_init[data1]    4.425207   0.850163   631.160156
2  test_profile  test_init[data2]   12.178936   0.942462  1482.765625
```
