### PR TITLE
Support initializing with `meta` dataframe in long format

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 # Next Release
 
-- [#796](https://github.com/IAMconsortium/pyam/pull/796] Raise explicit error message if no connection to IIASA manager service
-- [#794](https://github.com/IAMconsortium/pyam/pull/794] Fixed wrong color codes for AR6 Illustrative Pathways
+- [#801](https://github.com/IAMconsortium/pyam/pull/801) Support initializing with `meta` dataframe in long format
+- [#796](https://github.com/IAMconsortium/pyam/pull/796) Raise explicit error message if no connection to IIASA manager service
+- [#794](https://github.com/IAMconsortium/pyam/pull/794) Fixed wrong color codes for AR6 Illustrative Pathways
 
 # Release v2.0.0
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -84,12 +84,13 @@ class IamDataFrame(object):
 
     Parameters
     ----------
-    data : :class:`pandas.DataFrame` or file-like object as str or :class:`pathlib.Path`
+    data : :class:`pandas.DataFrame`, :class:`pathlib.Path` or file-like object
         Scenario timeseries data following the IAMC data format or
         a supported variation as pandas object or a path to a file.
     meta : :class:`pandas.DataFrame`, optional
-        A dataframe with suitable 'meta' indicators for the new instance.
-        The index will be downselected to scenarios present in `data`.
+        A dataframe with suitable 'meta' indicators in wide (indicator as column name)
+        or long (key/value columns) format.
+        The dataframe will be downselected to scenarios present in `data`.
     index : list, optional
         Columns to use for resulting IamDataFrame index.
     kwargs

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -147,10 +147,16 @@ class IamDataFrame(object):
 
         # if meta is given explicitly, verify that index and column names are valid
         if meta is not None:
+            if meta.index.names == [None]:
+                meta.set_index(index, inplace=True)
             if not meta.index.names == index:
                 raise ValueError(
                     f"Incompatible `index={index}` with `meta.index={meta.index.names}`"
                 )
+            # if meta is in "long" format as key-value columns, cast to wide format
+            if all(meta.columns == ["key", "value"]):
+                meta = meta.pivot(values="value", columns="key")
+                meta.columns.name = None
 
         # try casting to Path if file-like is string or LocalPath or pytest.LocalPath
         try:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -154,7 +154,7 @@ class IamDataFrame(object):
                     f"Incompatible `index={index}` with `meta.index={meta.index.names}`"
                 )
             # if meta is in "long" format as key-value columns, cast to wide format
-            if all(meta.columns == ["key", "value"]):
+            if len(meta.columns) == 2 and all(meta.columns == ["key", "value"]):
                 meta = meta.pivot(values="value", columns="key")
                 meta.columns.name = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ META_DF = pd.DataFrame(
         ["model_a", "scen_b", 2, np.nan],
     ],
     columns=META_IDX + META_COLS,
-).set_index(META_IDX)
+)
 
 
 FULL_FEATURE_DF = pd.DataFrame(


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

In preparation for better integration with ixmp4, this PR supports passing a **meta** dataframe with model-scenario "index" as columns and/or in long-format as key-value columns.
