### PR TITLE
Avoid misleading attribute-reference in iiasa.Connection docstring

### DIFF
--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -139,8 +139,8 @@ class Connection(object):
     ----------
     name : str, optional
         The name of a database API.
-        See :attr:`pyam.iiasa.Connection.valid_connections` for a list
-        of available APIs.
+        Use :attr:`valid_connections <pyam.iiasa.Connection.valid_connections>`
+        for a list of available APIs.
     creds : str or :class:`pathlib.Path`, optional
         By default, the class will search for user credentials which
         were set using :meth:`pyam.iiasa.set_config`.

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -585,7 +585,8 @@ def read_iiasa(
     ----------
     name : str
         | Name of an IIASA Scenario Explorer database instance.
-        | See :attr:`pyam.iiasa.Connection.valid_connections`.
+        | Use :attr:`valid_connections <pyam.iiasa.Connection.valid_connections>`
+          for a list of available instances.
     default_only : bool, optional
         If `True`, return *only* the default version of a model/scenario.
         If `False`, return all versions.
@@ -628,7 +629,8 @@ def lazy_read_iiasa(
         either xlsx or csv.
     name : str
         | Name of an IIASA Scenario Explorer database instance.
-        | See :attr:`pyam.iiasa.Connection.valid_connections`.
+        | Use :attr:`valid_connections <pyam.iiasa.Connection.valid_connections>`
+          for a list of available instances.
     default_only : bool, optional
         If `True`, return *only* the default version of a model/scenario.
         If `False`, return all versions.


### PR DESCRIPTION
# Description of PR

Per an observation by @Rlamboll, the current docstring of the **iiasa.Connection** class is misleading because it states 

> See [pyam.iiasa.Connection.valid_connections](https://pyam-iamc.readthedocs.io/en/latest/api/iiasa.html#pyam.iiasa.Connection.valid_connections) for a list of available APIs.

when a user actually has to do `pyam.iiasa.Connection().valid_connections`.

This PR changes the docstring to only show the attribute-name in the docstring (instead of `pyam.iiasa...`) while maintaining a functioning link to the docs of that attribute.