### PR TITLE
Add a `pyam.iiasa.platforms()` function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next release
 
+- [#829](https://github.com/IAMconsortium/pyam/pull/829) Add a `pyam.iiasa.list_platforms()` function
 - [#826](https://github.com/IAMconsortium/pyam/pull/826) Add `read_ixmp4()` function and extend integration test
 - [#825](https://github.com/IAMconsortium/pyam/pull/825) Add support for Python 3.12
 - [#824](https://github.com/IAMconsortium/pyam/pull/824) Update ixmp4 requirement to >=0.7.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Next release
 
-- [#829](https://github.com/IAMconsortium/pyam/pull/829) Add a `pyam.iiasa.list_platforms()` function
+- [#829](https://github.com/IAMconsortium/pyam/pull/829) Add a `pyam.iiasa.platforms()` function for a list of available platforms
 - [#826](https://github.com/IAMconsortium/pyam/pull/826) Add `read_ixmp4()` function and extend integration test
 - [#825](https://github.com/IAMconsortium/pyam/pull/825) Add support for Python 3.12
 - [#824](https://github.com/IAMconsortium/pyam/pull/824) Update ixmp4 requirement to >=0.7.1

--- a/docs/api/iiasa.rst
+++ b/docs/api/iiasa.rst
@@ -44,7 +44,6 @@ You can list all available ixmp4 platforms hosted by IIASA using the following:
 .. autofunction:: list_platforms
    :noindex:
 
-
 *Scenario Explorer* instances (legacy service)
 ----------------------------------------------
 

--- a/docs/api/iiasa.rst
+++ b/docs/api/iiasa.rst
@@ -41,8 +41,7 @@ You will be prompted to enter your password.
 The *Scenario Apps* use the |ixmp4| package as a database backend.
 You can list all available ixmp4 platforms hosted by IIASA using the following:
 
-.. autofunction:: list_platforms
-   :noindex:
+.. autofunctions:: platforms
 
 *Scenario Explorer* instances (legacy service)
 ----------------------------------------------

--- a/docs/api/iiasa.rst
+++ b/docs/api/iiasa.rst
@@ -38,10 +38,15 @@ You will be prompted to enter your password.
 *Scenario Apps* instances
 -------------------------
 
-Coming soon...
+The *Scenario Apps* use the |ixmp4| package as a database backend.
+You can list all available ixmp4 platforms hosted by IIASA using the following:
 
-*Scenario Explorer* instances
------------------------------
+.. autofunction:: list_platforms
+   :noindex:
+
+
+*Scenario Explorer* instances (legacy service)
+----------------------------------------------
 
 The *Scenario Explorer* infrastructure developed by the Scenario Services and Scientific
 Software team was developed and used for projects from 2018 until 2023.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -330,6 +330,7 @@ intersphinx_mapping = {
     "pandas_datareader": ("https://pandas-datareader.readthedocs.io/en/stable", None),
     "unfccc_di_api": ("https://unfccc-di-api.readthedocs.io/en/stable", None),
     "nomenclature": ("https://nomenclature-iamc.readthedocs.io/en/stable", None),
+    "ixmp4": ("https://docs.ece.iiasa.ac.at/projects/ixmp4/en/stable", None),
 }
 
 # Set up the plotting gallery with plotly scraper

--- a/docs/tutorials/iiasa.ipynb
+++ b/docs/tutorials/iiasa.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pyam.iiasa.list_platforms()"
+    "pyam.iiasa.platforms()"
    ]
   },
   {

--- a/docs/tutorials/iiasa.ipynb
+++ b/docs/tutorials/iiasa.ipynb
@@ -4,42 +4,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Read directly from IIASA data resources\n",
+    "# Query data from the IIASA database infrastructure\n",
     "\n",
-    "The IIASA *Energy, Climate, and Environment* Program hosts a suite of **Scenario Explorer** instances and related infrastructure to support analysis of integrated-assessment pathways in IPCC reports and model comparison projects. \n",
-    "High-profile use cases include the [IAMC 1.5°C Scenario Explorer hosted by IIASA](https://data.ece.iiasa.ac.at/iamc-1.5c-explorer) supporting the *IPCC Special Report on Global Warming of 1.5°C* (SR15) and the Horizon 2020 project [CD-LINKS](https://data.ece.iiasa.ac.at/cd-links).\n",
+    "The IIASA *Energy, Climate, and Environment* Program hosts a suite of **Scenario Explorer** instances and related database infrastructure to support analysis of integrated-assessment pathways in IPCC reports and model comparison projects. \n",
+    "High-profile use cases include the [AR6 Scenario Explorer hosted by IIASA](https://data.ece.iiasa.ac.at/ar6) supporting the *IPCC' Sixth Assessment Report* (AR6) and the Horizon 2020 project [ENGAGE](https://data.ece.iiasa.ac.at/engage).\n",
     "\n",
-    "IIASA's [modeling platform infrastructure](http://software.ene.iiasa.ac.at/ixmp-server) and the Scenario Explorer UI is not only a great resource on its own, but it also allows the underlying datasets to be directly queried.\n",
-    "**pyam** takes advantage of this ability to allow you to easily pull data and work with it in your Python data processing and analysis workflow."
+    "IIASA's [modeling platform infrastructure](http://docs.ece.iiasa.ac.at/) and the scenario apps are not only a great resource on its own, but it also allows the underlying datasets to be queried directly via a Rest API.\n",
+    "The **pyam** package takes advantage of this ability to allow you to easily pull data and work with it in your Python data processing and analysis workflow."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Connecting to a data resource (aka the database API of a Scenario Explorer instance)\n",
+    "## Access and permission management for project-internal databases\n",
     "\n",
-    "Accessing a data resource is done via a **Connection** object.\n",
-    "By default, your can connect to all public Scenario Explorer instances. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pyam\n",
+    "By default, your can connect to all public scenario database instances.\n",
     "\n",
-    "conn = pyam.iiasa.Connection()\n",
-    "conn.valid_connections"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you have credentials to connect to a non-public or restricted Scenario Explorer instance,\n",
+    "If you have credentials to connect to a private, project-internal database instance,  \n",
     "you can store this information by running the following command in a console:\n",
     "\n",
     "```\n",
@@ -55,15 +37,78 @@
     "\n",
     "</div>\n",
     "\n",
-    "\n",
-    "\n",
-    "When initializing a new **Connection** instance, **pyam** will automatically search for the configuration in a known location."
+    "When connecting to a database, **pyam** will automatically search for the configuration in a known location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyam"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Connecting to ixmp4 database instances hosted by IIASA\n",
+    "\n",
+    "The *Scenario Apps* use the **ixmp4** package as a database backend.\n",
+    "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "The *Scenario Services* team is currently migrating database instances from the legacy *Scenario Explorer* infrastructure  \n",
+    "to the new *Scenario Apps* services based on the **ixmp4** package.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "You can list all available ixmp4 platforms hosted by IIASA using the following function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyam.iiasa.list_platforms()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connecting to a (legacy) Scenario Explorer database\n",
+    "\n",
+    "Accessing the database connected to a **Scenario Explorer** is done via a **Connection** object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = pyam.iiasa.Connection()\n",
+    "conn.valid_connections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading data from a database hosted by IIASA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The **pyam** package can read both from **ixmp4** databases (connected to a *Scenario App*)  \n",
+    "and the (legacy) **Scenario Explorer** infrastructure with the same function.\n",
+    "\n",
     "In this example, we will be retrieving data from the *IAMC 1.5°C Scenario Explorer hosted by IIASA*\n",
     "([link](https://data.ece.iiasa.ac.at/iamc-1.5c-explorer)),\n",
     "which provides the quantitative scenario ensemble underpinning\n",
@@ -316,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -46,7 +46,12 @@ DEFAULT_IIASA_CREDS = Path("~").expanduser() / ".local" / "pyam" / "iiasa.yaml"
 
 
 def platforms() -> None:
-    """Print all available ixmp4 platforms hosted by IIASA"""
+    """Print all available ixmp4 platforms hosted by IIASA
+
+    See Also
+    --------
+    ixmp4.conf.settings.manager.list_platforms
+    """
 
     _platforms = ixmp4.conf.settings.manager.list_platforms()
     utils.echo("IIASA platform".ljust(20) + "Access".ljust(10) + "Notice\n")

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -46,6 +46,7 @@ DEFAULT_IIASA_CREDS = Path("~").expanduser() / ".local" / "pyam" / "iiasa.yaml"
 
 
 def list_platforms():
+    """Print all available ixmp4 platforms hosted by IIASA"""
 
     platforms = ixmp4.conf.settings.manager.list_platforms()
     utils.echo("IIASA platform".ljust(20) + "Access".ljust(10) + "Notice\n")
@@ -217,8 +218,8 @@ class Connection(object):
     def valid_connections(self):
         """Return available resources (database API connections)"""
         logger.warning(
-            "IIASA is migrating to a new database infrastructure based on the ixmp4 package."
-            "Please use `pyam.iiasa.list_platforms()` to list available ixmp4 databases."
+            "IIASA is migrating to a database infrastructure using the ixmp4 package."
+            "Use `pyam.iiasa.list_platforms()` to list available ixmp4 databases."
         )
         return list(self._connection_map.keys())
 

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -46,7 +46,7 @@ DEFAULT_IIASA_CREDS = Path("~").expanduser() / ".local" / "pyam" / "iiasa.yaml"
 
 
 def platforms() -> None:
-    """Print all available ixmp4 platforms hosted by IIASA
+    """Print a list of available ixmp4 platforms hosted by IIASA
 
     See Also
     --------
@@ -224,7 +224,7 @@ class Connection(object):
         """Return available resources (database API connections)"""
         logger.warning(
             "IIASA is migrating to a database infrastructure using the ixmp4 package."
-            "Use `pyam.iiasa.list_platforms()` to list available ixmp4 databases."
+            "Use `pyam.iiasa.platforms()` to list available ixmp4 databases."
         )
         return list(self._connection_map.keys())
 

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -216,6 +216,10 @@ class Connection(object):
     @lru_cache()
     def valid_connections(self):
         """Return available resources (database API connections)"""
+        logger.warning(
+            "IIASA is migrating to a new database infrastructure based on the ixmp4 package."
+            "Please use `pyam.iiasa.list_platforms()` to list available ixmp4 databases."
+        )
         return list(self._connection_map.keys())
 
     def connect(self, name):

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -12,13 +12,14 @@ import numpy as np
 import pandas as pd
 import requests
 import yaml
+from ixmp4.cli import utils
 from ixmp4.conf import settings
 from ixmp4.conf.auth import ManagerAuth
 from requests.auth import AuthBase
 
 from pyam.core import IamDataFrame
 from pyam.logging import deprecation_warning
-from pyam.str import is_str
+from pyam.str import is_str, shorten
 from pyam.utils import (
     IAMC_IDX,
     META_IDX,
@@ -35,11 +36,29 @@ _CITE_MSG = """
 You are connected to the {} scenario explorer hosted by IIASA.
  If you use this data in any published format, please cite the
  data as provided in the explorer guidelines: {}
-""".replace("\n", "")
+""".replace(
+    "\n", ""
+)
 IXMP4_LOGIN = "Please run `ixmp4 login <username>` in a console"
 
 # path to local configuration settings
 DEFAULT_IIASA_CREDS = Path("~").expanduser() / ".local" / "pyam" / "iiasa.yaml"
+
+
+def list_platforms():
+
+    platforms = ixmp4.conf.settings.manager.list_platforms()
+    utils.echo("IIASA platform".ljust(20) + "Access".ljust(10) + "Notice\n")
+
+    for p in platforms:
+        utils.important(shorten(p.name, 20), nl=False)
+        utils.echo(str(p.accessibility.value.lower()).ljust(10), nl=False)
+
+        if p.notice is not None:
+            utils.echo(shorten(p.notice, 55), nl=False)
+        utils.echo()
+
+    utils.info("\n" + str(len(platforms)) + " total \n")
 
 
 def set_config(user, password, file=None):

--- a/pyam/iiasa.py
+++ b/pyam/iiasa.py
@@ -45,13 +45,13 @@ IXMP4_LOGIN = "Please run `ixmp4 login <username>` in a console"
 DEFAULT_IIASA_CREDS = Path("~").expanduser() / ".local" / "pyam" / "iiasa.yaml"
 
 
-def list_platforms():
+def platforms() -> None:
     """Print all available ixmp4 platforms hosted by IIASA"""
 
-    platforms = ixmp4.conf.settings.manager.list_platforms()
+    _platforms = ixmp4.conf.settings.manager.list_platforms()
     utils.echo("IIASA platform".ljust(20) + "Access".ljust(10) + "Notice\n")
 
-    for p in platforms:
+    for p in _platforms:
         utils.important(shorten(p.name, 20), nl=False)
         utils.echo(str(p.accessibility.value.lower()).ljust(10), nl=False)
 
@@ -59,7 +59,7 @@ def list_platforms():
             utils.echo(shorten(p.notice, 55), nl=False)
         utils.echo()
 
-    utils.info("\n" + str(len(platforms)) + " total \n")
+    utils.info("\n" + str(len(_platforms)) + " total \n")
 
 
 def set_config(user, password, file=None):

--- a/pyam/str.py
+++ b/pyam/str.py
@@ -65,18 +65,21 @@ def _find_depth(data, s="", level=None):
         # test = lambda x: level == x if x is not None else False
         def test(x):
             return level == x if x is not None else False
+
     elif level[-1] == "-":
         level = int(level[:-1])
 
         # test = lambda x: level >= x if x is not None else False
         def test(x):
             return level >= x if x is not None else False
+
     elif level[-1] == "+":
         level = int(level[:-1])
 
         # test = lambda x: level <= x if x is not None else False
         def test(x):
             return level <= x if x is not None else False
+
     else:
         raise ValueError("Unknown level type: `{}`".format(level))
 
@@ -141,3 +144,10 @@ def escape_regexp(s):
 def is_str(x):
     """Returns True if x is a string"""
     return isinstance(x, six.string_types)
+
+
+def shorten(value: str, length: int):
+    """Shorten a string to a given length adding `...`"""
+    if len(value) > length - 4:
+        value = value[: length - 4] + "..."
+    return value.ljust(length)

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -55,9 +55,13 @@ NON_DEFAULT_DF = pd.DataFrame(
 )
 
 
-def test_platforms():
+def test_platforms(capsys):
     # test that the function does not raise an error
     iiasa.platforms()
+    assert (
+        "public-test         public    This is a public ixmp4 test instance"
+        in capsys.readouterr().out
+    )
 
 
 def test_unknown_conn():

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -55,6 +55,11 @@ NON_DEFAULT_DF = pd.DataFrame(
 )
 
 
+def test_platforms():
+    # test that the function does not raise an error
+    iiasa.platforms()
+
+
 def test_unknown_conn():
     # connecting to an unknown API raises an error
     match = "You do not have access to instance 'foo' or it does not exist."


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds a method `pyam.iiasa.list_platforms()` as a shorthand for the ixmp4 function down in the config hierarchy, producing an output like:

```
IIASA platform      Access    Notice

public-test         public    This is a public ixmp4 test instance hosted by the ... 
ecemf               private   
genie               public    This is a development instance for the GENIE knowle... 
ssp-extensions      public    
ecemf-internal      private   

5 total 
```

I modified this from the corresponding method in ixmp4 showing name, access level and notice (instead of dsn), because this seems more relevant for a Python-API-user.

@meksor, if you agree, I can implement the corresponding change in ixmp4?

# Update

Renamed the function to `pyam.iiasa.connections()` to avoid naming conflict with the ixmp4 method.

