### PR TITLE
Ensure that `rename()` reorders the index

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1195,6 +1195,7 @@ class IamDataFrame(object):
         # quickfix for issue 811, to be removed when tackling issue 812
         ret._data.sort_index(inplace=True)
         ret.meta.sort_index(inplace=True)
+        ret._exclude.sort_index(inplace=True)
 
         if not inplace:
             return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1192,6 +1192,10 @@ class IamDataFrame(object):
         if has_duplicates:
             ret._data = ret._data.reset_index().groupby(ret.dimensions).sum().value
 
+        # quickfix for issue 811, to be removed when tackling issue 812
+        ret._data.sort_index(inplace=True)
+        ret.meta.sort_index(inplace=True)
+
         if not inplace:
             return ret
 

--- a/tests/test_feature_rename.py
+++ b/tests/test_feature_rename.py
@@ -245,7 +245,6 @@ def test_rename_index(test_df):
         exp.columns = list(map(int, exp.columns))
     else:
         exp.columns = pd.to_datetime(exp.columns)
-
     pdt.assert_frame_equal(obs.timeseries(), exp)
 
     # test meta changes
@@ -267,30 +266,25 @@ def test_rename_index(test_df):
 
 
 def test_rename_append(test_df):
-    mapping = {"model": {"model_a": "model_b"}, "scenario": {"scen_a": "scen_c"}}
-    obs = test_df.rename(mapping, append=True)
+    obs = test_df.rename(
+        model={"model_a": "model_b"}, scenario={"scen_a": "scen_c"}, append=True
+    )
 
     # test data changes
-    times = [2005, 2010] if obs.time_col == "year" else obs.data.time.unique()
-    exp = (
-        pd.DataFrame(
-            [
-                ["model_a", "scen_a", "World", "Primary Energy", "EJ/yr", 1, 6.0],
-                ["model_a", "scen_a", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
-                ["model_a", "scen_b", "World", "Primary Energy", "EJ/yr", 2, 7],
-                ["model_b", "scen_c", "World", "Primary Energy", "EJ/yr", 1, 6.0],
-                ["model_b", "scen_c", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
-            ],
-            columns=IAMC_IDX + list(times),
-        )
-        .set_index(IAMC_IDX)
-        .sort_index()
-    )
-    if "year" in test_df.data:
+    exp = pd.DataFrame(
+        [
+            ["model_a", "scen_a", "World", "Primary Energy", "EJ/yr", 1, 6.0],
+            ["model_a", "scen_a", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
+            ["model_a", "scen_b", "World", "Primary Energy", "EJ/yr", 2, 7],
+            ["model_b", "scen_c", "World", "Primary Energy", "EJ/yr", 1, 6.0],
+            ["model_b", "scen_c", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
+        ],
+        columns=IAMC_IDX + list(obs.time),
+    ).set_index(IAMC_IDX)
+    if test_df.time_col == "year":
         exp.columns = list(map(int, exp.columns))
     else:
         exp.columns = pd.to_datetime(exp.columns)
-
     pdt.assert_frame_equal(obs.timeseries().sort_index(), exp)
 
     # test meta changes
@@ -303,6 +297,10 @@ def test_rename_append(test_df):
         columns=["model", "scenario"] + META_COLS,
     ).set_index(META_IDX)
     pdt.assert_frame_equal(obs.meta, exp)
+
+    # test 'exclude' changes
+    exp = pd.Series([False, False, False], index=exp.index)
+    pdt.assert_series_equal(obs.exclude, exp)
 
 
 def test_rename_duplicates():

--- a/tests/test_feature_rename.py
+++ b/tests/test_feature_rename.py
@@ -69,7 +69,7 @@ def test_append_other_scenario(test_df):
 
     # sort columns for assertion in older pandas versions
     df.meta = df.meta.reindex(columns=exp.columns)
-    pd.testing.assert_frame_equal(df.meta, exp)
+    pdt.assert_frame_equal(df.meta, exp)
 
     # assert that appending data works as expected
     ts = df.timeseries()
@@ -106,7 +106,7 @@ def test_append_same_scenario(test_df):
     # assert that merging of meta works as expected
     exp = test_df.meta.copy()
     exp["col2"] = [np.nan, "b"]
-    pd.testing.assert_frame_equal(df.meta, exp)
+    pdt.assert_frame_equal(df.meta, exp)
 
     # assert that appending data works as expected
     ts = df.timeseries()
@@ -167,7 +167,7 @@ def test_rename_data_cols_by_dict():
         variable={"test_1": "test", "test_3": "test"}, region={"region_a": "region_c"}
     )
     obs = RENAME_DF.rename(mapping, check_duplicates=False).data.reset_index(drop=True)
-    pd.testing.assert_frame_equal(obs, EXP_RENAME_DF, check_index_type=False)
+    pdt.assert_frame_equal(obs, EXP_RENAME_DF, check_index_type=False)
 
 
 def test_rename_data_cols_by_kwargs():
@@ -176,7 +176,7 @@ def test_rename_data_cols_by_kwargs():
         "region": {"region_a": "region_c"},
     }
     obs = RENAME_DF.rename(**args, check_duplicates=False).data.reset_index(drop=True)
-    pd.testing.assert_frame_equal(obs, EXP_RENAME_DF, check_index_type=False)
+    pdt.assert_frame_equal(obs, EXP_RENAME_DF, check_index_type=False)
 
 
 def test_rename_data_cols_by_mixed():
@@ -185,7 +185,7 @@ def test_rename_data_cols_by_mixed():
         "region": {"region_a": "region_c"},
     }
     obs = RENAME_DF.rename(**args, check_duplicates=False).data.reset_index(drop=True)
-    pd.testing.assert_frame_equal(obs, EXP_RENAME_DF, check_index_type=False)
+    pdt.assert_frame_equal(obs, EXP_RENAME_DF, check_index_type=False)
 
 
 def test_rename_conflict(test_df):
@@ -291,7 +291,7 @@ def test_rename_append(test_df):
     else:
         exp.columns = pd.to_datetime(exp.columns)
 
-    pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
+    pdt.assert_frame_equal(obs.timeseries().sort_index(), exp)
 
     # test meta changes
     exp = pd.DataFrame(
@@ -302,7 +302,7 @@ def test_rename_append(test_df):
         ],
         columns=["model", "scenario"] + META_COLS,
     ).set_index(META_IDX)
-    pd.testing.assert_frame_equal(obs.meta, exp)
+    pdt.assert_frame_equal(obs.meta, exp)
 
 
 def test_rename_duplicates():
@@ -323,4 +323,4 @@ def test_rename_duplicates():
     )
 
     assert compare(obs, exp).empty
-    pd.testing.assert_frame_equal(obs.data, exp.data)
+    pdt.assert_frame_equal(obs.data, exp.data)

--- a/tests/test_feature_rename.py
+++ b/tests/test_feature_rename.py
@@ -233,7 +233,6 @@ def test_rename_index(test_df):
     obs = test_df.rename(model={"model_a": "model_c"}, scenario={"scen_a": "scen_b"})
 
     # test data changes
-    times = [2005, 2010] if obs.time_col == "year" else obs.data.time.unique()
     exp = (
         pd.DataFrame(
             [
@@ -241,11 +240,11 @@ def test_rename_index(test_df):
                 ["model_c", "scen_b", "World", "Primary Energy", "EJ/yr", 1, 6.0],
                 ["model_c", "scen_b", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
             ],
-            columns=IAMC_IDX + list(times),
+            columns=IAMC_IDX + list(obs.time),
         )
         .set_index(IAMC_IDX)
     )
-    if "year" in test_df.data:
+    if test_df.time_col == "year":
         exp.columns = list(map(int, exp.columns))
     else:
         exp.columns = pd.to_datetime(exp.columns)

--- a/tests/test_feature_rename.py
+++ b/tests/test_feature_rename.py
@@ -261,6 +261,10 @@ def test_rename_index(test_df):
     # check that the attributes are ordered correctly
     assert obs.model == ["model_a", "model_c"]
 
+    # test 'exclude' changes
+    exp = pd.Series([False, False], index=exp.index)
+    pdt.assert_series_equal(obs.exclude, exp)
+
 
 def test_rename_append(test_df):
     mapping = {"model": {"model_a": "model_b"}, "scenario": {"scen_a": "scen_c"}}

--- a/tests/test_feature_rename.py
+++ b/tests/test_feature_rename.py
@@ -233,17 +233,14 @@ def test_rename_index(test_df):
     obs = test_df.rename(model={"model_a": "model_c"}, scenario={"scen_a": "scen_b"})
 
     # test data changes
-    exp = (
-        pd.DataFrame(
-            [
-                ["model_a", "scen_b", "World", "Primary Energy", "EJ/yr", 2, 7],
-                ["model_c", "scen_b", "World", "Primary Energy", "EJ/yr", 1, 6.0],
-                ["model_c", "scen_b", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
-            ],
-            columns=IAMC_IDX + list(obs.time),
-        )
-        .set_index(IAMC_IDX)
-    )
+    exp = pd.DataFrame(
+        [
+            ["model_a", "scen_b", "World", "Primary Energy", "EJ/yr", 2, 7],
+            ["model_c", "scen_b", "World", "Primary Energy", "EJ/yr", 1, 6.0],
+            ["model_c", "scen_b", "World", "Primary Energy|Coal", "EJ/yr", 0.5, 3],
+        ],
+        columns=IAMC_IDX + list(obs.time),
+    ).set_index(IAMC_IDX)
     if test_df.time_col == "year":
         exp.columns = list(map(int, exp.columns))
     else:


### PR DESCRIPTION
# Description of PR

This PR ensures that `rename()` reorders the data and meta index.

closes #811
