### PR TITLE
Skip the unfccc-di-api integration test

### DIFF
--- a/pyam/unfccc.py
+++ b/pyam/unfccc.py
@@ -56,13 +56,14 @@ def read_unfccc(
 
         .. code-block:: python
 
-            {
-                'Emissions|{gas}|Energy': ('1.  Energy', '*', '*', '*'),
-            }
+          {
+            "Emissions|{gas}|Energy":
+              ("1.  Energy", "*", "*", "*"),
+          }
 
         where the tuple corresponds to filters for the columns
-        `['category', 'classification', 'measure', 'gas']`
-        and `{<col>}` tags in the key are replaced by the column value.
+        ``["category", "classification", "measure", "gas"]``
+        and ``{<col>}`` tags in the key are replaced by the column value.
     model : str, optional
         Name to be used as model identifier
     scenario : str, optional
@@ -71,13 +72,19 @@ def read_unfccc(
     Returns
     -------
     :class:`IamDataFrame`
+
+    Notes
+    -----
+    This method is currently not tested due to a change in the UNFCCC-DI API,
+    which sometimes causes a `JsonDecodeError`.
+    See https://github.com/pik-primap/unfccc_di_api/issues/74 for more info.
     """
     if not HAS_UNFCCC:  # pragma: no cover
-        raise ImportError("Required package `unfccc-di-api` not found!")
+        raise ImportError("Required package `unfccc-di-api` not found.")
 
     # check that only one of `tier` or `mapping` is provided
     if (tier is None and mapping is None) or (tier is not None and mapping is not None):
-        raise ValueError("Please specify either `tier` or `mapping`!")
+        raise ValueError("Please specify either `tier` or `mapping`.")
 
     global _READER
     if _READER is None:
@@ -134,7 +141,7 @@ def read_unfccc(
 def _compile_variable(i, variable):
     """Translate UNFCCC columns into an IAMC-style variable"""
     if i["variable"]:
-        raise ValueError("Conflict in variable mapping!")
+        raise ValueError("Conflict in variable mapping.")
     return variable.format(**dict((c, i[c]) for c in NAME_COLS))
 
 

--- a/tests/test_unfccc.py
+++ b/tests/test_unfccc.py
@@ -1,3 +1,4 @@
+import pytest
 import pandas as pd
 from pyam import IamDataFrame, read_unfccc
 from pyam.testing import assert_iamframe_equal
@@ -11,6 +12,7 @@ UNFCCC_DF = pd.DataFrame(
 INDEX_ARGS = dict(model="UNFCCC", scenario="Data Inventory")
 
 
+@pytest.mark.skip("Skip due to https://github.com/pik-primap/unfccc_di_api/issues/74")
 def test_unfccc_tier1():
     # test that UNFCCC API returns expected data and units
     exp = IamDataFrame(


### PR DESCRIPTION
# Description of PR

This PR skips the unfccc-di-api integration test in response to https://github.com/pik-primap/unfccc_di_api/issues/74.