### PR TITLE
Quickfix for filtering by `measurand` as list with length > 2

### DIFF
--- a/pyam/filter.py
+++ b/pyam/filter.py
@@ -27,12 +27,12 @@ def filter_by_col(data, col, values, regexp, level=None):
 
 
 def filter_by_measurand(data, values, regexp, level=None):
-    variable, unit = values
-    if is_str(variable) and is_str(unit):
+    if len(values) == 2 and is_str(values[0]) and is_str(values[1]):
         return np.logical_and(
-            filter_by_col(data, "variable", variable, regexp, level),
-            filter_by_col(data, "unit", unit, regexp),
+            filter_by_col(data, "variable", values[0], regexp, level),
+            filter_by_col(data, "unit", values[1], regexp),
         )
+
     # values is an iterable of measurands
     keep_col = np.zeros(len(data), dtype=bool)
     for measurand in values:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -492,7 +492,9 @@ def test_filter_measurand_list(test_df):
     data.loc[5, "unit"] = "bar"
     df = IamDataFrame(data)
 
-    obs = df.filter(measurand=(("foo", "EJ/yr"), ("Primary Energy", "bar")))
+    obs = df.filter(
+        measurand=(("foo", "EJ/yr"), ("Primary Energy", "bar"), ("foo", "baz"))
+    )
 
     assert set(obs.variable) == {"Primary Energy", "foo"}
     assert set(obs.unit) == {"EJ/yr", "bar"}


### PR DESCRIPTION
# Description of PR

Quickfix to allow for filtering by measurand where the list of variable-unit-pairs is longer than two.
