### PR TITLE
Facilitate region-aggregation with inconsistent      model scenario region       time

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Release v2.0.0
 
+- [#789](https://github.com/IAMconsortium/pyam/pull/789) Support region-aggregation with weights-index >> data-index
+
 ## Highlights
 
 - Use **ixmp4** as dependency for better integration with the IIASA Scenario Explorer database infrastructure 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release v2.0.0
 
-- [#789](https://github.com/IAMconsortium/pyam/pull/789) Support region-aggregation with weights-index >> data-index
+- [#792](https://github.com/IAMconsortium/pyam/pull/792) Support region-aggregation with weights-index >> data-index
 
 ## Highlights
 

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -116,7 +116,10 @@ def _aggregate_region(
         raise ValueError("Using weights and components in one operation not supported.")
 
     # default subregions to all regions other than `region`
-    subregions = subregions or df._all_other_regions(region, variable)
+    if weight is None:
+        subregions = subregions or df._all_other_regions(region, variable)
+    else:
+        subregions = subregions or df._all_other_regions(region, [variable, weight])
 
     if not len(subregions):
         logger.info(

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 
 import numpy as np
 import pandas as pd
@@ -238,7 +237,7 @@ def test_check_aggregate_region_log(simple_df, caplog):
 @pytest.mark.parametrize(
     "variable",
     (
-        ("Primary Energy"),
+        "Primary Energy",
         (["Primary Energy", "Primary Energy|Coal", "Primary Energy|Wind"]),
     ),
 )
@@ -252,7 +251,7 @@ def test_aggregate_region_append(simple_df, variable):
 @pytest.mark.parametrize(
     "variable",
     (
-        ("Primary Energy"),
+        "Primary Energy",
         (["Primary Energy", "Primary Energy|Coal", "Primary Energy|Wind"]),
     ),
 )
@@ -315,7 +314,12 @@ def test_aggregate_region_with_weights(simple_df, caplog):
     exp = simple_df.filter(variable=v, region="World")
     assert_iamframe_equal(simple_df.aggregate_region(v, weight=w), exp)
 
-    # test that dropping negative weights works as expected
+def test_aggregate_region_with_negative_weights(simple_df, caplog):
+    # carbon price shouldn't be summed but be weighted by emissions
+    v = "Price|Carbon"
+    w = "Emissions|CO2"
+
+    # dropping negative weights works as expected
     neg_weights_df = simple_df.copy()
     neg_weights_df._data[18] = -6
     exp = simple_df.filter(variable=v, region="World", year=2010)
@@ -329,7 +333,7 @@ def test_aggregate_region_with_weights(simple_df, caplog):
     idx = caplog.messages.index(msg)
     assert caplog.records[idx].levelname == "WARNING"
 
-    # test that not dropping negative weights works as expected
+    # *not* dropping negative weights works as expected
     exp = simple_df.filter(variable=v, region="World")
     exp._data[0] = -8
     assert_iamframe_equal(

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -360,7 +360,9 @@ def test_aggregate_region_with_weights_inconsistent_index(
     log_message = "\n0  " + log_message + "model_a   scen_a  reg_b  2010"
     if simple_df.time_domain == "datetime":
         time_col = "     time"
-        log_message = log_message.replace("2005", "2005-6-17").replace(" 2010", "2010-07-21")
+        log_message = log_message.replace(" 2005", "2005-06-17").replace(
+            " 2010", "2010-07-21"
+        )
     else:
         time_col = "year"
 
@@ -373,7 +375,7 @@ def test_aggregate_region_with_weights_inconsistent_index(
     # missing data row prints a warning (data-index is a subset of weight-index)
     exp = simple_df.filter(variable=v, region="World")
     if not filter_arg:
-        exp._data[0] = 1.
+        exp._data[0] = 1.0
     exp._data[1] = 30.0
     _df = simple_df.filter(variable=v, region="reg_b", keep=False, **filter_arg)
     assert_iamframe_equal(_df.aggregate_region(v, weight=w), exp)

--- a/tests/test_feature_growth_rate.py
+++ b/tests/test_feature_growth_rate.py
@@ -66,5 +66,5 @@ def test_growth_rate_timeseries(x2010, rates):
 def test_growth_rate_timeseries_fails(value):
     """Check that a timeseries reaching/crossing 0 raises"""
 
-    with pytest.raises(ValueError, match="Cannot compute growth rate when*."):
+    with pytest.raises(ValueError, match="Cannot compute growth rate when"):
         growth_rate(pd.Series([1.0, value]))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -43,7 +43,7 @@ def test_not_a_file():
 
 def test_io_list():
     # initializing with a list raises an error
-    match = r"Initializing from list is not supported,*."
+    match = "Initializing from list is not supported,"
     with pytest.raises(ValueError, match=match):
         IamDataFrame([1, 2])
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR improves the handling of region-aggregation when variables and weights have an inconsistent index.

Now, if weights are missing, a ValueError is raised with (the head of) a list of missing rows. If variable data is missing, a warning is written to the log with (the head of) a list of missing rows.

closes #558
