### PR TITLE
Raise explicit error message if no connection to IIASA manager service

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
 # Next Release
+
+- [#796](https://github.com/IAMconsortium/pyam/pull/796] Raise explicit error message if no connection to IIASA manager service
 - [#794](https://github.com/IAMconsortium/pyam/pull/794] Fixed wrong color codes for AR6 Illustrative Pathways
 
 # Release v2.0.0

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -66,12 +66,13 @@ def _check_response(r, msg="Error connecting to IIASA database", error=RuntimeEr
 
 class SceSeAuth(AuthBase):
     def __init__(self, creds: str = None, auth_url: str = _AUTH_URL):
-        """Connection to the Scenario Services Manager AAC service.
+        """Connection to the Scenario Services manager service for authentication.
 
         Parameters
         ----------
         creds : pathlib.Path or str, optional
-            Path to a file with authentication credentials
+            Path to a file with authentication credentials. This feature is deprecated,
+            please run `ixmp4 login <username>` in a console instead.
         auth_url : str, optional
             Url of the authentication service
         """

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -96,6 +96,10 @@ class SceSeAuth(AuthBase):
                 f"{IXMP4_LOGIN} instead."
             )
 
+        # self.auth is None if connection to manager service cannot be established
+        if self.auth is None:
+            raise httpx.ConnectError("No connection to IIASA manager service.")
+
         # explicit token for anonymous login is not necessary for ixmp4 platforms
         # but is required for legacy Scenario Explorer databases
         if self.auth.user.username == "@anonymous":

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -87,6 +87,7 @@ class SceSeAuth(AuthBase):
             else:
                 self.auth = ixmp4.conf.settings.default_auth
         elif isinstance(creds, Path) or is_str(creds):
+            deprecation_warning(f"{IXMP4_LOGIN}.", "Using a pyam-credentials file")
             self.auth = _read_config(creds)
         else:
             raise DeprecationWarning(


### PR DESCRIPTION
# Description of PR

This PR fixes an ixmp4-integration issue where an AttributeError is raised (instead of a ConnectError) if the connection to the IIASA ScSe manager service cannot be established.
