### PR TITLE
Support region-aggregation with weights-index as superset

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Next Release
 
-- [#747](https://github.com/IAMconsortium/pyam/pull/747) Drop support for Python 3.7 #747
+- [#754](https://github.com/IAMconsortium/pyam/pull/754) Support region-aggregation with weights-index >> data-index
+- [#747](https://github.com/IAMconsortium/pyam/pull/747) Drop support for Python 3.7
 
 # Release v1.9.0
 

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -218,7 +218,7 @@ def _agg_weight(data, weight, method, drop_negative_weights):
 
     weight = weight.droplevel(["variable", "unit"])
 
-    if not data.droplevel(["variable", "unit"]).index.equals(weight.index):
+    if not all(data.droplevel(["variable", "unit"]).index.isin(weight.index)):
         raise ValueError("Inconsistent index between variable and weight!")
 
     if drop_negative_weights is True:
@@ -234,9 +234,10 @@ def _agg_weight(data, weight, method, drop_negative_weights):
 
     col1 = data.index.names.difference(["region"])
     col2 = data.index.names.difference(["region", "variable", "unit"])
-    return (data * weight).groupby(col1).apply(
+
+    return ((data * weight).groupby(col1).apply(
         pd.Series.sum, skipna=False
-    ) / weight.groupby(col2).sum()
+    ) / weight.groupby(col2).sum()).dropna()
 
 
 def _get_method_func(method):

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -235,9 +235,10 @@ def _agg_weight(data, weight, method, drop_negative_weights):
     col1 = data.index.names.difference(["region"])
     col2 = data.index.names.difference(["region", "variable", "unit"])
 
-    return ((data * weight).groupby(col1).apply(
-        pd.Series.sum, skipna=False
-    ) / weight.groupby(col2).sum()).dropna()
+    return (
+        (data * weight).groupby(col1).apply(pd.Series.sum, skipna=False)
+        / weight.groupby(col2).sum()
+    ).dropna()
 
 
 def _get_method_func(method):

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -115,11 +115,11 @@ def _aggregate_region(
     """Internal implementation for aggregating data over subregions"""
     if not isstr(variable) and components is not False:
         raise ValueError(
-            "Aggregating by list of variables with components is not supported!"
+            "Aggregating by list of variables with components is not supported."
         )
 
     if weight is not None and components is not False:
-        raise ValueError("Using weights and components in one operation not supported!")
+        raise ValueError("Using weights and components in one operation not supported.")
 
     # default subregions to all regions other than `region`
     subregions = subregions or df._all_other_regions(region, variable)
@@ -127,7 +127,7 @@ def _aggregate_region(
     if not len(subregions):
         logger.info(
             f"Cannot aggregate variable '{variable}' to '{region}' "
-            "because it does not exist in any subregion!"
+            "because it does not exist in any subregion."
         )
         return
 
@@ -137,7 +137,7 @@ def _aggregate_region(
     if weight is None:
         if drop_negative_weights is False:
             raise ValueError(
-                "Dropping negative weights can only be used with `weights`!"
+                "Dropping negative weights can only be used with `weights`."
             )
 
         _data = _group_and_agg(subregion_df._data[rows], "region", method=method)
@@ -214,19 +214,18 @@ def _agg_weight(data, weight, method, drop_negative_weights):
 
     # only summation allowed with weights
     if method not in ["sum", np.sum]:
-        raise ValueError("Only method 'np.sum' allowed for weighted average!")
+        raise ValueError("Only method 'np.sum' allowed for weighted average.")
 
     weight = weight.droplevel(["variable", "unit"])
 
     if not all(data.droplevel(["variable", "unit"]).index.isin(weight.index)):
-        raise ValueError("Inconsistent index between variable and weight!")
+        raise ValueError("Inconsistent index between variable and weight.")
 
     if drop_negative_weights is True:
         if any(weight < 0):
             logger.warning(
-                "Some of the weights are negative. "
-                "All data weighted by negative values will be dropped. "
-                "To apply both positive and negative weights to the data, "
+                "Some weights are negative. All data weighted by negative values will "
+                "be dropped. To use both positive and negative weights, "
                 "please use the keyword argument `drop_negative_weights=False`."
             )
             # Drop negative weights
@@ -250,4 +249,4 @@ def _get_method_func(method):
         return KNOWN_FUNCS[method]
 
     # raise error if `method` is a string but not in dict of known methods
-    raise ValueError(f"'{method}' is not a known method!")
+    raise ValueError(f"Unknown method: {method}")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1468,7 +1468,7 @@ class IamDataFrame(object):
         """Aggregate timeseries data by subregions.
 
         This function allows to add variable sub-categories that are only
-        defined at the `region` level by setting `components=True`
+        defined at the `region` level by setting `components=True`.
 
         Parameters
         ----------
@@ -1625,7 +1625,7 @@ class IamDataFrame(object):
         method="sum",
         append=False,
     ):
-        """Aggregate timeseries data by subannual time resolution
+        """Aggregate timeseries data by subannual time resolution.
 
         Parameters
         ----------
@@ -1666,7 +1666,7 @@ class IamDataFrame(object):
         weight=None,
         append=False,
     ):
-        """Downscale timeseries data to a number of subregions
+        """Downscale timeseries data to a number of subregions.
 
         Parameters
         ----------
@@ -1737,7 +1737,7 @@ class IamDataFrame(object):
         return META_IDX + cols + self.extra_cols
 
     def check_internal_consistency(self, components=False, **kwargs):
-        """Check whether a scenario ensemble is internally consistent
+        """Check whether a scenario ensemble is internally consistent.
 
         We check that all variables are equal to the sum of their sectoral
         components and that all the regions add up to the World total. If

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -306,16 +306,6 @@ def test_aggregate_region_with_components(simple_df):
     assert _df.check_aggregate_region(v, components=["foo"]) is None
 
 
-def test_aggregate_region_with_no_weights_drop_negative_weights_raises(simple_df):
-    # dropping negative weights can only be used with weight
-    pytest.raises(
-        ValueError,
-        simple_df.aggregate_region,
-        "Price|Carbon",
-        drop_negative_weights=False,
-    )
-
-
 def test_aggregate_region_with_weights(simple_df):
     # carbon price shouldn't be summed but be weighted by emissions
     v = "Price|Carbon"
@@ -346,6 +336,11 @@ def test_aggregate_region_raises(simple_df):
     # setting both weight and components raises an error
     pytest.raises(
         ValueError, simple_df.aggregate_region, v, components=True, weight="bar"
+    )
+
+    # dropping negative weights can only be used with weight
+    pytest.raises(
+        ValueError, simple_df.aggregate_region, v, drop_negative_weights=False,
     )
 
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -305,7 +305,7 @@ def test_aggregate_region_with_components(simple_df):
     assert _df.check_aggregate_region(v, components=["foo"]) is None
 
 
-def test_aggregate_region_with_weights(simple_df):
+def test_aggregate_region_with_weights(simple_df, caplog):
     # carbon price shouldn't be summed but be weighted by emissions
     v = "Price|Carbon"
     w = "Emissions|CO2"
@@ -333,6 +333,14 @@ def test_aggregate_region_with_weights(simple_df):
     assert_iamframe_equal(
         neg_weights_df.aggregate_region(v, weight=w, drop_negative_weights=False), exp
     )
+
+    msg = (
+        "Some weights are negative. All data weighted by negative values will "
+        "be dropped. To use both positive and negative weights, "
+        "please use the keyword argument `drop_negative_weights=False`."
+    )
+    idx = caplog.messages.index(msg)
+    assert caplog.records[idx].levelname == "WARNING"
 
 
 def test_aggregate_region_with_weights_raises(simple_df):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -97,8 +97,7 @@ def test_check_aggregate_top_level(simple_df):
 
 
 @pytest.mark.parametrize(
-    "variable",
-    (("Primary Energy"), (["Primary Energy", "Emissions|CO2"])),
+    "variable", ("Primary Energy", (["Primary Energy", "Emissions|CO2"]))
 )
 def test_aggregate_append(simple_df, variable):
     # remove `variable`, do aggregate and append, check equality to original
@@ -197,7 +196,7 @@ def test_aggregate_components_as_dict(simple_df):
 @pytest.mark.parametrize(
     "variable",
     (
-        ("Primary Energy"),
+        "Primary Energy",
         (["Primary Energy", "Primary Energy|Coal", "Primary Energy|Wind"]),
     ),
 )
@@ -322,7 +321,7 @@ def test_aggregate_region_with_weights(simple_df):
     assert_iamframe_equal(_df.aggregate_region(v, weight=w), exp)
 
 
-def test_aggregate_region_raises(simple_df):
+def test_aggregate_region_with_weights_raises(simple_df):
     v = "Price|Carbon"
     w = "Emissions|CO2"
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -339,7 +339,7 @@ def test_aggregate_region_with_weights_raises(simple_df):
 
     # dropping negative weights can only be used with weight
     pytest.raises(
-        ValueError, simple_df.aggregate_region, v, drop_negative_weights=False,
+        ValueError, simple_df.aggregate_region, v, drop_negative_weights=False
     )
 
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -358,6 +358,11 @@ def test_aggregate_region_with_weights(simple_df):
     exp = simple_df.filter(variable=v, region="World")
     assert_iamframe_equal(simple_df.aggregate_region(v, weight=w), exp)
 
+
+def test_aggregate_region_raises(simple_df):
+    v = "Price|Carbon"
+    w = "Emissions|CO2"
+
     # inconsistent index of variable and weight raises an error
     _df = simple_df.filter(variable=w, region="reg_b", keep=False)
     pytest.raises(ValueError, _df.aggregate_region, v, weight=w)
@@ -365,15 +370,9 @@ def test_aggregate_region_with_weights(simple_df):
     # using weight and method other than 'sum' raises an error
     pytest.raises(ValueError, simple_df.aggregate_region, v, method="max", weight="bar")
 
-
-def test_aggregate_region_with_components_and_weights_raises(simple_df):
     # setting both weight and components raises an error
     pytest.raises(
-        ValueError,
-        simple_df.aggregate_region,
-        "Emissions|CO2",
-        components=True,
-        weight="bar",
+        ValueError, simple_df.aggregate_region, v, components=True, weight="bar"
     )
 
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -358,6 +358,11 @@ def test_aggregate_region_with_weights(simple_df):
     exp = simple_df.filter(variable=v, region="World")
     assert_iamframe_equal(simple_df.aggregate_region(v, weight=w), exp)
 
+    # repeat test where data-index is a subset of weight-index
+    exp = simple_df.filter(variable=v, region="World", year=2005)
+    _df = simple_df.filter(variable=v, year=2010, keep=False)
+    assert_iamframe_equal(_df.aggregate_region(v, weight=w), exp)
+
 
 def test_aggregate_region_raises(simple_df):
     v = "Price|Carbon"

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -42,20 +42,6 @@ PRICE_MAX_DF = pd.DataFrame(
     columns=LONG_IDX + ["value"],
 )
 
-NEG_WEIGHTS_DF = pd.DataFrame(
-    [
-        ["model_a", "scen_a", "reg_a", "Emissions|CO2", "EJ/yr", 2005, -4.0],
-        ["model_a", "scen_a", "reg_a", "Emissions|CO2", "EJ/yr", 2010, 5.0],
-        ["model_a", "scen_a", "reg_b", "Emissions|CO2", "EJ/yr", 2005, 2.0],
-        ["model_a", "scen_a", "reg_b", "Emissions|CO2", "EJ/yr", 2010, 3.0],
-        ["model_a", "scen_a", "reg_a", "Price|Carbon", "USD/tCO2", 2005, 6.0],
-        ["model_a", "scen_a", "reg_a", "Price|Carbon", "USD/tCO2", 2010, 6.0],
-        ["model_a", "scen_a", "reg_b", "Price|Carbon", "USD/tCO2", 2005, 3.0],
-        ["model_a", "scen_a", "reg_b", "Price|Carbon", "USD/tCO2", 2010, 4.0],
-    ],
-    columns=LONG_IDX + ["value"],
-)
-
 
 @pytest.mark.parametrize(
     "variable,data",
@@ -318,24 +304,6 @@ def test_aggregate_region_with_components(simple_df):
     # rename emissions of bunker to test setting components as list
     _df = simple_df.rename(variable={"Emissions|CO2|Bunkers": "foo"})
     assert _df.check_aggregate_region(v, components=["foo"]) is None
-
-
-def test_agg_weight():
-    variable = "Price|Carbon"
-    weight = "Emissions|CO2"
-    # negative weights should be dropped on default
-    obs_1 = IamDataFrame(NEG_WEIGHTS_DF).aggregate_region(variable, weight=weight)._data
-    exp_1 = np.array([5.25])
-    np.testing.assert_array_equal(obs_1.values, exp_1)
-
-    # negative weights shouldn't be dropped if drop_negative_weights=False
-    obs_2 = (
-        IamDataFrame(NEG_WEIGHTS_DF)
-        .aggregate_region(variable, weight=weight, drop_negative_weights=False)
-        ._data
-    )
-    exp_2 = np.array([9, 5.25])
-    np.testing.assert_array_equal(obs_2.values, exp_2)
 
 
 def test_aggregate_region_with_no_weights_drop_negative_weights_raises(simple_df):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -372,10 +372,9 @@ def test_aggregate_region_empty(test_df, variable, append, caplog):
         # with `append=False` (default), an empty instance is returned
         assert test_df.aggregate_region(variable).empty
 
-    caplog.set_level(logging.INFO, logger="pyam.aggregation")
     msg = (
         f"Cannot aggregate variable '{variable}' to 'World' "
-        "because it does not exist in any subregion!"
+        "because it does not exist in any subregion."
     )
     idx = caplog.messages.index(msg)
     assert caplog.records[idx].levelname == "INFO"


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Per a request by @bs538, this PR extends the `aggregate_region()` method such that the computation is done if the weights-index is a superset of the data-index. Previously, the computation was only done if the index was identical.

E.g., if (for whatever reasons), CO2-prices are only given until 2050 but CO2 emissions are given until 2100, the method will now be able to compute region-aggregated CO2-prices until 2050.

The relevant change is going from `equals` to `isin` when checking the consistency of the two data- and weight-index, plus adding an element to a test. All other changes are simply clean-up of the tests and docstrings.