### PR TITLE
Add `test-platform` fixture for ixmp4 tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Bumped minimum version of pandas and numpy to fit **ixmp4**'s requirement.
 
 ## Individual updates
 
+- [#832](https://github.com/IAMconsortium/pyam/pull/832) Improve the test-suite for the ixmp4 integration
 - [#827](https://github.com/IAMconsortium/pyam/pull/827) Migrate to poetry for project management
 - [#830](https://github.com/IAMconsortium/pyam/pull/830) Implement more consistent logging behavior with **ixmp4**
 - [#829](https://github.com/IAMconsortium/pyam/pull/829) Add a `pyam.iiasa.platforms()` function for a list of available platforms

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -90,5 +90,6 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
 
         run = platform.runs.create(model=model, scenario=scenario)
         run.iamc.add(_df.data)
-        run.meta = dict(meta.loc[(model, scenario)])
+        if not meta.empty:
+            run.meta = dict(meta.loc[(model, scenario)])
         run.set_as_default()

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -59,7 +59,7 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
     if not isinstance(platform, ixmp4.Platform):
         platform = ixmp4.Platform(platform)
 
-    # TODO: implement a try-except to roll back changes if any error writing to platform
+    # TODO: implement try-except to roll back changes if any error writing to platform
     # depends on https://github.com/iiasa/ixmp4/issues/29
     # quickfix: ensure that units and regions exist before writing
     for dimension, values, model in [
@@ -74,10 +74,11 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
                 f"{dimension}."
             )
 
-    # The "version" meta-indicator should not be written to the database
+    # The "version" meta-indicator, added when reading from an ixmp4 platform,
+    # should not be written to the platform
     if "version" in df.meta.columns:
         logger.warning(
-            "The `meta.version` column will be dropped when writing to the ixmp4 database."
+            "The `meta.version` column was dropped when writing to the ixmp4 platform."
         )
         meta = df.meta.drop(columns="version")
     else:

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -54,7 +54,7 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
         The IamDataFrame instance with scenario data
     """
     if df.time_domain != "year":
-        raise NotImplementedError("Only time_domain='year' is supported for now")
+        raise NotImplementedError("Only time_domain='year' is supported for now.")
 
     if not isinstance(platform, ixmp4.Platform):
         platform = ixmp4.Platform(platform)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,7 +265,7 @@ def plot_stackplot_df():
     yield df
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def test_platform():
     platform = Platform(_backend=SqliteTestBackend())
     platform.regions.create(name="World", hierarchy="common")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from httpx import ConnectError
+from ixmp4.core import Platform
+from ixmp4.data.backend import SqliteTestBackend
 
 from pyam import IamDataFrame, iiasa
 from pyam.utils import IAMC_IDX, META_IDX
@@ -261,6 +263,14 @@ def recursive_df(request):
 def plot_stackplot_df():
     df = IamDataFrame(TEST_STACKPLOT_DF)
     yield df
+
+
+@pytest.fixture(scope="session")
+def test_platform():
+    platform = Platform(_backend=SqliteTestBackend())
+    platform.regions.create(name="World", hierarchy="common")
+    platform.units.create(name="EJ/yr")
+    yield platform
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -59,7 +59,7 @@ def test_ixmp4_reserved_columns(test_platform, test_df_year, drop_meta):
     """Make sure that a 'version' column in `meta` is not written to the platform"""
 
     if drop_meta:
-        test_df_year = pyam.IamDataFrame(test_df_year.data, index=test_df_year.index)
+        test_df_year = pyam.IamDataFrame(test_df_year.data)
 
     # test writing to platform with a version-number as meta indicator
     test_df_year.set_meta(1, "version")  # add version number added from ixmp4

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -54,11 +54,18 @@ def test_ixmp4_integration(test_platform, test_df_year):
     pyam.assert_iamframe_equal(exp, obs)
 
 
-def test_ixmp4_reserved_columns(test_platform, test_df_year):
+@pytest.mark.parametrize("drop_meta", (True, False))
+def test_ixmp4_reserved_columns(test_platform, test_df_year, drop_meta):
     """Make sure that a 'version' column in `meta` is not written to the platform"""
+
+    if drop_meta:
+        test_df_year = pyam.IamDataFrame(test_df_year.data, index=test_df_year.index)
 
     # test writing to platform with a version-number as meta indicator
     test_df_year.set_meta(1, "version")  # add version number added from ixmp4
     test_df_year.to_ixmp4(platform=test_platform)
 
-    assert "version" not in test_platform.runs.get("model_a", "scen_a").meta
+    if drop_meta:
+        assert test_platform.runs.get("model_a", "scen_a").meta.empty
+    else:
+        assert "version" not in test_platform.runs.get("model_a", "scen_a").meta

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -15,7 +15,7 @@ def test_to_ixmp4_missing_region_raises(test_platform, test_df_year):
 
 def test_to_ixmp4_missing_unit_raises(test_platform, test_df_year):
     """Writing to platform raises if unit not defined"""
-    test_df_year.rename(region={"EJ/yr": "foo"}, inplace=True)
+    test_df_year.rename(unit={"EJ/yr": "foo"}, inplace=True)
     with pytest.raises(UnitModel.NotFound, match="foo. Use `Platform.units."):
         test_df_year.to_ixmp4(platform=test_platform)
 

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -62,3 +62,16 @@ def test_ixmp4_integration(test_df_year):
     meta["version"] = 1
     exp = pyam.IamDataFrame(data, meta=meta, index=["model", "scenario", "version"])
     pyam.assert_iamframe_equal(exp, obs)
+
+
+def test_ixmp4_reserved_columns(test_df_year):
+    """Make sure that the `version` column is not written to the platform"""
+    platform = Platform(_backend=SqliteTestBackend())
+    platform.regions.create(name="World", hierarchy="common")
+    platform.units.create(name="EJ/yr")
+
+    # test writing to platform
+    test_df_year.set_meta(1, "version")  # add version number added from ixmp4
+    test_df_year.to_ixmp4(platform=platform)
+
+    assert "version" not in platform.runs.get("model_a", "scen_a").meta

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -66,6 +66,6 @@ def test_ixmp4_reserved_columns(test_platform, test_df_year, drop_meta):
     test_df_year.to_ixmp4(platform=test_platform)
 
     if drop_meta:
-        assert test_platform.runs.get("model_a", "scen_a").meta.empty
+        assert len(test_platform.runs.get("model_a", "scen_a").meta) == 0
     else:
         assert "version" not in test_platform.runs.get("model_a", "scen_a").meta

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -1,61 +1,51 @@
 import pytest
-from ixmp4.core import Platform
 from ixmp4.core.region import RegionModel
 from ixmp4.core.unit import UnitModel
-from ixmp4.data.backend import SqliteTestBackend
 
 import pyam
 from pyam import read_ixmp4
 
 
-def test_to_ixmp4_missing_region_raises(test_df_year):
+def test_to_ixmp4_missing_region_raises(test_platform, test_df_year):
     """Writing to platform raises if region not defined"""
-    platform = Platform(_backend=SqliteTestBackend())
-    with pytest.raises(RegionModel.NotFound, match="World. Use `Platform.regions."):
-        test_df_year.to_ixmp4(platform=platform)
+    test_df_year.rename(region={"World": "foo"})
+    with pytest.raises(RegionModel.NotFound, match="foo. Use `Platform.regions."):
+        test_df_year.to_ixmp4(platform=test_platform)
 
 
-def test_to_ixmp4_missing_unit_raises(test_df_year):
+def test_to_ixmp4_missing_unit_raises(test_platform, test_df_year):
     """Writing to platform raises if unit not defined"""
-    platform = Platform(_backend=SqliteTestBackend())
-    platform.regions.create(name="World", hierarchy="common")
-    with pytest.raises(UnitModel.NotFound, match="EJ/yr. Use `Platform.units."):
-        test_df_year.to_ixmp4(platform=platform)
+    test_df_year.rename(region={"EJ/yr": "foo"})
+    with pytest.raises(UnitModel.NotFound, match="foo. Use `Platform.units."):
+        test_df_year.to_ixmp4(platform=test_platform)
 
 
-def test_ixmp4_time_not_implemented(test_df):
+def test_ixmp4_time_not_implemented(test_platform, test_df):
     """Writing an IamDataFrame with datetime-data is not implemented"""
-    platform = Platform(_backend=SqliteTestBackend())
-    platform.regions.create(name="World", hierarchy="common")
-    platform.units.create(name="EJ/yr")
-
     if test_df.time_domain != "year":
         with pytest.raises(NotImplementedError):
-            test_df.to_ixmp4(platform=platform)
+            test_df.to_ixmp4(platform=test_platform)
 
 
-def test_ixmp4_integration(test_df_year):
+def test_ixmp4_integration(test_platform, test_df_year):
     """Write an IamDataFrame to the platform"""
-    platform = Platform(_backend=SqliteTestBackend())
-    platform.regions.create(name="World", hierarchy="common")
-    platform.units.create(name="EJ/yr")
 
     # test writing to platform
-    test_df_year.to_ixmp4(platform=platform)
+    test_df_year.to_ixmp4(platform=test_platform)
 
     # read only default scenarios (runs) - version number added as meta indicator
-    obs = read_ixmp4(platform=platform)
+    obs = read_ixmp4(platform=test_platform)
     exp = test_df_year.copy()
     exp.set_meta(1, "version")  # add version number added from ixmp4
     pyam.assert_iamframe_equal(exp, obs)
 
     # make one scenario a non-default scenario, make sure that it is not included
-    platform.runs.get("model_a", "scen_b").unset_as_default()
-    obs = read_ixmp4(platform=platform)
+    test_platform.runs.get("model_a", "scen_b").unset_as_default()
+    obs = read_ixmp4(platform=test_platform)
     pyam.assert_iamframe_equal(exp.filter(scenario="scen_a"), obs)
 
     # read all scenarios (runs) - version number used as additional index dimension
-    obs = read_ixmp4(platform=platform, default_only=False)
+    obs = read_ixmp4(platform=test_platform, default_only=False)
     data = test_df_year.data
     data["version"] = 1
     meta = test_df_year.meta.reset_index()
@@ -64,14 +54,11 @@ def test_ixmp4_integration(test_df_year):
     pyam.assert_iamframe_equal(exp, obs)
 
 
-def test_ixmp4_reserved_columns(test_df_year):
+def test_ixmp4_reserved_columns(test_platform, test_df_year):
     """Make sure that the `version` column is not written to the platform"""
-    platform = Platform(_backend=SqliteTestBackend())
-    platform.regions.create(name="World", hierarchy="common")
-    platform.units.create(name="EJ/yr")
 
-    # test writing to platform
+    # test writing to platform with a version-number as meta indicator
     test_df_year.set_meta(1, "version")  # add version number added from ixmp4
-    test_df_year.to_ixmp4(platform=platform)
+    test_df_year.to_ixmp4(platform=test_platform)
 
-    assert "version" not in platform.runs.get("model_a", "scen_a").meta
+    assert "version" not in test_platform.runs.get("model_a", "scen_a").meta

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -49,6 +49,11 @@ def test_ixmp4_integration(test_df_year):
     exp.set_meta(1, "version")  # add version number added from ixmp4
     pyam.assert_iamframe_equal(exp, obs)
 
+    # make one scenario a non-default scenario, make sure that it is not included
+    platform.runs.get("model_a", "scen_b").unset_as_default()
+    obs = read_ixmp4(platform=platform)
+    pyam.assert_iamframe_equal(exp.filter(scenario="scen_a"), obs)
+
     # read all scenarios (runs) - version number used as additional index dimension
     obs = read_ixmp4(platform=platform, default_only=False)
     data = test_df_year.data

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -8,14 +8,14 @@ from pyam import read_ixmp4
 
 def test_to_ixmp4_missing_region_raises(test_platform, test_df_year):
     """Writing to platform raises if region not defined"""
-    test_df_year.rename(region={"World": "foo"})
+    test_df_year.rename(region={"World": "foo"}, inplace=True)
     with pytest.raises(RegionModel.NotFound, match="foo. Use `Platform.regions."):
         test_df_year.to_ixmp4(platform=test_platform)
 
 
 def test_to_ixmp4_missing_unit_raises(test_platform, test_df_year):
     """Writing to platform raises if unit not defined"""
-    test_df_year.rename(region={"EJ/yr": "foo"})
+    test_df_year.rename(region={"EJ/yr": "foo"}, inplace=True)
     with pytest.raises(UnitModel.NotFound, match="foo. Use `Platform.units."):
         test_df_year.to_ixmp4(platform=test_platform)
 
@@ -55,7 +55,7 @@ def test_ixmp4_integration(test_platform, test_df_year):
 
 
 def test_ixmp4_reserved_columns(test_platform, test_df_year):
-    """Make sure that the `version` column is not written to the platform"""
+    """Make sure that a 'version' column in `meta` is not written to the platform"""
 
     # test writing to platform with a version-number as meta indicator
     test_df_year.set_meta(1, "version")  # add version number added from ixmp4


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR implements a few improvements related to the tests of the ixmp4-integration:

- Add a `test_platform` fixture in conftest
- Add a test for reading default-only runs from ixmp4
- Drop the "version" column from the meta-indicators when writing to an ixmp4 database (to avoid having a version-meta-indicator and a version-attribute of a Run) and add a test
