### PR TITLE
Fix a corner case in region-aggregation with missing data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Next Release
+
+- [#813](https://github.com/IAMconsortium/pyam/pull/813) Fix a corner case in region-aggregation with missing data
+
 # Release v2.1.0
 
 ## Highlights

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -168,7 +168,7 @@ def _aggregate_region(
             _df.index = replace_index_values(_df.index, "variable", mapping)
             _data = _data.add(_group_and_agg(_df, "region"), fill_value=0)
 
-    return _data
+    return _data.dropna()
 
 
 def _aggregate_time(df, variable, column, value, components, method="sum"):

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -385,8 +385,8 @@ def test_aggregate_region_with_weights_inconsistent_index(
 
     # missing data row prints a warning (data-index is a subset of weight-index)
     exp = simple_df.filter(variable=v, region="World")
-    if values == 4:
-        exp.filter(year=2005, inplace=True)
+    if filter_arg == dict(year=2010):
+        exp.filter(year=2005, inplace=True)  # in this case, there are no 2010 data
     exp._data.iloc[:] = values
     _df = simple_df.filter(variable=v, keep=False, **filter_arg)
     assert_iamframe_equal(_df.aggregate_region(v, weight=w), exp)

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -359,7 +359,7 @@ def test_aggregate_region_with_negative_weights(simple_df, caplog):
         (
             dict(year=2010),
             "0  model_a   scen_a  reg_a  2010\n1  model_a   scen_a  reg_b  2010",
-            (4, 30),
+            4,
         ),
     ),
 )
@@ -385,6 +385,8 @@ def test_aggregate_region_with_weights_inconsistent_index(
 
     # missing data row prints a warning (data-index is a subset of weight-index)
     exp = simple_df.filter(variable=v, region="World")
+    if values == 4:
+        exp.filter(year=2005, inplace=True)
     exp._data.iloc[:] = values
     _df = simple_df.filter(variable=v, keep=False, **filter_arg)
     assert_iamframe_equal(_df.aggregate_region(v, weight=w), exp)

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -356,6 +356,11 @@ def test_aggregate_region_with_negative_weights(simple_df, caplog):
             "0  model_a   scen_a  reg_b  2010",
             (4, 30),
         ),
+        (
+            dict(year=2010),
+            "0  model_a   scen_a  reg_a  2010\n1  model_a   scen_a  reg_b  2010",
+            (4, 30),
+        ),
     ),
 )
 def test_aggregate_region_with_weights_inconsistent_index(


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR fixes a corner-case in the region-aggregation-with weights if all data for a year are missing.
