### PR TITLE
Implement `run.transact()` for compatibility with ixmp4 v0.11

### DIFF
--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -112,17 +112,18 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df):
 
         run = platform.runs.create(model=model, scenario=scenario)
 
-        if df.time_domain == "year":
-            run.iamc.add(_df.data)
-        elif df.time_domain == "datetime":
-            run.iamc.add(
-                _df.data.rename(columns={"time": "step_datetime"}),
-                type=DataPoint.Type.DATETIME,
-            )
+        with run.transact("Import run"):
+            if df.time_domain == "year":
+                run.iamc.add(_df.data)
+            elif df.time_domain == "datetime":
+                run.iamc.add(
+                    _df.data.rename(columns={"time": "step_datetime"}),
+                    type=DataPoint.Type.DATETIME,
+                )
 
-        if not meta.empty:
-            run.meta = dict(meta.loc[(model, scenario)])
-        run.set_as_default()
+            if not meta.empty:
+                run.meta = dict(meta.loc[(model, scenario)])
+            run.set_as_default()
 
 
 def _validate_dimensions(platform, df):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # Please also add a section "Dependency changes" to the release notes
 dependencies = [
     "iam-units>=2020.4.21",
-    "ixmp4>=0.9.0",
+    "ixmp4>=0.11.1",
     "matplotlib>=3.6.0",
     "numpy>=1.26.0",
     "openpyxl>=3.1.2",
@@ -58,7 +58,7 @@ dynamic = ["version"]
 [tool.poetry]
 documentation = "https://pyam-iamc.readthedocs.io"
 packages = [{ include = "pyam" }]
-requires-poetry = ">=2.0,<3.0" 
+requires-poetry = ">=2.0,<3.0"
 version = "0.0.0"
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Added~
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR adds the `run-transact()` context handling for compatibility with ixmp4 v0.11. I considered adding an if-else depending on the installed ixmp4 version, but given that the IIASA infrastructure will be upgraded to ixmp4 when merging/releasing this new feature, the complication and test-handling doesn't seem worth the extra effort.
