### PR TITLE
Update documentation link in first-steps tutorial to `require_data()`

### DIFF
--- a/docs/tutorials/pyam_first_steps.ipynb
+++ b/docs/tutorials/pyam_first_steps.ipynb
@@ -509,7 +509,10 @@
    "source": [
     "### Check for required variables\n",
     "\n",
-    "We first use the [require_variable()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.require_variable) function to assert that the scenarios contain data for the expected timeseries."
+    "We first use the [require_data()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.require_data) function to assert that the scenarios contain data for the expected timeseries.\n",
+    "\n",
+    "This method returns the list of scenarios and data rows where the required arguments are missing.\n",
+    "If the method returns **None**, all required data are present."
    ]
   },
   {
@@ -534,8 +537,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The two cells above show that all scenarios report primary-energy data, but not all scenarios provide this timeseries until the end of the century.\n",
-    "\n",
+    "The two cells above show that all scenarios report primary-energy data, but not all scenarios provide this timeseries until the end of the century."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Validate numerical values in the timeseries data\n",
     "\n",
     "The [validate()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.validate) function performs checks on specific values of timeseries data. The `criteria` argument specifies a valid range by an upper and lower bound (`up`, `lo`) for a variable and a subset of years to which the validation is applied - all scenarios with a value in at least one year outside that range are considered to *not satisfy* the validation. The function returns a list of data points not satisfying the criteria.\n",

--- a/docs/tutorials/pyam_first_steps.ipynb
+++ b/docs/tutorials/pyam_first_steps.ipynb
@@ -511,7 +511,7 @@
     "\n",
     "We first use the [require_data()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.require_data) function to assert that the scenarios contain data for the expected timeseries.\n",
     "\n",
-    "This method returns the list of scenarios and data rows where the required arguments are missing.\n",
+    "This method returns the list of scenarios and data rows where any combination of the required arguments are missing.  \n",
     "If the method returns **None**, all required data are present."
    ]
   },


### PR DESCRIPTION
# Description of PR

Per a comment by @phackstock and @jkikstra, this PR fixes the explanations in the first-steps tutorial to point to the new `require_data()` method.
