### PR TITLE
Re-inserting the gallery to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ language = "English"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "gallery"]
+exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ language = "English"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = ["_build", "gallery/plot_*.ipynb"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     ixmp4 >= 0.4.0
     numpy >= 1.23.0, < 1.24
 #    requests  included via ixmp4
-    pyjwt
 #    httpx[http2] included via ixmp4
     openpyxl
     pandas >= 2.0.0


### PR DESCRIPTION
# Description of PR

This PR reverts a bugfix that inadvertently removed the plotting-gallery from the docs.

Correct docs are rendered at https://pyam-iamc.readthedocs.io/en/docs-gallery/gallery/index.html
