### PR TITLE
Add `to_ixmp4()` method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Next release
+
+- [#797](https://github.com/IAMconsortium/pyam/pull/797) Add `to_ixmp4()` method to write to an **ixmp4** platform
+
 # Release v2.1.0
 
 ## Highlights
@@ -10,7 +14,6 @@
 
 - [#804](https://github.com/IAMconsortium/pyam/pull/804) Support filters as direct keyword arguments for `validate()` method
 - [#801](https://github.com/IAMconsortium/pyam/pull/801) Support initializing with `meta` dataframe in long format
-- [#797](https://github.com/IAMconsortium/pyam/pull/797) Add `to_ixmp4()` method to write to an **ixmp4** platform
 - [#796](https://github.com/IAMconsortium/pyam/pull/796) Raise explicit error message if no connection to IIASA manager service
 - [#794](https://github.com/IAMconsortium/pyam/pull/794) Fix wrong color codes for AR6 Illustrative Pathways
 - [#792](https://github.com/IAMconsortium/pyam/pull/792) Support region-aggregation with weights-index >> data-index

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 - [#804](https://github.com/IAMconsortium/pyam/pull/804) Support filters as direct keyword arguments for `validate()` method
 - [#801](https://github.com/IAMconsortium/pyam/pull/801) Support initializing with `meta` dataframe in long format
 - [#797](https://github.com/IAMconsortium/pyam/pull/797] Add `to_ixmp4()` method to write to an **ixmp4** platform
+- [#796](https://github.com/IAMconsortium/pyam/pull/796) Raise explicit error message if no connection to IIASA manager service
 - [#794](https://github.com/IAMconsortium/pyam/pull/794) Fix wrong color codes for AR6 Illustrative Pathways
 - [#792](https://github.com/IAMconsortium/pyam/pull/792) Support region-aggregation with weights-index >> data-index
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 - [#804](https://github.com/IAMconsortium/pyam/pull/804) Support filters as direct keyword arguments for `validate()` method
 - [#801](https://github.com/IAMconsortium/pyam/pull/801) Support initializing with `meta` dataframe in long format
-- [#797](https://github.com/IAMconsortium/pyam/pull/797] Add `to_ixmp4()` method to write to an **ixmp4** platform
+- [#797](https://github.com/IAMconsortium/pyam/pull/797) Add `to_ixmp4()` method to write to an **ixmp4** platform
 - [#796](https://github.com/IAMconsortium/pyam/pull/796) Raise explicit error message if no connection to IIASA manager service
 - [#794](https://github.com/IAMconsortium/pyam/pull/794) Fix wrong color codes for AR6 Illustrative Pathways
 - [#792](https://github.com/IAMconsortium/pyam/pull/792) Support region-aggregation with weights-index >> data-index

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 - [#804](https://github.com/IAMconsortium/pyam/pull/804) Support filters as direct keyword arguments for `validate()` method
 - [#801](https://github.com/IAMconsortium/pyam/pull/801) Support initializing with `meta` dataframe in long format
-- [#796](https://github.com/IAMconsortium/pyam/pull/796) Raise explicit error message if no connection to IIASA manager service
+- [#797](https://github.com/IAMconsortium/pyam/pull/797] Add `to_ixmp4()` method to write to an **ixmp4** platform
 - [#794](https://github.com/IAMconsortium/pyam/pull/794) Fix wrong color codes for AR6 Illustrative Pathways
 - [#792](https://github.com/IAMconsortium/pyam/pull/792) Support region-aggregation with weights-index >> data-index
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -11,6 +11,8 @@ from pandas.api.types import is_integer
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import ixmp4
+
 from pyam.slice import IamSlice
 from pyam.filter import filter_by_time_domain, filter_by_year, filter_by_dt_arg
 
@@ -2332,6 +2334,26 @@ class IamDataFrame(object):
 
         # append to `self` or return as `IamDataFrame`
         return self._finalize(_value, append=append)
+
+    def to_ixmp4(self, platform: ixmp4.Platform):
+        """Save all scenarios as new default runs in an ixmp4 platform database instance
+
+        Parameters
+        ----------
+        platform : :class:`ixmp4.Platform` or str
+            The ixmp4 platform database instance to which the scenario data is saved
+        """
+        if not isinstance(platform, ixmp4.Platform):
+            platform = ixmp4.Platform(platform)
+
+        for model, scenario in self.index:
+            _df = self.filter(model=model, scenario=scenario)
+
+            run = platform.Run(model=model, scenario=scenario, version="new")
+            run.iamc.add(_df.data)
+            for key, value in dict(_df.meta.iloc[0]).items():
+                run.meta[key] = value
+            run.set_as_default()
 
     def _to_file_format(self, iamc_index):
         """Return a dataframe suitable for writing to a file"""

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -13,6 +13,7 @@ from tempfile import TemporaryDirectory
 
 import ixmp4
 
+from pyam.ixmp4 import write_to_ixmp4
 from pyam.slice import IamSlice
 from pyam.filter import filter_by_time_domain, filter_by_year, filter_by_dt_arg
 
@@ -2343,17 +2344,7 @@ class IamDataFrame(object):
         platform : :class:`ixmp4.Platform` or str
             The ixmp4 platform database instance to which the scenario data is saved
         """
-        if not isinstance(platform, ixmp4.Platform):
-            platform = ixmp4.Platform(platform)
-
-        for model, scenario in self.index:
-            _df = self.filter(model=model, scenario=scenario)
-
-            run = platform.Run(model=model, scenario=scenario, version="new")
-            run.iamc.add(_df.data)
-            for key, value in dict(_df.meta.iloc[0]).items():
-                run.meta[key] = value
-            run.set_as_default()
+        write_to_ixmp4(self, platform)
 
     def _to_file_format(self, iamc_index):
         """Return a dataframe suitable for writing to a file"""

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2344,7 +2344,7 @@ class IamDataFrame(object):
         platform : :class:`ixmp4.Platform` or str
             The ixmp4 platform database instance to which the scenario data is saved
         """
-        write_to_ixmp4(self, platform)
+        write_to_ixmp4(platform, self)
 
     def _to_file_format(self, iamc_index):
         """Return a dataframe suitable for writing to a file"""

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -34,7 +34,7 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
     for model, scenario in df.index:
         _df = df.filter(model=model, scenario=scenario)
 
-        run = platform.Run(model=model, scenario=scenario, version="new")
+        run = platform.runs.create(model=model, scenario=scenario)
         run.iamc.add(_df.data)
         run.meta = dict(_df.meta.iloc[0])
         run.set_as_default()

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -26,7 +26,7 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
         ("regions", df.region, RegionModel),
         ("units", df.unit, UnitModel),
     ]:
-        platform_values = platform.__getattribute__(dimension).tabulate().name.values
+        platform_values = getattr(platform, dimension).tabulate().name.values
         if missing := set(values).difference(platform_values):
             raise model.NotFound(
                 ", ".join(missing)

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -27,7 +27,7 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
         ("units", df.unit, UnitModel),
     ]:
         platform_values = platform.__getattribute__(dimension).tabulate().name.values
-        if missing := [i for i in values if i not in platform_values]:
+        if missing := set(values).difference(platform_values):
             raise model.NotFound(
                 ", ".join(missing)
                 + f". Use `Platform.{dimension}.create()` to add the missing {dimension}."

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -1,5 +1,6 @@
 import ixmp4
-
+from ixmp4.core.region import RegionModel
+from ixmp4.core.unit import UnitModel
 
 def write_to_ixmp4(df, platform: ixmp4.Platform):
     """Save all scenarios as new default runs in an ixmp4 platform database instance
@@ -13,6 +14,18 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
     """
     if not isinstance(platform, ixmp4.Platform):
         platform = ixmp4.Platform(platform)
+
+    # TODO: implement a try-except to roll back changes if any error writing to platform
+    # depends on https://github.com/iiasa/ixmp4/issues/29
+    # quickfix: ensure that units and regions exist before writing
+
+    platform_regions = platform.regions.tabulate().name.values
+    if any([r not in platform_regions for r in df.region]):
+        raise RegionModel.NotFound()
+
+    platform_units = platform.units.tabulate().name.values
+    if any([r not in platform_regions for r in df.unit]):
+        raise UnitModel.NotFound()
 
     for model, scenario in df.index:
         _df = df.filter(model=model, scenario=scenario)

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -20,12 +20,18 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
     # quickfix: ensure that units and regions exist before writing
 
     platform_regions = platform.regions.tabulate().name.values
-    if any([r not in platform_regions for r in df.region]):
-        raise RegionModel.NotFound()
+    if missing := [r for r in df.region if r not in platform_regions]:
+        raise RegionModel.NotFound(
+            ", ".join(missing) +
+            ". Use `Platform.regions.create()` to add the missing region(s)."
+        )
 
     platform_units = platform.units.tabulate().name.values
-    if any([r not in platform_regions for r in df.unit]):
-        raise UnitModel.NotFound()
+    if missing := [u for u in df.unit if u not in platform_units]:
+        raise UnitModel.NotFound(
+            ", ".join(missing) +
+            ". Use `Platform.units.create()` to add the missing unit(s)."
+    )
 
     for model, scenario in df.index:
         _df = df.filter(model=model, scenario=scenario)

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -3,7 +3,7 @@ from ixmp4.core.region import RegionModel
 from ixmp4.core.unit import UnitModel
 
 
-def write_to_ixmp4(platform: ixmp4.Platform, df):
+def write_to_ixmp4(platform: ixmp4.Platform | str, df):
     """Save all scenarios as new default runs in an ixmp4 platform database instance
 
     Parameters

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -1,0 +1,24 @@
+import ixmp4
+
+
+def write_to_ixmp4(df, platform: ixmp4.Platform):
+    """Save all scenarios as new default runs in an ixmp4 platform database instance
+
+    Parameters
+    ----------
+    df : pyam.IamDataFrame
+        The IamDataFrame instance with scenario data
+    platform : :class:`ixmp4.Platform` or str
+        The ixmp4 platform database instance to which the scenario data is saved
+    """
+    if not isinstance(platform, ixmp4.Platform):
+        platform = ixmp4.Platform(platform)
+
+    for model, scenario in df.index:
+        _df = df.filter(model=model, scenario=scenario)
+
+        run = platform.Run(model=model, scenario=scenario, version="new")
+        run.iamc.add(_df.data)
+        for key, value in dict(_df.meta.iloc[0]).items():
+            run.meta[key] = value
+        run.set_as_default()

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -18,20 +18,16 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
     # TODO: implement a try-except to roll back changes if any error writing to platform
     # depends on https://github.com/iiasa/ixmp4/issues/29
     # quickfix: ensure that units and regions exist before writing
-
-    platform_regions = platform.regions.tabulate().name.values
-    if missing := [r for r in df.region if r not in platform_regions]:
-        raise RegionModel.NotFound(
-            ", ".join(missing) +
-            ". Use `Platform.regions.create()` to add the missing region(s)."
-        )
-
-    platform_units = platform.units.tabulate().name.values
-    if missing := [u for u in df.unit if u not in platform_units]:
-        raise UnitModel.NotFound(
-            ", ".join(missing) +
-            ". Use `Platform.units.create()` to add the missing unit(s)."
-    )
+    for dimension, values, model in [
+        ("regions", df.region, RegionModel),
+        ("units", df.unit, UnitModel)
+    ]:
+        platform_values = platform.__getattribute__(dimension).tabulate().name.values
+        if missing := [i for i in values if i not in platform_values]:
+            raise model.NotFound(
+                ", ".join(missing) +
+                f". Use `Platform.{dimension}.create()` to add the missing {dimension}."
+            )
 
     for model, scenario in df.index:
         _df = df.filter(model=model, scenario=scenario)

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -3,6 +3,7 @@ import ixmp4
 from ixmp4.core.region import RegionModel
 from ixmp4.core.unit import UnitModel
 
+
 def write_to_ixmp4(df, platform: ixmp4.Platform):
     """Save all scenarios as new default runs in an ixmp4 platform database instance
 
@@ -21,13 +22,13 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
     # quickfix: ensure that units and regions exist before writing
     for dimension, values, model in [
         ("regions", df.region, RegionModel),
-        ("units", df.unit, UnitModel)
+        ("units", df.unit, UnitModel),
     ]:
         platform_values = platform.__getattribute__(dimension).tabulate().name.values
         if missing := [i for i in values if i not in platform_values]:
             raise model.NotFound(
-                ", ".join(missing) +
-                f". Use `Platform.{dimension}.create()` to add the missing {dimension}."
+                ", ".join(missing)
+                + f". Use `Platform.{dimension}.create()` to add the missing {dimension}."
             )
 
     for model, scenario in df.index:

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -9,10 +9,10 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
 
     Parameters
     ----------
-    df : pyam.IamDataFrame
-        The IamDataFrame instance with scenario data
     platform : :class:`ixmp4.Platform` or str
         The ixmp4 platform database instance to which the scenario data is saved
+    df : pyam.IamDataFrame
+        The IamDataFrame instance with scenario data
     """
     if not isinstance(platform, ixmp4.Platform):
         platform = ixmp4.Platform(platform)

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -1,3 +1,4 @@
+import numpy as np
 import ixmp4
 from ixmp4.core.region import RegionModel
 from ixmp4.core.unit import UnitModel
@@ -35,5 +36,8 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
         run = platform.Run(model=model, scenario=scenario, version="new")
         run.iamc.add(_df.data)
         for key, value in dict(_df.meta.iloc[0]).items():
-            run.meta[key] = value
+            if isinstance(value, np.int64):
+                run.meta[key] = int(value)
+            else:
+                run.meta[key] = value
         run.set_as_default()

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -1,10 +1,9 @@
-import numpy as np
 import ixmp4
 from ixmp4.core.region import RegionModel
 from ixmp4.core.unit import UnitModel
 
 
-def write_to_ixmp4(df, platform: ixmp4.Platform):
+def write_to_ixmp4(platform: ixmp4.Platform, df):
     """Save all scenarios as new default runs in an ixmp4 platform database instance
 
     Parameters

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -13,6 +13,9 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
     df : pyam.IamDataFrame
         The IamDataFrame instance with scenario data
     """
+    if df.time_domain != "year":
+        raise NotImplementedError("Only time_domain='year' is supported for now")
+
     if not isinstance(platform, ixmp4.Platform):
         platform = ixmp4.Platform(platform)
 

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -36,9 +36,5 @@ def write_to_ixmp4(df, platform: ixmp4.Platform):
 
         run = platform.Run(model=model, scenario=scenario, version="new")
         run.iamc.add(_df.data)
-        for key, value in dict(_df.meta.iloc[0]).items():
-            if isinstance(value, np.int64):
-                run.meta[key] = int(value)
-            else:
-                run.meta[key] = value
+        run.meta = dict(_df.meta.iloc[0])
         run.set_as_default()

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -228,7 +228,7 @@ def _intuit_column_groups(df, index, include_index=False):
     elif isinstance(df, pd.DataFrame):
         existing_cols = existing_cols.union(df.columns)
 
-    # check that there is no column in the timeseries data with reserved names
+    # check that there is no unnamed column in the timeseries data
     if None in existing_cols:
         raise ValueError("Unnamed column in timeseries data: None")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.10, <3.12
 # Please also add a section "Dependency changes" to the release notes
 install_requires =
     iam-units >= 2020.4.21
-    ixmp4 >= 0.4.0
+    ixmp4 >= 0.6.0
     numpy >= 1.23.0, < 1.24
 #    requests  included via ixmp4
 #    httpx[http2] included via ixmp4

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -8,7 +8,7 @@ from ixmp4.core.unit import UnitModel
 def test_to_ixmp4_missing_region_raises(test_df_year):
     """Writing to platform raises if region not defined"""
     platform = Platform(_backend=SqliteTestBackend())
-    with pytest.raises(RegionModel.NotFound, match="World. Use `Platform"):
+    with pytest.raises(RegionModel.NotFound, match="World. Use `Platform.regions."):
         test_df_year.to_ixmp4(platform=platform)
 
 
@@ -16,7 +16,7 @@ def test_to_ixmp4_missing_unit_raises(test_df_year):
     """Writing to platform raises if unit not defined"""
     platform = Platform(_backend=SqliteTestBackend())
     platform.regions.create(name="World", hierarchy="common")
-    with pytest.raises(UnitModel.NotFound, match="EJ/yr. Use `Platform"):
+    with pytest.raises(UnitModel.NotFound, match="EJ/yr. Use `Platform.units."):
         test_df_year.to_ixmp4(platform=platform)
 
 

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -20,11 +20,16 @@ def test_to_ixmp4_missing_unit_raises(test_df_year):
         test_df_year.to_ixmp4(platform=platform)
 
 
-def test_ixmp4_integration(test_df_year):
+def test_ixmp4_integration(test_df):
     """Write an IamDataFrame to the platform"""
     platform = Platform(_backend=SqliteTestBackend())
     platform.regions.create(name="World", hierarchy="common")
     platform.units.create(name="EJ/yr")
-    test_df_year.to_ixmp4(platform=platform)
+
+    if test_df.time_domain == "year":
+        test_df.to_ixmp4(platform=platform)
+    else:
+        with pytest.raises(NotImplementedError):
+            test_df.to_ixmp4(platform=platform)
 
     # TODO add test for reading data from ixmp4 platform

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -1,0 +1,20 @@
+import pytest
+from ixmp4.core import Platform
+from ixmp4.data.backend import SqliteTestBackend
+from ixmp4.core.region import RegionModel
+from ixmp4.core.unit import UnitModel
+
+
+def test_to_ixmp4_missing_region_raises(test_df_year):
+    """Writing to platform raises if region not defined"""
+    platform = Platform(_backend=SqliteTestBackend())
+    with pytest.raises(RegionModel.NotFound):
+        test_df_year.to_ixmp4(platform=platform)
+
+
+def test_to_ixmp4_missing_unit_raises(test_df_year):
+    """Writing to platform raises if unit not defined"""
+    platform = Platform(_backend=SqliteTestBackend())
+    platform.regions.create(name="World", hierarchy="common")
+    with pytest.raises(UnitModel.NotFound):
+        test_df_year.to_ixmp4(platform=platform)

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -18,3 +18,11 @@ def test_to_ixmp4_missing_unit_raises(test_df_year):
     platform.regions.create(name="World", hierarchy="common")
     with pytest.raises(UnitModel.NotFound, match="EJ/yr. Use `Platform"):
         test_df_year.to_ixmp4(platform=platform)
+
+
+def test_ixmp4_integration(test_df):
+    """Write an IamDataFrame to the platform"""
+    platform = Platform(_backend=SqliteTestBackend())
+    platform.regions.create(name="World", hierarchy="common")
+    platform.units.create(name="EJ/yr")
+    test_df.to_ixmp4(platform=platform)

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -8,7 +8,7 @@ from ixmp4.core.unit import UnitModel
 def test_to_ixmp4_missing_region_raises(test_df_year):
     """Writing to platform raises if region not defined"""
     platform = Platform(_backend=SqliteTestBackend())
-    with pytest.raises(RegionModel.NotFound):
+    with pytest.raises(RegionModel.NotFound, match="World. Use `Platform"):
         test_df_year.to_ixmp4(platform=platform)
 
 
@@ -16,5 +16,5 @@ def test_to_ixmp4_missing_unit_raises(test_df_year):
     """Writing to platform raises if unit not defined"""
     platform = Platform(_backend=SqliteTestBackend())
     platform.regions.create(name="World", hierarchy="common")
-    with pytest.raises(UnitModel.NotFound):
+    with pytest.raises(UnitModel.NotFound, match="EJ/yr. Use `Platform"):
         test_df_year.to_ixmp4(platform=platform)

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -20,9 +20,9 @@ def test_to_ixmp4_missing_unit_raises(test_df_year):
         test_df_year.to_ixmp4(platform=platform)
 
 
-def test_ixmp4_integration(test_df):
+def test_ixmp4_integration(test_df_year):
     """Write an IamDataFrame to the platform"""
     platform = Platform(_backend=SqliteTestBackend())
     platform.regions.create(name="World", hierarchy="common")
     platform.units.create(name="EJ/yr")
-    test_df.to_ixmp4(platform=platform)
+    test_df_year.to_ixmp4(platform=platform)

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -26,3 +26,5 @@ def test_ixmp4_integration(test_df_year):
     platform.regions.create(name="World", hierarchy="common")
     platform.units.create(name="EJ/yr")
     test_df_year.to_ixmp4(platform=platform)
+
+    # TODO add test for reading data from ixmp4 platform


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a method `to_ixmp4()` to easily save all scenarios in an IamDataFrame (including meta indicators) to an ixmp4 platform database instance.

The method name `to_ixmp4()` doesn't seem elegant, any alternative suggestions of comments?
