### PR TITLE
Support subannual (categorical) data with ixmp4.Platform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Next Release
 
+- [#979](https://github.com/IAMconsortium/pyam/pull/979) Support subannual (categorical) data with **ixmp4.Platform**
 - [#978](https://github.com/IAMconsortium/pyam/pull/978) Support writing mixed time-domain to **ixmp4.Platform**
 - [#952](https://github.com/IAMconsortium/pyam/pull/952) Add an `aggregate_kyoto_gases()` method
 
@@ -45,8 +46,8 @@ instead of printing a list.
 - [#944](https://github.com/IAMconsortium/pyam/pull/944) Refactor to a `format_n()` function for nice log messages
 - [#943](https://github.com/IAMconsortium/pyam/pull/943) Improved handling for division by zero
 - [#941](https://github.com/IAMconsortium/pyam/pull/941) Add a `compute.share()` method
-- [#938](https://github.com/IAMconsortium/pyam/pull/938) Add a function to initialize an IamDataFrame from an **ixmp4.Run**
-- [#950](https://github.com/IAMconsortium/pyam/pull/950) Add a useful error message on empty query result from an **ixmp4.Platform**
+- [#938](https://github.com/IAMconsortium/pyam/pull/938) Initialize an IamDataFrame from an **ixmp4.Run**
+- [#950](https://github.com/IAMconsortium/pyam/pull/950) Add error message on empty query result from **ixmp4.Platform**
 
 # Release v3.2.0
 

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -179,7 +179,11 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
                     if "subannual" in _df_year.extra_cols:
                         # import the yearly vs. subannual-categorical data separately
                         # TODO revise handling of yearly values in mixed time domain
-                        run.iamc.add(_df_year.filter(subannual="").data)
+                        run.iamc.add(
+                            _df_year.filter(subannual="").data.drop(
+                                columns=["subannual"]
+                            )
+                        )
                         run.iamc.add(_df_year.filter(subannual="", keep=False).data)
                         # remove subannual column for type-infering in ixmp4
                         run.iamc.add(

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -182,8 +182,11 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
                         run.iamc.add(_df_year.filter(subannual="").data)
                         run.iamc.add(_df_year.filter(subannual="", keep=False).data)
                         # remove subannual column for type-infering in ixmp4
-                        _df_datetime = _df.filter(time_domain="datetime").data
-                        run.iamc.add(_df_datetime.drop(columns=["subannual"]))
+                        run.iamc.add(
+                            _df.filter(time_domain="datetime").data.drop(
+                                columns=["subannual"]
+                            )
+                        )
                     else:
                         run.iamc.add(_df.filter(time_domain="year").data)
                         run.iamc.add(_df.filter(time_domain="datetime").data)

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -180,11 +180,11 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
                         # import the yearly vs. subannual-categorical data separately
                         # TODO revise handling of yearly values in mixed time domain
                         run.iamc.add(
-                            _df_year.filter(subannual="").data.drop(
+                            _df_year.filter(subannual="*", keep=False).data.drop(
                                 columns=["subannual"]
                             )
                         )
-                        run.iamc.add(_df_year.filter(subannual="", keep=False).data)
+                        run.iamc.add(_df_year.filter(subannual="*").data)
                         # remove subannual column for type-infering in ixmp4
                         run.iamc.add(
                             _df.filter(time_domain="datetime").data.drop(

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -8,6 +8,8 @@ from ixmp4.data.iamc.datapoint.filter import FacadeDataPointFilter
 from ixmp4.data.meta.filter import FacadeRunMetaEntryFilter
 from ixmp4.data.run.filter import FacadeRunFilter
 
+from pyam.utils import adjust_log_level
+
 logger = logging.getLogger(__name__)
 
 
@@ -139,7 +141,7 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
     checkpoint_message : str
         The message for the ixmp4 checkpoint (similar to a commit message).
     """
-    if df.extra_cols:
+    if df.extra_cols and df.extra_cols != ["subannual"]:
         raise NotImplementedError(
             "Only data with standard IAMC columns can be written to an ixmp4 platform."
         )
@@ -157,7 +159,7 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
         )
         meta = df.meta.drop(columns="version")
     else:
-        meta = df.meta.copy()
+        meta = df.meta
 
     # Create runs and add IAMC timeseries data and meta indicators
     for model, scenario in df.index:
@@ -171,8 +173,20 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
             # in "mixed" time domain, year and datetime values have to be added
             # separately for correct column-renaming in ixmp4
             else:
-                run.iamc.add(_df.filter(time_domain="year").data)
-                run.iamc.add(_df.filter(time_domain="datetime").data)
+                # silence the time-to-year column-renaming log message
+                with adjust_log_level():
+                    _df_year = _df.filter(time_domain="year")
+                    if "subannual" in _df_year.extra_cols:
+                        # import the yearly vs. subannual-categorical data separately
+                        # TODO revise handling of yearly values in mixed time domain
+                        run.iamc.add(_df_year.filter(subannual="").data)
+                        run.iamc.add(_df_year.filter(subannual="", keep=False).data)
+                        # remove subannual column for type-infering in ixmp4
+                        _df_datetime = _df.filter(time_domain="datetime").data
+                        run.iamc.add(_df_datetime.drop(columns=["subannual"]))
+                    else:
+                        run.iamc.add(_df.filter(time_domain="year").data)
+                        run.iamc.add(_df.filter(time_domain="datetime").data)
 
             if not meta.empty:
                 run.meta = dict(meta.loc[(model, scenario)])

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -8,7 +8,7 @@ from ixmp4.data.iamc.datapoint.filter import FacadeDataPointFilter
 from ixmp4.data.meta.filter import FacadeRunMetaEntryFilter
 from ixmp4.data.run.filter import FacadeRunFilter
 
-from pyam.utils import adjust_log_level
+from pyam.utils import adjust_log_level, remove_from_list
 
 logger = logging.getLogger(__name__)
 
@@ -141,9 +141,9 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
     checkpoint_message : str
         The message for the ixmp4 checkpoint (similar to a commit message).
     """
-    if df.extra_cols and df.extra_cols != ["subannual"]:
+    if invalid_extra_cols := remove_from_list(df.extra_cols, ["subannual"]):
         raise NotImplementedError(
-            "Only data with standard IAMC columns can be written to an ixmp4 platform."
+            "Invalid extra-columns: " + ", ".join(invalid_extra_cols)
         )
 
     if not isinstance(platform, ixmp4.Platform):

--- a/pyam/ixmp4.py
+++ b/pyam/ixmp4.py
@@ -175,25 +175,8 @@ def write_to_ixmp4(platform: ixmp4.Platform | str, df, checkpoint_message: str):
             else:
                 # silence the time-to-year column-renaming log message
                 with adjust_log_level():
-                    _df_year = _df.filter(time_domain="year")
-                    if "subannual" in _df_year.extra_cols:
-                        # import the yearly vs. subannual-categorical data separately
-                        # TODO revise handling of yearly values in mixed time domain
-                        run.iamc.add(
-                            _df_year.filter(subannual="*", keep=False).data.drop(
-                                columns=["subannual"]
-                            )
-                        )
-                        run.iamc.add(_df_year.filter(subannual="*").data)
-                        # remove subannual column for type-infering in ixmp4
-                        run.iamc.add(
-                            _df.filter(time_domain="datetime").data.drop(
-                                columns=["subannual"]
-                            )
-                        )
-                    else:
-                        run.iamc.add(_df.filter(time_domain="year").data)
-                        run.iamc.add(_df.filter(time_domain="datetime").data)
+                    run.iamc.add(_df.filter(time_domain="year").data)
+                run.iamc.add(_df.filter(time_domain="datetime").data)
 
             if not meta.empty:
                 run.meta = dict(meta.loc[(model, scenario)])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -461,7 +461,9 @@ def format_data(df, index, **kwargs):  # noqa: C901
 def _validate_complete_index(df):
     """Validate that there are no nan's in the (index) columns"""
     # TODO: better handling of subannual=None for datetime time-domain
-    null_cells = df.drop(columns="subannual").isnull()
+    if "subannual" in df.columns:
+        df = df.dropna(subset=["subannual"])
+    null_cells = df.isnull()
     null_rows = null_cells.any(axis=1)
     if null_rows.any():
         null_cols = null_cells.any()

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -460,7 +460,8 @@ def format_data(df, index, **kwargs):  # noqa: C901
 
 def _validate_complete_index(df):
     """Validate that there are no nan's in the (index) columns"""
-    null_cells = df.isnull()
+    # TODO: better handling of subannual=None for datetime time-domain
+    null_cells = df.drop(columns="subannual").isnull()
     null_rows = null_cells.any(axis=1)
     if null_rows.any():
         null_cols = null_cells.any()

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -27,11 +27,11 @@ def test_to_ixmp4_missing_unit_raises(test_platform, test_df_year):
 
 
 def test_ixmp4_extra_cols_not_implemented(test_platform, test_df_year):
-    """Writing an IamDataFrame with extra-columns is not implemented"""
+    """Writing an IamDataFrame with extra-columns (except subannual) not implemented"""
 
     data = test_df_year.data
-    data["extra_column"] = "fof"
-    with pytest.raises(NotImplementedError):
+    data["extra_column"] = "foo"
+    with pytest.raises(NotImplementedError, match="Invalid extra-columns: foo"):
         pyam.IamDataFrame(data).to_ixmp4(platform=test_platform)
 
 

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -25,11 +25,11 @@ def test_to_ixmp4_missing_unit_raises(test_platform, test_df_year):
         test_df_year.to_ixmp4(platform=test_platform)
 
 
-def test_ixmp4_subannual_not_implemented(test_platform, test_df_year):
-    """Writing an IamDataFrame with subannual timeslices is not implemented"""
+def test_ixmp4_extra_cols_not_implemented(test_platform, test_df_year):
+    """Writing an IamDataFrame with extra-columns is not implemented"""
 
     data = test_df_year.data
-    data["subannual"] = "summer-day"
+    data["extra_column"] = "fof"
     with pytest.raises(NotImplementedError):
         pyam.IamDataFrame(data).to_ixmp4(platform=test_platform)
 

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -75,6 +75,11 @@ def test_ixmp4_mixed_time_domain_subannual(test_platform):
     df.set_meta(1, "version")  # add version number added from ixmp4
     assert_iamframe_equal(df, obs)
 
+    # ensure that the correct types are written to the database
+    db_data = test_platform.backend.iamc.datapoints.tabulate()
+    for value, datapoint_type in [(7, "ANNUAL"), (-2, "DATETIME"), (3, "CATEGORICAL")]:
+        assert db_data[db_data.value == value].type.values[0] == datapoint_type
+
 
 def test_ixmp4_integration(test_platform, test_df):
     """Write an IamDataFrame to the platform"""

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -51,7 +51,7 @@ def test_ixmp4_mixed_time_domain(test_platform, test_df_mixed):
 def test_ixmp4_mixed_time_domain_subannual(test_platform):
     TEST_DF = pd.DataFrame(
         [
-            [2005, 7, ""],
+            [2005, 7, None],
             ["2005-10-10", -2, None],
             [2005, 3, "summer-day"],
         ],

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -30,7 +30,7 @@ def test_ixmp4_extra_cols_not_implemented(test_platform, test_df_year):
     """Writing an IamDataFrame with extra-columns (except subannual) not implemented"""
 
     data = test_df_year.data
-    data["extra_column"] = "foo"
+    data["foo"] = "bar"
     with pytest.raises(NotImplementedError, match="Invalid extra-columns: foo"):
         pyam.IamDataFrame(data).to_ixmp4(platform=test_platform)
 

--- a/tests/test_ixmp4.py
+++ b/tests/test_ixmp4.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import ixmp4 as ixmp4_module
+import pandas as pd
 import pytest
 from ixmp4.core.region import Region
 from ixmp4.core.unit import Unit
@@ -45,6 +46,34 @@ def test_ixmp4_mixed_time_domain(test_platform, test_df_mixed):
     exp = test_df_mixed.copy()
     exp.set_meta(1, "version")  # add version number added from ixmp4
     assert_iamframe_equal(exp, obs)
+
+
+def test_ixmp4_mixed_time_domain_subannual(test_platform):
+    TEST_DF = pd.DataFrame(
+        [
+            [2005, 7, ""],
+            ["2005-10-10", -2, None],
+            [2005, 3, "summer-day"],
+        ],
+        columns=["time", "value", "subannual"],
+    )
+
+    df = pyam.IamDataFrame(
+        TEST_DF,
+        model="model_a",
+        scenario="scen_a",
+        region="World",
+        variable="Primary Energy",
+        unit="EJ/yr",
+    )
+
+    # test writing to platform
+    df.to_ixmp4(platform=test_platform)
+
+    # read only default scenarios (runs) - version number added as meta indicator
+    obs = read_ixmp4(platform=test_platform)
+    df.set_meta(1, "version")  # add version number added from ixmp4
+    assert_iamframe_equal(df, obs)
 
 
 def test_ixmp4_integration(test_platform, test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR adds functionality to write and read subannual (categorical) datapoints to an **ixmp4.Platform**.

**pyam** currently translates all "None" to empty strings `''` in the index to allow filtering and avoid some hiccups when plotting. But this may need to be revised. I'm still thinking about this. But beyond the scope of this PR.

@meksor, I had to remove the subannual column before adding to the **Run** because otherwise the automatic type-inference wouldn't work. I think that this is ok, just highlighting in case I'm misunderstanding something or you have a different idea for implementation (or handling this in ixmp4).