### PR TITLE
Refactor to use validation module

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ instead of `pyam.to_list()`.
 
 ## Individual updates
 
+- [#771](https://github.com/IAMconsortium/pyam/pull/771) Refactor to start a separate validation module
 - [#764](https://github.com/IAMconsortium/pyam/pull/764) Clean-up exposing internal methods and attributes
 - [#763](https://github.com/IAMconsortium/pyam/pull/763) Implement a fix against carrying over unused levels when initializing from an indexed pandas object
 - [#759](https://github.com/IAMconsortium/pyam/pull/759) Excise "exclude" column from meta and add a own attribute

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -68,7 +68,7 @@ from pyam.index import (
 )
 from pyam.time import swap_time_for_year, swap_year_for_time
 from pyam.logging import raise_data_error, deprecation_warning
-from pyam.validation import on_failed_validation
+from pyam.validation import exclude_on_fail
 
 logger = logging.getLogger(__name__)
 
@@ -1039,7 +1039,7 @@ class IamDataFrame(object):
         index_missing_required = pd.concat([index_none, index_incomplete])
         if not index_missing_required.empty:
             if exclude_on_fail:
-                on_failed_validation(self, index_missing_required)
+                exclude_on_fail(self, index_missing_required)
             return index_missing_required
 
     def require_variable(self, variable, unit=None, year=None, exclude_on_fail=False):
@@ -1084,7 +1084,7 @@ class IamDataFrame(object):
         )
 
         if exclude_on_fail:
-            on_failed_validation(self, idx)
+            exclude_on_fail(self, idx)
 
         logger.info(msg.format(n, variable))
         return pd.DataFrame(index=idx).reset_index()
@@ -1119,7 +1119,7 @@ class IamDataFrame(object):
             logger.info(msg.format(len(df), len(self.data)))
 
             if exclude_on_fail and len(df) > 0:
-                on_failed_validation(self, df)
+                exclude_on_fail(self, df)
             return df.reset_index()
 
     def rename(
@@ -1488,7 +1488,7 @@ class IamDataFrame(object):
             logger.info(msg.format(variable, sum(rows), len(df_var)))
 
             if exclude_on_fail:
-                on_failed_validation(self, _meta_idx(df_var[rows].reset_index()))
+                exclude_on_fail(self, _meta_idx(df_var[rows].reset_index()))
 
             return pd.concat(
                 [df_var[rows], df_components[rows]],
@@ -1643,7 +1643,7 @@ class IamDataFrame(object):
             logger.info(msg.format(variable, sum(rows), len(df_region)))
 
             if exclude_on_fail:
-                on_failed_validation(self, _meta_idx(df_region[rows].reset_index()))
+                exclude_on_fail(self, _meta_idx(df_region[rows].reset_index()))
 
             _df = pd.concat(
                 [

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -68,6 +68,7 @@ from pyam.index import (
 )
 from pyam.time import swap_time_for_year, swap_year_for_time
 from pyam.logging import raise_data_error, deprecation_warning
+from pyam.validation import on_failed_validation
 
 logger = logging.getLogger(__name__)
 
@@ -1038,7 +1039,7 @@ class IamDataFrame(object):
         index_missing_required = pd.concat([index_none, index_incomplete])
         if not index_missing_required.empty:
             if exclude_on_fail:
-                self._exclude_on_fail(index_missing_required)
+                on_failed_validation(self, index_missing_required)
             return index_missing_required
 
     def require_variable(self, variable, unit=None, year=None, exclude_on_fail=False):
@@ -1083,7 +1084,7 @@ class IamDataFrame(object):
         )
 
         if exclude_on_fail:
-            self._exclude_on_fail(idx)
+            on_failed_validation(self, idx)
 
         logger.info(msg.format(n, variable))
         return pd.DataFrame(index=idx).reset_index()
@@ -1118,7 +1119,7 @@ class IamDataFrame(object):
             logger.info(msg.format(len(df), len(self.data)))
 
             if exclude_on_fail and len(df) > 0:
-                self._exclude_on_fail(df)
+                on_failed_validation(self, df)
             return df.reset_index()
 
     def rename(
@@ -1487,7 +1488,7 @@ class IamDataFrame(object):
             logger.info(msg.format(variable, sum(rows), len(df_var)))
 
             if exclude_on_fail:
-                self._exclude_on_fail(_meta_idx(df_var[rows].reset_index()))
+                on_failed_validation(self, _meta_idx(df_var[rows].reset_index()))
 
             return pd.concat(
                 [df_var[rows], df_components[rows]],
@@ -1642,7 +1643,7 @@ class IamDataFrame(object):
             logger.info(msg.format(variable, sum(rows), len(df_region)))
 
             if exclude_on_fail:
-                self._exclude_on_fail(_meta_idx(df_region[rows].reset_index()))
+                on_failed_validation(self, _meta_idx(df_region[rows].reset_index()))
 
             _df = pd.concat(
                 [

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -68,7 +68,7 @@ from pyam.index import (
 )
 from pyam.time import swap_time_for_year, swap_year_for_time
 from pyam.logging import raise_data_error, deprecation_warning
-from pyam.validation import exclude_on_fail
+from pyam.validation import _exclude_on_fail
 
 logger = logging.getLogger(__name__)
 
@@ -1039,7 +1039,7 @@ class IamDataFrame(object):
         index_missing_required = pd.concat([index_none, index_incomplete])
         if not index_missing_required.empty:
             if exclude_on_fail:
-                exclude_on_fail(self, index_missing_required)
+                _exclude_on_fail(self, index_missing_required)
             return index_missing_required
 
     def require_variable(self, variable, unit=None, year=None, exclude_on_fail=False):
@@ -1084,7 +1084,7 @@ class IamDataFrame(object):
         )
 
         if exclude_on_fail:
-            exclude_on_fail(self, idx)
+            _exclude_on_fail(self, idx)
 
         logger.info(msg.format(n, variable))
         return pd.DataFrame(index=idx).reset_index()
@@ -1119,7 +1119,7 @@ class IamDataFrame(object):
             logger.info(msg.format(len(df), len(self.data)))
 
             if exclude_on_fail and len(df) > 0:
-                exclude_on_fail(self, df)
+                _exclude_on_fail(self, df)
             return df.reset_index()
 
     def rename(
@@ -1488,7 +1488,7 @@ class IamDataFrame(object):
             logger.info(msg.format(variable, sum(rows), len(df_var)))
 
             if exclude_on_fail:
-                exclude_on_fail(self, _meta_idx(df_var[rows].reset_index()))
+                _exclude_on_fail(self, _meta_idx(df_var[rows].reset_index()))
 
             return pd.concat(
                 [df_var[rows], df_components[rows]],
@@ -1643,7 +1643,7 @@ class IamDataFrame(object):
             logger.info(msg.format(variable, sum(rows), len(df_region)))
 
             if exclude_on_fail:
-                exclude_on_fail(self, _meta_idx(df_region[rows].reset_index()))
+                _exclude_on_fail(self, _meta_idx(df_region[rows].reset_index()))
 
             _df = pd.concat(
                 [

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -520,6 +520,21 @@ def merge_exclude(left, right, ignore_conflict=False):
     return pd.concat([left, right.loc[diff]], sort=False)
 
 
+def make_index(df, cols=META_IDX, unique=True):
+    """Create an index from the columns/index of a dataframe or series"""
+
+    def _get_col(c):
+        try:
+            return df.index.get_level_values(c)
+        except KeyError:
+            return df[c]
+
+    index = list(zip(*[_get_col(col) for col in cols]))
+    if unique:
+        index = pd.unique(index)
+    return pd.MultiIndex.from_tuples(index, names=tuple(cols))
+
+
 def pattern_match(
     data, values, level=None, regexp=False, has_nan=False, return_codes=False
 ):

--- a/pyam/validation.py
+++ b/pyam/validation.py
@@ -6,7 +6,7 @@ from pyam.utils import make_index, s
 logger = logging.getLogger(__name__)
 
 
-def on_failed_validation(df, index):
+def exclude_on_fail(df, index):
     """Assign a selection of scenarios as `exclude: True`"""
 
     if not isinstance(index, pd.MultiIndex):

--- a/pyam/validation.py
+++ b/pyam/validation.py
@@ -1,0 +1,19 @@
+import logging
+import pandas as pd
+
+from pyam.utils import make_index, s
+
+logger = logging.getLogger(__name__)
+
+
+def on_failed_validation(df, index):
+    """Assign a selection of scenarios as `exclude: True`"""
+
+    if not isinstance(index, pd.MultiIndex):
+        index = make_index(index, cols=df.index.names)
+
+    df.exclude[index] = True
+    n = len(index)
+    logger.info(
+        f"{n} scenario{s(n)} failed validation and will be set as `exclude=True`."
+    )

--- a/pyam/validation.py
+++ b/pyam/validation.py
@@ -6,7 +6,7 @@ from pyam.utils import make_index, s
 logger = logging.getLogger(__name__)
 
 
-def exclude_on_fail(df, index):
+def _exclude_on_fail(df, index):
     """Assign a selection of scenarios as `exclude: True`"""
 
     if not isinstance(index, pd.MultiIndex):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import re
 import datetime
 
 import numpy as np


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR does three things:
- move the utility-method `make_index()` to the utils module
- move the utility-method `_exclude_on_fail()` to a new validation module
- add tests to show that `require_data()` implements logical-and, i.e., all combinations across dimensions are required, (see #768 
