### PR TITLE
Switch IIASA-Connection `default` argument

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,18 @@
 # Next Release
 
+## API changes
+
+In anticipation of a change in the **ixmp** API, the argument `default` in the
+IIASA-Connection methods was renamed to `is_default` with the following behavior:
+
+- If `True`, return *only* the default version of a model/scenario.
+- If `False`, return all versions for each model/scenario *except the default* (not yet implemented).
+- If `None`, return all versions (previously `default=False`).
+
+## Individual updates
+
 - [#734](https://github.com/IAMconsortium/pyam/pull/734) Validation for illegal column names in `data`
+- [#733](https://github.com/IAMconsortium/pyam/pull/733) Change IIASA-Connection argument to `is_default`
 - [#731](https://github.com/IAMconsortium/pyam/pull/731) Add fast-path to initialization for sufficient multiindex
 - [#732](https://github.com/IAMconsortium/pyam/pull/732) Fix a few typos in tutorials
 - [#730](https://github.com/IAMconsortium/pyam/pull/730) Refactor initialization code

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,16 +3,12 @@
 ## API changes
 
 In anticipation of a change in the **ixmp** API, the argument `default` in the
-IIASA-Connection methods was renamed to `is_default` with the following behavior:
-
-- If `True`, return *only* the default version of a model/scenario.
-- If `False`, return all versions for each model/scenario *except the default* (not yet implemented).
-- If `None`, return all versions (previously `default=False`).
+IIASA-Connection methods was renamed to `default_only`.
 
 ## Individual updates
 
 - [#734](https://github.com/IAMconsortium/pyam/pull/734) Validation for illegal column names in `data`
-- [#733](https://github.com/IAMconsortium/pyam/pull/733) Change IIASA-Connection argument to `is_default`
+- [#733](https://github.com/IAMconsortium/pyam/pull/733) Change IIASA-Connection argument to `default_only`
 - [#731](https://github.com/IAMconsortium/pyam/pull/731) Add fast-path to initialization for sufficient multiindex
 - [#732](https://github.com/IAMconsortium/pyam/pull/732) Fix a few typos in tutorials
 - [#730](https://github.com/IAMconsortium/pyam/pull/730) Refactor initialization code

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -603,17 +603,18 @@ class Connection(object):
 
 def _new_default_api(kwargs):
     """Change kwargs from `default` to `is_default`"""
+    # TODO: argument `default` is deprecated, remove for release >= 2.0
     v = kwargs.pop("default")
     _arg = "The argument `default`"
     if v is False:
         deprecation_warning("Use `is_default=None` to get all scenarios.")
         return None
-    if v is True:
+    elif v is True:
         deprecation_warning("Use `is_default=True` to get all default scenarios.")
         return True
 
     # Note that the legacy ixmp API does not support querying all non-default versions
-    raise ValueError(f"Illegal value {v} for `default`, please use `is_default`.")
+    raise ValueError(f"Illegal value '{v}' for `default`, please use `is_default`.")
 
 
 def read_iiasa(

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -605,12 +605,12 @@ def _new_default_api(kwargs):
     """Change kwargs from `default` to `is_default`"""
     # TODO: argument `default` is deprecated, remove for release >= 2.0
     v = kwargs.pop("default")
-    _arg = "The argument `default`"
+    item = "The argument `default`"
     if v is False:
-        deprecation_warning("Use `is_default=None` to get all scenarios.")
+        deprecation_warning("Use `is_default=None` to get all scenarios.", item)
         return None
     elif v is True:
-        deprecation_warning("Use `is_default=True` to get all default scenarios.")
+        deprecation_warning("Use `is_default=True` to get all default scenarios.", item)
         return True
 
     # Note that the legacy ixmp API does not support querying all non-default versions

--- a/pyam/logging.py
+++ b/pyam/logging.py
@@ -16,12 +16,10 @@ def adjust_log_level(logger="pyam", level="ERROR"):
     logger.setLevel(old_level)
 
 
-def deprecation_warning(msg, type="This method", stacklevel=3):
+def deprecation_warning(msg, item="This method", stacklevel=3):
     """Write deprecation warning to log"""
-    warn = "is deprecated and will be removed in future versions."
-    warnings.warn(
-        "{} {} {}".format(type, warn, msg), DeprecationWarning, stacklevel=stacklevel
-    )
+    message = f"{item} is deprecated and will be removed in future versions. {msg}"
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
 
 
 def raise_data_error(msg, data):

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -223,7 +223,7 @@ def test_meta(conn, kwargs, default):
 @pytest.mark.parametrize("default", [True, False])
 def test_properties(conn, kwargs, default):
     # test that connection returns the correct properties dataframe
-    obs = conn.properties(default, **kwargs)
+    obs = conn.properties(default=default, **kwargs)
 
     if default:
         exp_cols = ["version"]


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

In anticipation of the release of the re-implemented **ixmp** package, this PR changes the API of the **iiasa.Connection** methods to resemble other filter options (and the forthcoming ixmp API).

Currently, a user could be confused that the query
```python
iiasa.Connection("integration-test").index(default=False)
```
will return a table of runs that have both *True* and *False* in the `is_default` column.

Going forward, a user has to do `is_default=None` to get *all scenarios* (default and non-default), while `is_default=True` will return only the default scenarios (as currently implemented by `default=True`).

The new ixmp package will also support `is_default=False` to return only the non-default scenarios - the current ixmp API does not support that option.