### PR TITLE
Fix a typo in the `multiply()` docstring

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2118,7 +2118,7 @@ class IamDataFrame(object):
         Parameters
         ----------
         a, b : str, list of str or a number
-            Items to be used for the division.
+            Items to be multiplied.
         name : str
             Name of the computed timeseries data on the `axis`.
         axis : str, optional


### PR DESCRIPTION
# Description of PR

Fix a copy-paste typo in the docstring of the `multiply()` method
