### PR TITLE
Show all missing rows for `require_data()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ instead of `pyam.to_list()`.
 
 ## Individual updates
 
+- [#772](https://github.com/IAMconsortium/pyam/pull/772) Show all missing rows for `require_data()`
 - [#771](https://github.com/IAMconsortium/pyam/pull/771) Refactor to start a separate validation module
 - [#764](https://github.com/IAMconsortium/pyam/pull/764) Clean-up exposing internal methods and attributes
 - [#763](https://github.com/IAMconsortium/pyam/pull/763) Implement a fix against carrying over unused levels when initializing from an indexed pandas object

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1011,6 +1011,7 @@ class IamDataFrame(object):
 
         # fast exit if no arguments are given
         if not required:
+            logger.warning("No validation criteria provided.")
             return
 
         # create index of required elements

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -974,7 +974,7 @@ class IamDataFrame(object):
     def require_data(
         self, region=None, variable=None, unit=None, year=None, exclude_on_fail=False
     ):
-        """Check whether scenarios have values for all combinations of given elements
+        """Check whether scenarios have values for all (combinations of) given elements.
 
         Parameters
         ----------
@@ -993,7 +993,7 @@ class IamDataFrame(object):
         Returns
         -------
         :class:`pandas.DataFrame` or None
-            A dataframe of the scenarios and columns not satisfying the criteria.
+            A dataframe of missing (combinations of) elements for all scenarios.
         """
 
         # TODO: option to require values in certain ranges, see `_apply_criteria()`

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -43,6 +43,7 @@ from pyam.utils import (
     IAMC_IDX,
     SORT_IDX,
     ILLEGAL_COLS,
+    remove_from_list,
 )
 from pyam.filter import (
     datetime_match,
@@ -65,6 +66,7 @@ from pyam.index import (
     get_keep_col,
     verify_index_integrity,
     replace_index_values,
+    append_index_col,
 )
 from pyam.time import swap_time_for_year, swap_year_for_time
 from pyam.logging import raise_data_error, deprecation_warning
@@ -991,14 +993,13 @@ class IamDataFrame(object):
         Returns
         -------
         :class:`pandas.DataFrame` or None
-            A dataframe of the *index* of scenarios not satisfying the criteria.
+            A dataframe of the scenarios and columns not satisfying the criteria.
         """
 
         # TODO: option to require values in certain ranges, see `_apply_criteria()`
 
         # create mapping of required dimensions
         required = {}
-        n = 1  # expected number of rows per scenario
         for dim, value in [
             ("region", region),
             ("variable", variable),
@@ -1006,41 +1007,38 @@ class IamDataFrame(object):
             ("year", year),
         ]:
             if value is not None:
-                required[dim] = value
-                n *= len(to_list(value))
+                required[dim] = to_list(value)
 
-        # fast exit if no arguments values are given
+        # fast exit if no arguments are given
         if not required:
             return
 
-        # downselect to relevant rows
-        keep = self._apply_filters(**required)
-        rows = self._data.index[keep]
-
-        # identify scenarios that have none of the required values
-        index_none = self.index.difference(
-            rows.droplevel(level=self.coordinates).drop_duplicates()
-        ).to_frame(index=False)
-
-        # identify scenarios that have some but not all required values
-        columns = [i for i in self.coordinates if i not in required]
-        rows = rows.droplevel(level=columns).drop_duplicates()
-        data = (
-            pd.DataFrame(index=rows)
-            .reset_index(level=list(required))
-            .groupby(self.index.names)
+        # create index of required elements
+        index_required = pd.MultiIndex.from_product(
+            required.values(), names=required.keys()
         )
 
-        index_incomplete = pd.DataFrame(
-            [idx for idx, df in data if len(df) != n], columns=self.index.names
-        )
+        # create scenario index of suitable length, merge required elements as columns
+        n = len(self.index)
+        index = self.index.repeat(len(index_required))
+        for i, name in enumerate(required.keys()):
+            index = append_index_col(
+                index, list(index_required.get_level_values(i)) * n, name=name
+            )
 
-        # merge all scenarios where not all required data is present
-        index_missing_required = pd.concat([index_none, index_incomplete])
-        if not index_missing_required.empty:
+        # identify scenarios that do not have all required elements
+        rows = (
+            self._data.index[self._apply_filters(**required)]
+            .droplevel(level=remove_from_list(self.coordinates, required))
+            .drop_duplicates()
+        )
+        missing_required = index.difference(rows)
+
+        if not missing_required.empty:
             if exclude_on_fail:
-                _exclude_on_fail(self, index_missing_required)
-            return index_missing_required
+                non_index_levels = remove_from_list(self.coordinates, self.index.names)
+                _exclude_on_fail(self, missing_required.droplevel(non_index_levels))
+            return missing_required.to_frame(index=False)
 
     def require_variable(self, variable, unit=None, year=None, exclude_on_fail=False):
         """Check whether all scenarios have a required variable

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1016,7 +1016,7 @@ class IamDataFrame(object):
 
         # create index of required elements
         index_required = pd.MultiIndex.from_product(
-            required.values(), names=required.keys()
+            required.values(), names=list(required)
         )
 
         # create scenario index of suitable length, merge required elements as columns
@@ -1037,8 +1037,7 @@ class IamDataFrame(object):
 
         if not missing_required.empty:
             if exclude_on_fail:
-                non_index_levels = remove_from_list(self.coordinates, self.index.names)
-                _exclude_on_fail(self, missing_required.droplevel(non_index_levels))
+                _exclude_on_fail(self, missing_required.droplevel(list(required)))
             return missing_required.to_frame(index=False)
 
     def require_variable(self, variable, unit=None, year=None, exclude_on_fail=False):

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -63,9 +63,9 @@ def test_require_data(test_df_year, kwargs, exclude_on_fail):
     pdt.assert_frame_equal(obs, exp)
 
     if exclude_on_fail:
-        list(df.exclude) == [False, True]
+        assert list(df.exclude) == [False, True]
     else:
-        list(df.exclude) == [False, False]
+        assert list(df.exclude) == [False, False]
 
 
 def test_require_variable_pass(test_df):

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -51,7 +51,15 @@ def test_require_data(test_df_year, kwargs, exclude_on_fail):
     df = test_df_year.append(IamDataFrame(DATA_GAS))
 
     obs = df.require_data(**kwargs, exclude_on_fail=exclude_on_fail)
+
     exp = pd.DataFrame([["model_a", "scen_b"]], columns=["model", "scenario"])
+    # add parametrization-dependent columns to expected output
+    if kwargs["variable"] == "Primary Energy|Coal":
+        exp["variable"] = ["Primary Energy|Coal"]
+    else:
+        exp["variable"] = ["Primary Energy"]
+        exp["year"] = [2010]
+
     pdt.assert_frame_equal(obs, exp)
 
     if exclude_on_fail:


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR changes the returned dataframe of the `require_data()` method to not only show the failing scenarios (dataframe of model-scenario combinations), but a dataframe that has all missing combinations of elements.

So if *model_a* - *scen_a* does not have the variable*Emissions|CO2* at the global level, the method will return the following:

model | scenario | region | variable
------|------|------|------
model_a | scen_a | World | Emissions\|CO2


closes #768