### PR TITLE
Update reference values for WB-datareader test

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-Copyright 2017-2023 IIASA and the pyam developer team
+Copyright 2017-2024 IIASA and the pyam developer team
 
 The **pyam** package is licensed under the Apache License, Version 2.0 (the "License");
 you may not use the package except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ doi: [10.21105/joss.01095](https://doi.org/10.21105/joss.01095).
 License
 -------
 
-Copyright 2017-2023 IIASA and the pyam developer team
+Copyright 2017-2024 IIASA and the pyam developer team
 
 The **pyam** package is licensed
 under the Apache License, Version 2.0 (the "License");  

--- a/manuscripts/ORE/source/conf.py
+++ b/manuscripts/ORE/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "pyam"
-copyright = "2023 IIASA and the pyam developer team"
+copyright = "2024 IIASA and the pyam developer team"
 author = "Daniel Huppmann, Matthew Gidden, et al."
 
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -992,8 +992,6 @@ class IamDataFrame(object):
             A dataframe of missing (combinations of) elements for all scenarios.
         """
 
-        # TODO: option to require values in certain ranges, see `_apply_criteria()`
-
         # create mapping of required dimensions
         required = {}
         for dim, value in [

--- a/tests/test_datareader.py
+++ b/tests/test_datareader.py
@@ -21,7 +21,7 @@ WB_REASON = "World Bank API unavailable"
 WB_DF = pd.DataFrame(
     [
         ["foo", "WDI", "Canada", "GDP", "n/a", 42793.1, 43704.4, 44680.8],
-        ["foo", "WDI", "Mexico", "GDP", "n/a", 17262.3, 17693.0, 17846.0],
+        ["foo", "WDI", "Mexico", "GDP", "n/a", 18634.9, 19017.8, 19144.0],
         ["foo", "WDI", "United States", "GDP", "n/a", 51569.8, 53035.7, 54395.4],
     ],
     columns=IAMC_IDX + [2003, 2004, 2005],


### PR DESCRIPTION
# Description of PR

The values in the WB-dataset were updated, causing the unit-tests against the data API to fail. This PR updates the expected values and bumps the copyright year in anticipation of the new year.
