### PR TITLE
Fix the `categorize()` function

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -73,6 +73,7 @@ from pyam.utils import (
     read_file,
     read_pandas,
     remove_from_list,
+    s,
     to_list,
     write_sheet,
 )
@@ -1009,20 +1010,23 @@ class IamDataFrame:
 
         # assign scenarios that satisfy criteria to the category
         if not_valid is None:
-            category_index = self.index
+            cat_index = self.index
         else:
             not_valid_index = not_valid.set_index(self.index.names).index.unique()
             if len(not_valid_index) < len(self.index):
-                category_index = self.index.difference(not_valid_index)
+                cat_index = self.index.difference(not_valid_index)
             else:
-                logger.info("No scenarios satisfy the criteria")
+                logger.info(
+                    f"No scenarios satisfy the criteria for category `{name}: {value}`"
+                )
                 return
 
         # update meta indicators
         self._new_meta_column(name)
-        self.meta.loc[category_index, name] = value
-        msg = "{} scenario{} categorized as `{}: {}`"
-        logger.info(msg.format(len(category_index), "" if len(category_index) == 1 else "s", name, value))
+        self.meta.loc[cat_index, name] = value
+        logger.info(
+            f"{len(cat_index)} scenario{s(cat_index)} categorized as `{name}: {value}`"
+        )
 
     def _new_meta_column(self, name):
         """Add a column to meta if it doesn't exist, set value to nan"""

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -60,6 +60,7 @@ from pyam.utils import (
     IAMC_IDX,
     ILLEGAL_COLS,
     META_IDX,
+    adjust_log_level,
     compare_year_time,
     format_data,
     get_excel_file_with_kwargs,
@@ -999,12 +1000,13 @@ class IamDataFrame:
                 run_control().update({kind: {name: {value: arg}}})
 
         # find all data that satisfies the validation criteria
-        # TODO: if validate returned an empty index, this check would be easier
-        not_valid = self.validate(
-            upper_bound=upper_bound,
-            lower_bound=lower_bound,
-            **kwargs,
-        )
+        with adjust_log_level(logger="pyam.validation", level="ERROR"):
+            not_valid = self.validate(
+                upper_bound=upper_bound,
+                lower_bound=lower_bound,
+                **kwargs,
+            )
+
         # assign scenarios that satisfy criteria to the category
         if not_valid is None:
             category_index = self.index

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1005,21 +1005,22 @@ class IamDataFrame:
             lower_bound=lower_bound,
             **kwargs,
         )
+        # assign scenarios that satisfy criteria to the category
         if not_valid is None:
-            idx = self.index
-        elif len(not_valid) < len(self.index):
-            idx = self.index.difference(
-                not_valid.set_index(["model", "scenario"]).index.unique()
-            )
+            category_index = self.index
         else:
-            logger.info("No scenarios satisfy the criteria")
-            return
+            not_valid_index = not_valid.set_index(self.index.names).index.unique()
+            if len(not_valid_index) < len(self.index):
+                category_index = self.index.difference(not_valid_index)
+            else:
+                logger.info("No scenarios satisfy the criteria")
+                return
 
-        # update meta dataframe
+        # update meta indicators
         self._new_meta_column(name)
-        self.meta.loc[idx, name] = value
+        self.meta.loc[category_index, name] = value
         msg = "{} scenario{} categorized as `{}: {}`"
-        logger.info(msg.format(len(idx), "" if len(idx) == 1 else "s", name, value))
+        logger.info(msg.format(len(category_index), "" if len(category_index) == 1 else "s", name, value))
 
     def _new_meta_column(self, name):
         """Add a column to meta if it doesn't exist, set value to nan"""

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -175,6 +175,13 @@ def test_category_match(test_df):
     }
     exp = pd.DataFrame(dct).set_index(["model", "scenario"])["category"]
 
+    if test_df.time_domain == "year":
+        # make sure scen_b is out of bounds with multiple datapoints
+        # see https://github.com/IAMconsortium/pyam/issues/929
+        test_df._data.loc[
+            ("model_a", "scen_b", "World", "Primary Energy", "EJ/yr", 2005)
+        ] = 6.5
+
     test_df.categorize("category", "foo", variable="Primary Energy", upper_bound=6)
     obs = test_df["category"]
-    pd.testing.assert_series_equal(obs, exp)
+    pdt.assert_series_equal(obs, exp)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

This PR fixes the `categorize()` method when the number of invalid datapoints exceeds the number of scenarios (i.e., when there are more than one datapoint per scenario to be validated in the criteria).

Closes #929
