### PR TITLE
replacing deprecated in1d, using ravel for scalars

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next release
 
+- [#882](https://github.com/IAMconsortium/pyam/pull/882) Replacing deprecated in1d, using ravel for scalars
 - [#880](https://github.com/IAMconsortium/pyam/pull/880) Use `pd.Series.iloc[pos]` for forward-compatibility
 - [#877](https://github.com/IAMconsortium/pyam/pull/xxx) Support `engine` and other `pd.ExcelFile` keywords.
 

--- a/pyam/plotting.py
+++ b/pyam/plotting.py
@@ -227,7 +227,7 @@ def assign_style_props(df, color=None, marker=None, linestyle=None, cmap=None):
         values = list(d.values())
         # find if any colors in our properties corresponds with special colors
         # we know about
-        overlap_idx = np.in1d(values, list(PYAM_COLORS.keys()))
+        overlap_idx = np.isin(values, list(PYAM_COLORS.keys()))
         if overlap_idx.any():  # some exist in our special set
             keys = np.array(list(d.keys()))[overlap_idx]
             values = np.array(values)[overlap_idx]

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -130,7 +130,7 @@ def cross_threshold(
 
     # it year (as int) is returned, add one because int() rounds down
     if return_type is int:
-        return [y + 1 for y in map(int, years)]
+        return [y + 1 for y in map(int, years.ravel())]
     return years
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added


# Description of PR

Removes the warnings:

```
D:\a\pyam\pyam\pyam\plotting.py:230: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    overlap_idx = np.in1d(values, list(PYAM_COLORS.keys()))

```

<details>

<summary>tests to check isin:</summary>

```
pytest tests/test_plotting.py::test_line_plot_cmap_color_arg
pytest tests/test_plotting.py::test_line_color
pytest tests/test_plotting.py::test_line_PYAM_COLORS
pytest tests/test_plotting.py::test_line_color_fill_between
pytest tests/test_plotting.py::test_line_color_fill_between_interpolate
pytest tests/test_plotting.py::test_line_color_final_ranges
pytest tests/test_plotting.py::test_line_filter_title
pytest tests/test_plotting.py::test_line_update_rc
pytest tests/test_plotting.py::test_scatter_variables_with_meta_color
```

</details>

```

  D:\a\pyam\pyam\pyam\timeseries.py:133: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    return [y + 1 for y in map(int, years)]
```

<details>

<summary>tests to check scalar:</summary>

```
pytest tests/test_timeseries.py::test_cross_treshold
pytest tests/test_timeseries.py::test_cross_treshold_from_below
pytest tests/test_timeseries.py::test_cross_treshold_from_above
```

</details>



1.  `np.in1d  `is replaced by `np.isin`.

2. To get `scalar` values ​​during iteration I made the `years` array flat having applied `ravel()`.
The `years` values ​​have an extra dimension, which is why there is a warning:

```
[[2006.]
 [2010.]]
```