### PR TITLE
Update docs to pandas 2.0 conventions

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -396,7 +396,7 @@ class IamDataFrame(object):
 
         Returns
         -------
-        - A :class:`pandas.Int64Index` if the :attr:`time_domain` is 'year'
+        - A :class:`pandas.Index` (dtype 'int64') if the :attr:`time_domain` is 'year'
         - A :class:`pandas.DatetimeIndex` if the :attr:`time_domain` is 'datetime'
         - A :class:`pandas.Index` if the :attr:`time_domain` is 'mixed'
         """

--- a/pyam/slice.py
+++ b/pyam/slice.py
@@ -48,7 +48,7 @@ class IamSlice(pd.Series):
 
         Returns
         -------
-        - A :class:`pandas.Int64Index` if the time-domain is 'year'
+        - A :class:`pandas.Index` (dtype 'int64') if the :attr:`time_domain` is 'year'
         - A :class:`pandas.DatetimeIndex` if the time-domain is 'datetime'
         - A :class:`pandas.Index` if the time-domain is 'mixed'
         """


### PR DESCRIPTION
# Description of PR

pandas 2.0 does not have an own **Int64Index** class anymore, see [here](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#index-can-now-hold-numpy-numeric-dtypes)
