### PR TITLE
Exclude release notes from ruff

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Next release
+
+- [#xxx](https://github.com/IAMconsortium/pyam/pull/xxx) Description of the PR
+
 # Release v2.2.4
 
 Support filtering by a `measurand` argument with tuples of variable and units

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ requires = ["poetry-core>=1.2.0", "poetry-dynamic-versioning"]
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
+    "RELEASE_NOTES.md",
     ".git",
     ".ipynb_checkpoints",
     ".mypy_cache",


### PR DESCRIPTION
# Description of PR

This PR adds RELEASE_NOTES.md to ruff-ignore and adds a template to the release notes
