### PR TITLE
Address pandas groupby warning

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Bumped minimum version of **ixmp4** to 0.11.1 for compatbility with versioning a
 
 ## Individual updates
 
+- [#918](https://github.com/IAMconsortium/pyam/pull/918) Address pandas groupby warning
 - [#915](https://github.com/IAMconsortium/pyam/pull/915) Implement `run.transact()` and bump requirements to ixmp4 >0.11
 - [#914](https://github.com/IAMconsortium/pyam/pull/914) Fix dynamic versioning
 - [#912](https://github.com/IAMconsortium/pyam/pull/912) Support writing datetime-domain data to an **ixmp4** platform

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -187,7 +187,7 @@ def _aggregate_time(df, variable, column, value, components, method="sum"):
             df.filter(**filter_args)
             .data.pivot_table(index=index, columns=column)
             .value.rename_axis(None, axis=1)
-            .apply(_get_method_func(method), axis=1)
+            .apply(method, axis=1)
         ],
         names=[column] + index,
         keys=[value],
@@ -206,7 +206,7 @@ def _group_and_agg(df, by, method="sum"):
     """Group-by & aggregate `pd.Series` by index names on `by`"""
     cols = df.index.names.difference(to_list(by))
     # pick aggregator func (default: sum)
-    return df.groupby(cols).agg(_get_method_func(method))
+    return df.groupby(cols).agg(method)
 
 
 def _agg_weight(data, weight, method, drop_negative_weights):

--- a/pyam/aggregation.py
+++ b/pyam/aggregation.py
@@ -8,7 +8,7 @@ from pyam._compare import _compare
 from pyam.index import replace_index_values
 from pyam.logging import adjust_log_level, format_log_message
 from pyam.str import find_depth, is_str, reduce_hierarchy
-from pyam.utils import KNOWN_FUNCS, is_list_like, to_list
+from pyam.utils import is_list_like, to_list
 
 logger = logging.getLogger(__name__)
 
@@ -254,15 +254,3 @@ def _agg_weight(data, weight, method, drop_negative_weights):
     return (data * weight).groupby(col1).apply(
         pd.Series.sum, skipna=False
     ) / weight.groupby(col2).sum()
-
-
-def _get_method_func(method):
-    """Translate a string to a known method"""
-    if not is_str(method):
-        return method
-
-    if method in KNOWN_FUNCS:
-        return KNOWN_FUNCS[method]
-
-    # raise error if `method` is a string but not in dict of known methods
-    raise ValueError(f"Unknown method: {method}")

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -47,14 +47,6 @@ NUMERIC_TO_STR = dict(
     )
 )
 
-KNOWN_FUNCS = {
-    "min": np.min,
-    "max": np.max,
-    "avg": np.mean,
-    "mean": np.mean,
-    "sum": "sum",
-}
-
 
 def to_list(x):
     """Return x as a list"""

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -185,7 +185,7 @@ def test_aggregate_empty(test_df, variable, append, caplog):
 
 def test_aggregate_unknown_method(simple_df):
     """Check that using unknown string as method raises an error"""
-    pytest.raises(ValueError, simple_df.aggregate, "Primary Energy", method="foo")
+    pytest.raises(AttributeError, simple_df.aggregate, "Primary Energy", method="foo")
 
 
 def test_aggregate_components_as_dict(simple_df):
@@ -442,7 +442,7 @@ def test_aggregate_region_empty(test_df, variable, append, caplog):
 def test_aggregate_region_unknown_method(simple_df):
     # using unknown string as method raises an error
     v = "Emissions|CO2"
-    pytest.raises(ValueError, simple_df.aggregate_region, v, method="foo")
+    pytest.raises(AttributeError, simple_df.aggregate_region, v, method="foo")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Tests Added
- [ ] ~~Documentation Added~~
- [x] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

Closes #917. 
Since pandas supports directly referencing the groupby apply function by string and the current way we're doing it will be deprecated, this PR directly uses the `method` input. It removes no longer used code and adjusts two tests since an unknown aggregation function is now handled directly by pyam.