### PR TITLE
To access a value by position, use ser.iloc[pos]

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Next release
 
-- [#880](https://github.com/IAMconsortium/pyam/pull/880) To access a value by position, use ser.iloc[pos]
+- [#880](https://github.com/IAMconsortium/pyam/pull/880) Use `pd.Series.iloc[pos]` for forward-compatibility
 - [#877](https://github.com/IAMconsortium/pyam/pull/xxx) Support `engine` and other `pd.ExcelFile` keywords.
 
 # Release v2.2.4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next release
 
+- [#880](https://github.com/IAMconsortium/pyam/pull/880) To access a value by position, use ser.iloc[pos]
 - [#877](https://github.com/IAMconsortium/pyam/pull/xxx) Support `engine` and other `pd.ExcelFile` keywords.
 
 # Release v2.2.4

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -324,7 +324,7 @@ def test_aggregate_region_with_negative_weights(simple_df, caplog):
 
     # dropping negative weights works as expected
     neg_weights_df = simple_df.copy()
-    neg_weights_df._data[18] = -6
+    neg_weights_df._data.iloc[18] = -6
     exp = simple_df.filter(variable=v, region="World", year=2010)
     assert_iamframe_equal(neg_weights_df.aggregate_region(v, weight=w), exp)
 
@@ -338,7 +338,7 @@ def test_aggregate_region_with_negative_weights(simple_df, caplog):
 
     # *not* dropping negative weights works as expected
     exp = simple_df.filter(variable=v, region="World")
-    exp._data[0] = -8
+    exp._data.iloc[0] = -8
     assert_iamframe_equal(
         neg_weights_df.aggregate_region(v, weight=w, drop_negative_weights=False), exp
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -269,7 +269,7 @@ def test_load_meta_exclude(test_pd_df):
     """Initializing from xlsx where 'meta' has an exclude columns (pyam < 2.0)"""
     obs = IamDataFrame(TEST_DATA_DIR / "exclude_meta_sheet.xlsx")
     exp = IamDataFrame(test_pd_df)
-    exp.exclude[0] = True
+    exp.exclude.iloc[0] = True
     assert_iamframe_equal(obs, exp)
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added


# Description of PR

This PR removes the warnings: FutureWarning: 

`Series.__setitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To set a value by position, use ser.iloc[pos] = value`

tests to check:

```
pytest tests/test_feature_aggregate.py::test_aggregate_region_with_negative_weights[None]
pytest tests/test_feature_aggregate.py::test_aggregate_region_with_negative_weights[datetime]
pytest tests/test_io.py::test_load_meta_exclude
```

