### PR TITLE
Support writing mixed time-domain to ixmp4.Platform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+# Next Release
+
+- [#978](https://github.com/IAMconsortium/pyam/pull/978) Support writing mixed time-domain to **ixmp4.Platform**
+- [#952](https://github.com/IAMconsortium/pyam/pull/952) Add an `aggregate_kyoto_gases()` method
+
 # Release v3.3.2
 
 ## Highlights
@@ -24,8 +29,6 @@ instead of printing a list.
 ## Individual updates
 
 - [#970](https://github.com/IAMconsortium/pyam/pull/970) Fixes for ixmp4 v0.15.x
-
-- [#952](https://github.com/IAMconsortium/pyam/pull/952) Add an `aggregate_kyoto_gases()` method
 
 # Release v3.3.0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -6582,4 +6582,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.15"
-content-hash = "29728520d45c9e47d378ef2233a38f3499bed251688b377729c93d620aeb779f"
+content-hash = "447e2cf542a14ed331eeadb62ea73b0636a018dc80f84c6389ca85afa1ef0940"

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2437,7 +2437,7 @@ class IamDataFrame:
         platform: ixmp4.Platform,
         checkpoint_message: str = "Import run from pyam",
     ):
-        """Save all scenarios as new default runs in an ixmp4 platform database instance
+        """Save all scenarios as new default runs in an **ixmp4.Platform**  instance
 
         Parameters
         ----------

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -166,21 +166,13 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
         run = platform.runs.create(model=model, scenario=scenario)
 
         with run.transact(checkpoint_message):
-            if _df.time_domain == "year":
-                run.iamc.add(_df.data.rename(columns={"year": "step_year"}))
-            elif _df.time_domain == "datetime":
-                run.iamc.add(_df.data.rename(columns={"time": "step_datetime"}))
-            elif _df.time_domain == "mixed":
-                run.iamc.add(
-                    _df.filter(time_domain="year").data.rename(
-                        columns={"time": "step_year"}
-                    )
-                )
-                run.iamc.add(
-                    _df.filter(time_domain="datetime").data.rename(
-                        columns={"time": "step_datetime"}
-                    )
-                )
+            if _df.time_domain in ["year", "datetime"]:
+                run.iamc.add(_df.data)
+            # in "mixed" time domain, year and datetime values have to be added
+            # separately for correct column-renaming in ixmp4
+            else:
+                run.iamc.add(_df.filter(time_domain="year").data)
+                run.iamc.add(_df.filter(time_domain="datetime").data)
 
             if not meta.empty:
                 run.meta = dict(meta.loc[(model, scenario)])

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -2,7 +2,6 @@ import logging
 
 import ixmp4
 import pandas as pd
-from ixmp4.core.iamc import DataPoint
 from ixmp4.core.region import Region
 from ixmp4.core.unit import Unit
 from ixmp4.data.iamc.datapoint.filter import FacadeDataPointFilter

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -145,12 +145,6 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
             "Only data with standard IAMC columns can be written to an ixmp4 platform."
         )
 
-    if df.time_domain not in ["year", "datetime"]:
-        raise NotImplementedError(
-            "Only data with time domain 'year' or 'datetime' can be written to an ixmp4"
-            " platform."
-        )
-
     if not isinstance(platform, ixmp4.Platform):
         platform = ixmp4.Platform(platform)
 
@@ -173,12 +167,20 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
         run = platform.runs.create(model=model, scenario=scenario)
 
         with run.transact(checkpoint_message):
-            if df.time_domain == "year":
-                run.iamc.add(_df.data)
-            elif df.time_domain == "datetime":
+            if _df.time_domain == "year":
+                run.iamc.add(_df.data.rename(columns={"year": "step_year"}))
+            elif _df.time_domain == "datetime":
+                run.iamc.add(_df.data.rename(columns={"time": "step_datetime"}))
+            elif _df.time_domain == "mixed":
                 run.iamc.add(
-                    _df.data.rename(columns={"time": "step_datetime"}),
-                    type=DataPoint.Type.DATETIME,
+                    _df.filter(time_domain="year").data.rename(
+                        columns={"time": "step_year"}
+                    )
+                )
+                run.iamc.add(
+                    _df.filter(time_domain="datetime").data.rename(
+                        columns={"time": "step_datetime"}
+                    )
                 )
 
             if not meta.empty:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # Please also add a section "Dependency changes" to the release notes
 dependencies = [
     "iam-units>=2021.8.12",
-    "ixmp4>=0.15.8",
+    "ixmp4>=0.16.1",
     "matplotlib>=3.6.0",
     "numpy>=1.26.0",
     "openpyxl>=3.1.2",

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -34,11 +34,17 @@ def test_ixmp4_subannual_not_implemented(test_platform, test_df_year):
         pyam.IamDataFrame(data).to_ixmp4(platform=test_platform)
 
 
-def test_ixmp4_mixed_time_domain_not_implemented(test_platform, test_df_mixed):
-    """Writing an IamDataFrame with mixed time domain is not implemented"""
+def test_ixmp4_mixed_time_domain(test_platform, test_df_mixed):
+    """Writing an IamDataFrame with mixed time domain to the platform"""
 
-    with pytest.raises(NotImplementedError, match="Only data with time domain 'year'"):
-        test_df_mixed.to_ixmp4(platform=test_platform)
+    # test writing to platform
+    test_df_mixed.to_ixmp4(platform=test_platform)
+
+    # read only default scenarios (runs) - version number added as meta indicator
+    obs = read_ixmp4(platform=test_platform)
+    exp = test_df_mixed.copy()
+    exp.set_meta(1, "version")  # add version number added from ixmp4
+    assert_iamframe_equal(exp, obs)
 
 
 def test_ixmp4_integration(test_platform, test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Use the improved ixmp4 iamc structure to use mixed time-domain when writing to and reading from a Platform.
