### PR TITLE
Sort columns of `timeseries()` with mixed time domain

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 The next release must be bumped to v3.0.0.
 
+- [#896](https://github.com/IAMconsortium/pyam/pull/896) Sort columns of `timeseries()` with mixed time domain
 - [#893](https://github.com/IAMconsortium/pyam/pull/893) No sorting of timeseries data on initialization or append
 - [#879](https://github.com/IAMconsortium/pyam/pull/879) Add `read_netcdf()` function
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -795,8 +795,8 @@ class IamDataFrame:
         Parameters
         ----------
         iamc_index : bool, optional
-            If True, use `['model', 'scenario', 'region', 'variable', 'unit']`;
-            else, use all 'data' columns.
+            If True, return only IAMC-index `['model', 'scenario', 'region', 'variable',
+            'unit']`; else, use all 'data' columns.
 
         Raises
         ------

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -703,7 +703,7 @@ class IamDataFrame:
         df.columns.name = ret.time_col
         df = df.stack(future_stack=True).dropna()  # wide data to pd.Series
         df.name = "value"
-        ret._data = df.sort_index()
+        ret._data = df
         ret._set_attributes()
 
         if not inplace:
@@ -816,12 +816,10 @@ class IamDataFrame:
                 )
             s = self._data.droplevel(self.extra_cols)
             if s.index.has_duplicates:
-                raise ValueError(
-                    "Dropping non-IAMC-index causes duplicated index."
-                )
+                raise ValueError("Dropping non-IAMC-index causes duplicated index.")
 
         return (
-            s.unstack(level=self.time_col, sort=False)
+            s.unstack(level=self.time_col)
             .rename_axis(None, axis=1)
             .sort_index(
                 axis=1, key=compare_year_time if self.time_domain == "mixed" else None

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -817,7 +817,7 @@ class IamDataFrame:
             s = self._data.droplevel(self.extra_cols)
             if s.index.has_duplicates:
                 raise ValueError(
-                    "Data with IAMC-index has duplicated index, use `iamc_index=False`"
+                    "Dropping non-IAMC-index causes duplicated index."
                 )
 
         return (

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -58,6 +58,7 @@ from pyam.utils import (
     IAMC_IDX,
     ILLEGAL_COLS,
     META_IDX,
+    compare_year_time,
     format_data,
     get_excel_file_with_kwargs,
     is_list_like,
@@ -813,10 +814,18 @@ class IamDataFrame:
                 raise ValueError(
                     "Cannot use `iamc_index=True` with 'datetime' time-domain."
                 )
-            s = s.droplevel(self.extra_cols)
+            s = self._data.droplevel(self.extra_cols)
+            if s.index.has_duplicates:
+                raise ValueError(
+                    "Data with IAMC-index has duplicated index, use `iamc_index=False`"
+                )
 
         return (
-            s.unstack(level=self.time_col).sort_index(axis=1).rename_axis(None, axis=1)
+            s.unstack(level=self.time_col, sort=False)
+            .rename_axis(None, axis=1)
+            .sort_index(
+                axis=1, key=compare_year_time if self.time_domain == "mixed" else None
+            )
         )
 
     def set_meta(self, meta, name=None, index=None):  # noqa: C901

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -4,6 +4,7 @@ import logging
 import re
 import string
 import warnings
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import dateutil
@@ -601,6 +602,16 @@ def print_list(x, n):
             break
 
     return lst + count
+
+
+# utility method to compare years (as integer) and datetime for index-sorting
+compare_year_time = lambda x: pd.Index(
+    [
+        # set year lower than first timestep of that year (2010 < 2010-01-01 00:00)
+        datetime(time, 1, 1, 0, 0, 0) - timedelta(0, 0.01)
+        if isinstance(time, int) else time for time in x
+    ]
+)
 
 
 def to_time(x):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -605,15 +605,14 @@ def print_list(x, n):
 
 
 # utility method to compare years (as integer) and datetime for index-sorting
-compare_year_time = lambda x: pd.Index(
-    [
+def compare_year_time(x):
+    return pd.Index([
         # set year lower than first timestep of that year (2010 < 2010-01-01 00:00)
         datetime(time, 1, 1, 0, 0, 0) - timedelta(0, 0.01)
         if isinstance(time, int)
         else time
         for time in x
-    ]
-)
+    ])
 
 
 def to_time(x):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -609,7 +609,9 @@ compare_year_time = lambda x: pd.Index(
     [
         # set year lower than first timestep of that year (2010 < 2010-01-01 00:00)
         datetime(time, 1, 1, 0, 0, 0) - timedelta(0, 0.01)
-        if isinstance(time, int) else time for time in x
+        if isinstance(time, int)
+        else time
+        for time in x
     ]
 )
 

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -43,7 +43,7 @@ def test_cast_from_value_col_and_args(test_df_year):
         ],
         columns=[
             "scenario",
-            "iso",
+            "node",
             "unit",
             "year",
             "Primary Energy",
@@ -53,7 +53,7 @@ def test_cast_from_value_col_and_args(test_df_year):
     df = IamDataFrame(
         df_with_value_cols,
         model="model_a",
-        region="iso",
+        region="node",
         value=["Primary Energy", "Primary Energy|Coal"],
     )
     pdt.assert_series_equal(df._data, test_df_year._data, check_like=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,12 +130,12 @@ def test_init_df_with_na_scenario(test_pd_df):
 def test_init_df_with_float_cols(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005.0, 2010: 2010.0})
     obs = IamDataFrame(_test_df).timeseries().reset_index()
-    pd.testing.assert_series_equal(obs[2005], test_pd_df[2005])
+    pdt.assert_series_equal(obs[2005], test_pd_df[2005])
 
 
 def test_init_df_from_timeseries(test_df):
     df = IamDataFrame(test_df.timeseries())
-    pd.testing.assert_frame_equal(df.timeseries(), test_df.timeseries())
+    pdt.assert_frame_equal(df.timeseries(), test_df.timeseries())
 
 
 def test_init_df_from_timeseries_unused_levels(test_df):
@@ -164,7 +164,7 @@ def test_init_df_with_extra_col(test_pd_df):
     # check that timeseries data is as expected
     obs = df.timeseries().reset_index()
     exp = tdf[obs.columns]  # get the columns into the right order
-    pd.testing.assert_frame_equal(obs, exp)
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_init_df_with_meta_with_index(test_pd_df):
@@ -172,7 +172,7 @@ def test_init_df_with_meta_with_index(test_pd_df):
     df = IamDataFrame(test_pd_df, meta=META_DF)
 
     # check that scenario not existing in data is removed during initialization
-    pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
+    pdt.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
     assert df.scenario == ["scen_a", "scen_b"]
 
 
@@ -181,7 +181,7 @@ def test_init_df_with_meta_no_index(test_pd_df):
     df = IamDataFrame(test_pd_df, meta=META_DF.reset_index())
 
     # check that scenario not existing in data is removed during initialization
-    pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
+    pdt.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]])
     assert df.scenario == ["scen_a", "scen_b"]
 
 
@@ -200,7 +200,7 @@ def test_init_df_with_meta_key_value(test_pd_df):
     df = IamDataFrame(test_pd_df, meta=meta_df)
 
     # check that scenario not existing in data is removed during initialization
-    pd.testing.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]], check_dtype=False)
+    pdt.assert_frame_equal(df.meta, META_DF.iloc[[0, 1]], check_dtype=False)
     assert df.scenario == ["scen_a", "scen_b"]
 
 
@@ -391,7 +391,7 @@ def test_index(test_df_year):
     exp = pd.MultiIndex.from_arrays(
         [["model_a"] * 2, ["scen_a", "scen_b"]], names=["model", "scenario"]
     )
-    pd.testing.assert_index_equal(test_df_year.index, exp)
+    pdt.assert_index_equal(test_df_year.index, exp)
 
 
 def test_index_attributes(test_df):
@@ -641,7 +641,7 @@ def test_filter_meta_index(test_df):
     exp = pd.MultiIndex(
         levels=[["model_a"], ["scen_b"]], codes=[[0], [0]], names=["model", "scenario"]
     )
-    pd.testing.assert_index_equal(obs, exp)
+    pdt.assert_index_equal(obs, exp)
 
 
 def test_meta_idx(test_df):
@@ -674,7 +674,7 @@ def test_pd_filter_by_meta(test_df):
     exp["boolean"] = True
     exp["integer"] = 0
 
-    pd.testing.assert_frame_equal(obs, exp)
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_pd_filter_by_meta_no_index(test_df):
@@ -690,7 +690,7 @@ def test_pd_filter_by_meta_no_index(test_df):
     exp["boolean"] = True
     exp["int"] = 0
 
-    pd.testing.assert_frame_equal(obs, exp)
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_pd_filter_by_meta_nonmatching_index(test_df):
@@ -703,7 +703,7 @@ def test_pd_filter_by_meta_nonmatching_index(test_df):
     exp = data.iloc[2:3].copy()
     exp["string"] = "b"
 
-    pd.testing.assert_frame_equal(obs, exp)
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_pd_join_by_meta_nonmatching_index(test_df):
@@ -716,7 +716,7 @@ def test_pd_join_by_meta_nonmatching_index(test_df):
     exp = data.copy()
     exp["string"] = [np.nan, np.nan, "b"]
 
-    pd.testing.assert_frame_equal(obs.sort_index(level=1), exp)
+    pdt.assert_frame_equal(obs.sort_index(level=1), exp)
 
 
 def test_normalize(test_df):
@@ -729,7 +729,7 @@ def test_normalize(test_df):
         obs = test_df.normalize(time=datetime.datetime(2005, 6, 17)).data.reset_index(
             drop=True
         )
-    pd.testing.assert_frame_equal(obs, exp)
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_normalize_not_time(test_df):
@@ -750,7 +750,7 @@ def test_offset(test_df, padding):
         obs = test_df.offset(
             time=datetime.datetime(2005, 6, 17), **kwargs
         ).data.reset_index(drop=True)
-    pd.testing.assert_frame_equal(obs, exp)
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_offset_not_time(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,7 +48,7 @@ def test_init_df_with_non_default_index(test_pd_df, index):
     """Casting to IamDataFrame and returning as `timeseries()` yields original frame"""
 
     # set a value to `nan` to check that timeseries columns are ordered correctly
-    test_pd_df.loc[0, test_pd_df.columns[5]] = np.nan
+    test_pd_df.loc[0, 2010] = np.nan
 
     # any number of columns can be set as index
     df = test_pd_df.copy() if index is None else test_pd_df.set_index(index)
@@ -553,7 +553,7 @@ def test_timeseries_long(test_df, unsort):
         exp.columns.name = None
 
     obs = test_df.timeseries()
-    pdt.assert_frame_equal(obs, exp, check_column_type=False)
+    pdt.assert_frame_equal(obs, exp, check_like=True, check_column_type=False)
 
 
 @pytest.mark.parametrize("unsort", [False, True])
@@ -588,11 +588,11 @@ def test_timeseries_time_iamc_raises(test_df_time):
 def test_timeseries_to_iamc_index(test_pd_df, test_df_year):
     """Reducing timeseries() of an IamDataFrame with extra-columns to IAMC-index"""
     test_pd_df["foo"] = "bar"
-    exta_col_df = IamDataFrame(test_pd_df)
-    assert exta_col_df.extra_cols == ["foo"]
+    extra_col_df = IamDataFrame(test_pd_df)
+    assert extra_col_df.extra_cols == ["foo"]
 
     # assert that reducing to IAMC-columns (dropping extra-columns) with timeseries()
-    obs = exta_col_df.timeseries(iamc_index=True)
+    obs = extra_col_df.timeseries(iamc_index=True)
     exp = test_df_year.timeseries()
     pdt.assert_frame_equal(obs, exp)
 
@@ -602,13 +602,14 @@ def test_timeseries_to_iamc_index_duplicated_raises(test_pd_df):
     test_pd_df = pd.concat([test_pd_df, test_pd_df])
     # adding an extra-col creates a unique index
     test_pd_df["foo"] = ["bar", "bar", "bar", "baz", "baz", "baz"]
-    exta_col_df = IamDataFrame(test_pd_df)
-    assert exta_col_df.extra_cols == ["foo"]
+
+    extra_col_df = IamDataFrame(test_pd_df)
+    assert extra_col_df.extra_cols == ["foo"]
 
     # dropping the extra-column by setting `iamc_index=True` creates duplicated index
-    match = "Index contains duplicate entries, cannot reshape"
+    match = "Dropping non-IAMC-index causes duplicated index"
     with pytest.raises(ValueError, match=match):
-        exta_col_df.timeseries(iamc_index=True)
+        extra_col_df.timeseries(iamc_index=True)
 
 
 def test_pivot_table(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
-import datetime
 import logging
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -570,6 +570,18 @@ def test_timeseries_wide(test_pd_df, unsort):
     pdt.assert_frame_equal(obs, exp, check_column_type=False)
 
 
+def test_timeseries_mixed_time_domain(test_pd_df):
+    """Assert that timeseries is shown as expected from mixed time-domain data"""
+    test_pd_df = test_pd_df.rename(columns={2005: "2010-01-01 00:00"})
+    exp = (
+        test_pd_df.set_index(IAMC_IDX)[[2010, "2010-01-01 00:00"]]
+        .rename(columns={"2010-01-01 00:00": datetime(2010, 1, 1, 0, 0)})
+    )
+
+    obs = IamDataFrame(test_pd_df).timeseries()
+    pdt.assert_frame_equal(obs, exp, check_column_type=False)
+
+
 def test_timeseries_empty_raises(test_df_year):
     """Calling `timeseries()` on an empty IamDataFrame raises"""
     _df = test_df_year.filter(model="foo")
@@ -726,7 +738,7 @@ def test_normalize(test_df):
     if "year" in test_df.data:
         obs = test_df.normalize(year=2005).data.reset_index(drop=True)
     else:
-        obs = test_df.normalize(time=datetime.datetime(2005, 6, 17)).data.reset_index(
+        obs = test_df.normalize(time=datetime(2005, 6, 17)).data.reset_index(
             drop=True
         )
     pdt.assert_frame_equal(obs, exp)
@@ -748,7 +760,7 @@ def test_offset(test_df, padding):
         obs = test_df.offset(year=2005, **kwargs).data.reset_index(drop=True)
     else:
         obs = test_df.offset(
-            time=datetime.datetime(2005, 6, 17), **kwargs
+            time=datetime(2005, 6, 17), **kwargs
         ).data.reset_index(drop=True)
     pdt.assert_frame_equal(obs, exp)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -526,8 +526,8 @@ def test_variable_depth_with_list_raises(test_df, filter_name):
 
 
 @pytest.mark.parametrize("unsort", [False, True])
-def test_timeseries(test_df, unsort):
-    """Assert that the timeseries is shown as expected even from unordered data"""
+def test_timeseries_long(test_df, unsort):
+    """Assert that timeseries is shown as expected from (unsorted) long data"""
     exp = TEST_DF.set_index(IAMC_IDX)
 
     if unsort:
@@ -556,12 +556,18 @@ def test_timeseries(test_df, unsort):
     pdt.assert_frame_equal(obs, exp, check_column_type=False)
 
 
-def test_timeseries_wide_unsorted(test_pd_df):
-    """Assert that the timeseries is shown as expected even from unordered data"""
+@pytest.mark.parametrize("unsort", [False, True])
+def test_timeseries_wide(test_pd_df, unsort):
+    """Assert that timeseries is shown as expected from (unsorted) wide data"""
 
     # for some reason, `unstack` behaves differently if columns or rows are not sorted
     exp = test_pd_df.set_index(IAMC_IDX)
-    obs = IamDataFrame(test_pd_df[IAMC_IDX + [2010, 2005]]).timeseries()
+
+    if unsort:
+        obs = IamDataFrame(test_pd_df[IAMC_IDX + [2010, 2005]]
+        ).timeseries()
+    else:
+        obs = IamDataFrame(test_pd_df).timeseries()
     pdt.assert_frame_equal(obs, exp, check_column_type=False)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -564,8 +564,7 @@ def test_timeseries_wide(test_pd_df, unsort):
     exp = test_pd_df.set_index(IAMC_IDX)
 
     if unsort:
-        obs = IamDataFrame(test_pd_df[IAMC_IDX + [2010, 2005]]
-        ).timeseries()
+        obs = IamDataFrame(test_pd_df[IAMC_IDX + [2010, 2005]]).timeseries()
     else:
         obs = IamDataFrame(test_pd_df).timeseries()
     pdt.assert_frame_equal(obs, exp, check_column_type=False)

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -92,18 +92,22 @@ def test_concat(test_df, reverse, iterable):
     if iterable:
         dfs = iter(dfs)
 
-    result = concat(dfs)
+    obs = concat(dfs)
 
     # check that the original object is not updated
     assert test_df.scenario == ["scen_a", "scen_b"]
     assert other.scenario == ["scen_c"]
 
     # assert that merging of meta works as expected
-    pdt.assert_frame_equal(result.meta[EXP_META.columns], EXP_META, check_like=True)
+    pdt.assert_frame_equal(obs.meta, EXP_META, check_like=True)
 
     # assert that appending data works as expected
-    ts = result.timeseries()
-    npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
+    ts = obs.timeseries()
+    print(ts)
+    pdt.assert_frame_equal(
+        ts.iloc[0:1].droplevel("scenario"),
+        ts.iloc[3:].droplevel("scenario")
+    )
 
 
 def test_concat_non_default_index():

--- a/tests/test_feature_append_concat.py
+++ b/tests/test_feature_append_concat.py
@@ -102,11 +102,10 @@ def test_concat(test_df, reverse, iterable):
     pdt.assert_frame_equal(obs.meta, EXP_META, check_like=True)
 
     # assert that appending data works as expected
-    ts = obs.timeseries()
-    print(ts)
+    ts = obs.timeseries().sort_index()
     pdt.assert_frame_equal(
-        ts.iloc[0:1].droplevel("scenario"),
-        ts.iloc[3:].droplevel("scenario")
+        ts.iloc[2:3].droplevel("scenario"),
+        ts.iloc[3:4].droplevel("scenario"),
     )
 
 
@@ -162,9 +161,9 @@ def test_concat_with_pd_dataframe(test_df, reverse):
 
     # merge with only the timeseries `data` DataFrame of `other`
     if reverse:
-        result = concat([other.data, test_df])
+        obs = concat([other.data, test_df])
     else:
-        result = concat([test_df, other.data])
+        obs = concat([test_df, other.data])
 
     # check that the original object is not updated
     assert test_df.scenario == ["scen_a", "scen_b"]
@@ -172,11 +171,14 @@ def test_concat_with_pd_dataframe(test_df, reverse):
     # assert that merging meta from `other` is ignored
     exp_meta = META_DF.copy()
     exp_meta.loc[("model_a", "scen_c"), "number"] = np.nan
-    pdt.assert_frame_equal(result.meta, exp_meta[META_COLS])
+    pdt.assert_frame_equal(obs.meta, exp_meta[META_COLS])
 
     # assert that appending data works as expected
-    ts = result.timeseries()
-    npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
+    ts = obs.timeseries().sort_index()
+    pdt.assert_frame_equal(
+        ts.iloc[2:3].droplevel("scenario"),
+        ts.iloc[3:4].droplevel("scenario"),
+    )
 
 
 def test_concat_all_pd_dataframe(test_df):
@@ -185,11 +187,14 @@ def test_concat_all_pd_dataframe(test_df):
     other = test_df.filter(scenario="scen_b").rename({"scenario": {"scen_b": "scen_c"}})
 
     # merge only the timeseries `data` DataFrame of both items
-    result = concat([test_df.data, other.data])
+    obs = concat([test_df.data, other.data])
 
     # assert that appending data works as expected
-    ts = result.timeseries()
-    npt.assert_array_equal(ts.iloc[2].values, ts.iloc[3].values)
+    ts = obs.timeseries().sort_index()
+    pdt.assert_frame_equal(
+        ts.iloc[2:3].droplevel("scenario"),
+        ts.iloc[3:4].droplevel("scenario"),
+    )
 
 
 @pytest.mark.parametrize("inplace", (True, False))

--- a/tests/test_iiasa.py
+++ b/tests/test_iiasa.py
@@ -375,9 +375,7 @@ def test_lazy_read(tmpdir):
     assert df.model == ["model_a"]
     # This is read from the file, so the filter is not applied.
     df2 = lazy_read_iiasa(tmp_file, TEST_API)
-    assert (
-        df.data.sort_values(by=IAMC_IDX).reset_index(drop=True).equals(df2.data)
-    )
+    assert df.data.sort_values(by=IAMC_IDX).reset_index(drop=True).equals(df2.data)
     # If requesting with an inconsistent filter, get nothing back. Strings and filters
     # work interchangably.
     tmp_file = str(tmp_file)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR ensures that `timeseries()` returns a meaningfully sorted dataframe even for data with mixed time domain.
