### PR TITLE
fix FutureWarning: ChainedAssignmentError

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 The next release must be bumped to v3.0.0.
 
+- [#900](https://github.com/IAMconsortium/pyam/pull/900) fix ChainedAssignmentError, refactoring
 - [#896](https://github.com/IAMconsortium/pyam/pull/896) Add `sort_data()` method
 - [#896](https://github.com/IAMconsortium/pyam/pull/896) Sort columns of `timeseries()` with mixed time domain
 - [#893](https://github.com/IAMconsortium/pyam/pull/893) No sorting of timeseries data on initialization or append

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -139,7 +139,7 @@ def test_line_color_fill_between(plot_df):
 @pytest.mark.mpl_image_compare(**MPL_KWARGS)
 def test_line_color_fill_between_interpolate(plot_df):
     # designed to create the sawtooth behavior at a midpoint with missing data
-    df = pyam.IamDataFrame(plot_df.data.copy())
+    df = plot_df.data.copy()
     fig, ax = plt.subplots(figsize=(8, 8))
     newdata = [
         "test_model1",
@@ -150,7 +150,7 @@ def test_line_color_fill_between_interpolate(plot_df):
         2010,
         3.50,
     ]
-    df.data.loc[len(df.data) - 1] = newdata
+    df.loc[len(df) - 1] = newdata
     newdata = [
         "test_model1",
         "test_scenario1",
@@ -160,7 +160,7 @@ def test_line_color_fill_between_interpolate(plot_df):
         2012,
         3.50,
     ]
-    df.data.loc[len(df.data)] = newdata
+    df.loc[len(df)] = newdata
     newdata = [
         "test_model1",
         "test_scenario1",
@@ -170,7 +170,10 @@ def test_line_color_fill_between_interpolate(plot_df):
         2015,
         3.50,
     ]
-    df.data.loc[len(df.data) + 1] = newdata
+    df.loc[len(df) + 1] = newdata
+    columns_ = ['model', 'scenario', 'region', 'variable', 'unit', 'year']
+    df = df.drop_duplicates(subset=columns_)
+    df = pyam.IamDataFrame(df)
     df.plot(ax=ax, color="model", fill_between=True, legend=True)
     return fig
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -172,7 +172,7 @@ def test_line_color_fill_between_interpolate(plot_df):
     ]
     df.loc[len(df) + 1] = newdata
     columns_ = ['model', 'scenario', 'region', 'variable', 'unit', 'year']
-    df = df.drop_duplicates(subset=columns_)
+    df = df.drop_duplicates(subset=columns_).reset_index(drop=True)
     df = pyam.IamDataFrame(df)
     df.plot(ax=ax, color="model", fill_between=True, legend=True)
     return fig


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR removes the warnings: FutureWarning:
```
FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
  You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
  A typical example is when you are setting values in a column of a DataFrame, like:
  
  df["col"][row_indexer] = value
  
  Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.
```

The code was also refactored taking into account the new pyam (`pyam.IamDataFrame` was not updated).

tests to check: `pytest tests/test_plotting.py::test_line_color_fill_between_interpolate`