### PR TITLE
Refactor implementation of `subannual` timeslices

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Next Release
 
+## API changes
+
+- Change expected behavior of *subannual* column to use `None` for yearly data (instead of 'year')
+- Rename the method `aggregate_time()` to `aggregate_subannual()`
+
+## Individual updates
+
+- [#981](https://github.com/IAMconsortium/pyam/pull/981) Refactor implementation of subannual timeslices
 - [#979](https://github.com/IAMconsortium/pyam/pull/979) Support subannual (categorical) data with **ixmp4.Platform**
 - [#978](https://github.com/IAMconsortium/pyam/pull/978) Support writing mixed time-domain to **ixmp4.Platform**
 - [#952](https://github.com/IAMconsortium/pyam/pull/952) Add an `aggregate_kyoto_gases()` method

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Callable
 
 import ixmp4
 import numpy as np
@@ -31,7 +32,7 @@ from pyam.aggregation import (
     aggregate_data,
 )
 from pyam.compute import IamComputeAccessor
-from pyam.exceptions import format_log_message, raise_data_error
+from pyam.exceptions import format_log_message, raise_data_error, deprecation_warning
 from pyam.filter import (
     datetime_match,
     filter_by_col,
@@ -1701,39 +1702,52 @@ class IamDataFrame:
             _df.index = _df.index.reorder_levels(self.dimensions)
             return _df
 
-    def aggregate_time(
+    def aggregate_time(self, *args, **kwargs):
+        """Aggregate timeseries data by subannual time resolution.
+
+        This  method is deprecated, please use :ref:`aggregate_subannual` instead.
+        """
+        if "column" in kwargs:
+            raise NotImplementedError(
+                "Custom subannual time domain no longer supported."
+            )
+        # TODO: deprecated, remove for release >= 4.1
+        deprecation_warning(
+            "Please use `aggregate_subannual()` instead.", "Method `aggregate_time()`"
+        )
+        return self.aggregate_subannual(*args, **kwargs)
+
+    def aggregate_subannual(
         self,
-        variable,
-        column="subannual",
-        value=None,
-        components=None,
-        method="sum",
-        append=False,
+        variable: str | list[str],
+        *,
+        value: None | str = None,
+        components: None | str | list[str] = None,
+        method: Callable | str = "sum",
+        append: bool = False,
     ):
         """Aggregate timeseries data by subannual time resolution.
 
         Parameters
         ----------
         variable : str or list of str
-            variable(s) to be aggregated
-        column : str, optional
-            the data column to be used as subannual time representation
+            Variable(s) to be aggregated
         value : str, optional
-            the name of the aggregated (subannual) time
+            Name of the aggregated timeslice (default `None` for yearly aggregate)
         components : list of str
-            subannual timeslices to be aggregated; defaults to all subannual
+            Subannual timeslices to be aggregated; defaults to all subannual
             timeslices other than `value`
         method : func or str, optional
-            method to use for aggregation,
+            Method to use for aggregation,
             e.g. :func:`numpy.mean`, :func:`numpy.sum`, 'min', 'max'
         append : bool, optional
-            append the aggregate timeseries to `self` and return None,
+            Append the aggregate timeseries to `self` and return None,
             else return aggregate timeseries as new :class:`IamDataFrame`
         """
         _df = _aggregate_time(
             self,
             variable,
-            column=column,
+            column="subannual",
             value=value,
             components=components,
             method=method,

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1705,7 +1705,7 @@ class IamDataFrame:
         self,
         variable,
         column="subannual",
-        value="year",
+        value=None,
         components=None,
         method="sum",
         append=False,

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2059,6 +2059,12 @@ class IamDataFrame:
 
                 keep_col = datetime_match(self.get_data_column("time"), values)
 
+            elif col == "subannual" and isinstance(values, bool):
+                keep_col = filter_by_col(self._data, "subannual", "*", regexp=False)
+                # if filter is `subannual=False`, keep only where values are `None`
+                if not values:
+                    keep_col = ~keep_col
+
             elif col == "measurand":
                 keep_col = filter_by_measurand(self._data, values, regexp, level)
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2076,7 +2076,7 @@ class IamDataFrame:
             elif col == "subannual" and isinstance(values, bool):
                 keep_col = filter_by_col(self._data, "subannual", "*", regexp=False)
                 # if filter is `subannual=False`, keep only where values are `None`
-                if not values:
+                if values is False:
                     keep_col = ~keep_col
 
             elif col == "measurand":

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -32,7 +32,7 @@ from pyam.aggregation import (
     aggregate_data,
 )
 from pyam.compute import IamComputeAccessor
-from pyam.exceptions import format_log_message, raise_data_error, deprecation_warning
+from pyam.exceptions import deprecation_warning, format_log_message, raise_data_error
 from pyam.filter import (
     datetime_match,
     filter_by_col,

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -14,7 +14,7 @@ import packaging.version
 import pandas as pd
 from pandas.api.types import is_list_like
 
-from pyam.exceptions import raise_data_error, deprecation_warning
+from pyam.exceptions import deprecation_warning, raise_data_error
 from pyam.index import get_index_levels, replace_index_labels
 from pyam.str import concat_with_pipe, escape_regexp, find_depth, is_str
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -14,7 +14,7 @@ import packaging.version
 import pandas as pd
 from pandas.api.types import is_list_like
 
-from pyam.exceptions import raise_data_error
+from pyam.exceptions import raise_data_error, deprecation_warning
 from pyam.index import get_index_levels, replace_index_labels
 from pyam.str import concat_with_pipe, escape_regexp, find_depth, is_str
 
@@ -434,6 +434,16 @@ def format_data(df, index, **kwargs):  # noqa: C901
         # replace missing units by an empty string for user-friendly filtering
         if "unit" in df.columns:
             df = df.assign(unit=df["unit"].fillna(""))
+
+        # guard against legacy "subannual" values
+        if "subannual" in df.columns:
+            if legacy_subannual := [
+                i for i in df["subannual"].unique() if i in ["year", ""]
+            ]:
+                deprecation_warning(
+                    "Please use `None` instead.",
+                    "Using '" + "', '".join(legacy_subannual) + "' as subannual values",
+                )
 
         df, time_col, extra_cols = _format_data_to_series(df, index)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,7 +217,7 @@ def subannual_df():
         return _data
 
     # primary energy is a direct sum across sub-annual timeslices
-    mapping = [("year", 1), ("winter", 0.7), ("summer", 0.3)]
+    mapping = [(None, 1), ("winter", 0.7), ("summer", 0.3)]
     lst = [add_subannual(_df.copy(), name, value) for name, value in mapping]
 
     df = IamDataFrame(model="model_a", scenario="scen_a", data=pd.concat(lst))

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -433,10 +433,18 @@ def test_aggregate_region_unknown_method(simple_df):
         ["Primary Energy", "Primary Energy|Coal"],
     ),
 )
-def test_aggregate_time(subannual_df, variable):
-    # check that `variable` is a a direct sum and matches given total
-    exp = subannual_df.filter(variable=variable, subannual=["year"])
-    assert_iamframe_equal(subannual_df.aggregate_time(variable), exp)
+# checks new (None) vs. legacy ("year") convention for yearly data in "subannual"
+@pytest.mark.parametrize("subannual_year", (None, "year"))
+def test_aggregate_time(subannual_df, variable, subannual_year):
+    # check that `variable` is a direct sum and matches given total
+
+    if subannual_year == "year":
+        subannual_df = IamDataFrame(subannual_df.data.fillna("year"))
+
+    assert_iamframe_equal(
+        subannual_df.filter(variable=variable, subannual=subannual_year or False),
+        subannual_df.aggregate_time(variable, value=subannual_year),
+    )
 
 
 def test_check_internal_consistency(simple_df):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -106,6 +106,12 @@ def test_filter_day(test_df, test_day):
         pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
+def test_filter_subannual_bool(subannual_df):
+    # Check that filtering by `subannual` using bool works as expected
+    assert subannual_df.filter(subannual=True).subannual == ["summer", "winter"]
+    assert subannual_df.filter(subannual=False).subannual == []
+
+
 def test_filter_with_numpy_64_date_vals(test_df):
     dates = test_df[test_df.time_col].unique()
     res_0 = test_df.filter(**{test_df.time_col: dates[0]})

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -106,10 +106,11 @@ def test_filter_day(test_df, test_day):
         pdt.assert_index_equal(obs.time, EXP_DATETIME_INDEX)
 
 
-def test_filter_subannual_bool(subannual_df):
-    # Check that filtering by `subannual` using bool works as expected
+def test_filter_subannual(subannual_df):
+    # Check that filtering by `subannual` using bool and string works as expected
     assert subannual_df.filter(subannual=True).subannual == ["summer", "winter"]
     assert subannual_df.filter(subannual=False).subannual == []
+    assert subannual_df.filter(subannual="summer").subannual == ["summer"]
 
 
 def test_filter_with_numpy_64_date_vals(test_df):


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- ~Documentation Added~
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR follows up on an API change in #980, where the yearly aggregate is now identified as `None` rather than the string `year` in IamDataFrame instances with mixed time domain.

The following changes are implemented specifically:
- a warning when importing data that uses "year" or an empty string in the subannual column (legacy format)
- rename the method `aggregate_time()` to `aggregate_subannual()` for clarity (with deprecation warning)
- add an option
  ```python
  df.filter(subannual=True/False)
  ```
  to easily filter for all timeseries datapoints that are related to subannual categorical time resolution (or the inverse)
- rework the existing test to cover both the legacy and new formulation
