### PR TITLE
Bugfix for incorrect dimension-accessors when initializing from pandas 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ When importing an xlsx file created with pyam < 2.0, which has an "exclude" colu
 
 ## Individual updates
 
+- [#763](https://github.com/IAMconsortium/pyam/pull/763) Implement a fix against carrying over unused levels when initializing from an indexed pandas object
 - [#759](https://github.com/IAMconsortium/pyam/pull/759) Excise "exclude" column from meta and add a own attribute
 - [#747](https://github.com/IAMconsortium/pyam/pull/747) Drop support for Python 3.7 #747
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -378,6 +378,9 @@ def format_data(df, index, **kwargs):
 
         df = df.reorder_levels(index + REQUIRED_COLS + [time_col] + extra_cols).dropna()
 
+        # remove unused levels to guard against issue #762
+        df.index = df.index.remove_unused_levels()
+
     else:
         if isinstance(df, pd.Series):
             if not df.name:
@@ -429,9 +432,6 @@ def format_data(df, index, **kwargs):
     del rows
     if df.empty:
         logger.warning("Formatted data is empty!")
-
-    # remove unused levels to guard against issue #762
-    df.index = df.index.remove_unused_levels()
 
     return df.sort_index(), index, time_col, extra_cols
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -430,6 +430,9 @@ def format_data(df, index, **kwargs):
     if df.empty:
         logger.warning("Formatted data is empty!")
 
+    # remove unused levels to guard against issue #762
+    df.index = df.index.remove_unused_levels()
+
     return df.sort_index(), index, time_col, extra_cols
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -128,6 +128,17 @@ def test_init_df_from_timeseries(test_df):
     pd.testing.assert_frame_equal(df.timeseries(), test_df.timeseries())
 
 
+def test_init_df_from_timeseries_unused_levels(test_df):
+    # this test guards against regression for the bug
+    # reported in https://github.com/IAMconsortium/pyam/issues/762
+
+    for _, df in test_df.timeseries().groupby(["model", "scenario"]):
+        # we're only interested in the second model-scenario combination
+        pass
+
+    # pandas does not remove unused levels (here: "Primary Energy|Coal") in a groupby
+    assert IamDataFrame(df).variable == ["Primary Energy"]
+
 def test_init_df_with_extra_col(test_pd_df):
     tdf = test_pd_df.copy()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -132,12 +132,14 @@ def test_init_df_from_timeseries_unused_levels(test_df):
     # this test guards against regression for the bug
     # reported in https://github.com/IAMconsortium/pyam/issues/762
 
-    for _, df in test_df.timeseries().groupby(["model", "scenario"]):
+    for (model, scenario), data in test_df.timeseries().groupby(["model", "scenario"]):
         # we're only interested in the second model-scenario combination
-        pass
+        if model == "model_a" and scenario == "scen_b":
+            df = IamDataFrame(data)
 
-    # pandas does not remove unused levels (here: "Primary Energy|Coal") in a groupby
-    assert IamDataFrame(df).variable == ["Primary Energy"]
+    # pandas 2.0 does not remove unused levels (here: "Primary Energy|Coal") in groupby
+    # we check that unused levels are removed at initialization of the IamDataFrame
+    assert df.variable == ["Primary Energy"]
 
 
 def test_init_df_with_extra_col(test_pd_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,6 +139,7 @@ def test_init_df_from_timeseries_unused_levels(test_df):
     # pandas does not remove unused levels (here: "Primary Energy|Coal") in a groupby
     assert IamDataFrame(df).variable == ["Primary Energy"]
 
+
 def test_init_df_with_extra_col(test_pd_df):
     tdf = test_pd_df.copy()
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR introduces an explicit removal of unused levels when initializing from a pandas object. This bug could lead to inconsistent return-values of the dimension-accessors.

closes #762
