### PR TITLE
Extend `set_meta_from_data()` to apply on different column

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Next Release
+
+- [#98](https://github.com/IAMconsortium/pyam/pull/986) Extend `set_meta_from_data()` to apply on different column
+
 # Release v3.3.3
 
 ## Highlights

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -941,15 +941,15 @@ class IamDataFrame:
         Parameters
         ----------
         name : str
-            Column name of the 'meta' table.
-        method : function, optional
+            Resulting column name in the 'meta' table.
+        method : function or str, optional
             Method for aggregation
             (e.g., :func:`numpy.max <numpy.ndarray.max>`);
             required if downselected data do not yield unique values.
         column : str, optional
             The column from `data` to be used to derive the indicator.
         on : str, optional
-            If given, apply the `method` on this column and use correspind value from
+            If given, apply the `method` on this column and use corresponding value from
             `column` as meta indicator.
         **kwargs
             Passed to :meth:`slice` for downselection of data.

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -935,31 +935,82 @@ class IamDataFrame:
         self._new_meta_column(name)
         self.meta[name] = meta[name].combine_first(self.meta[name])
 
-    def set_meta_from_data(self, name, method=None, column="value", **kwargs):
+    def set_meta_from_data(self, name, method=None, column="value", on=None, **kwargs):
         """Add meta indicators from downselected timeseries data
 
         Parameters
         ----------
         name : str
-            Column name of the 'meta' table
+            Column name of the 'meta' table.
         method : function, optional
             Method for aggregation
             (e.g., :func:`numpy.max <numpy.ndarray.max>`);
-            required if downselected data do not yield unique values
+            required if downselected data do not yield unique values.
         column : str, optional
-            The column from `data` to be used to derive the indicator
+            The column from `data` to be used to derive the indicator.
+        on : str, optional
+            If given, apply the `method` on this column and use correspind value from
+            `column` as meta indicator.
         **kwargs
-            Passed to :meth:`slice` for downselected data
+            Passed to :meth:`slice` for downselection of data.
+
+        Raises
+        ------
+        ValueError
+            If the resulting meta-indicators are not unique for each element
+            of the :attr:`index`.
+
+        Examples
+        --------
+        A simple use case for this method is to compute a meta-indicator for the peak
+        (maximum) temperature from annual temperature timeseries data for each scenario:
+
+        .. code:: python
+
+           df.set_meta_from_data(
+               name="Climate Assessment|Peak Warming [°C]",
+               method="max",
+               variable="Climate Assessment|Surface Temperature",
+           )
+
+        Alternatively, the *method* can be applied on a column *on* and the
+        corresponding value from the *column* is set as meta indicator. This can be
+        used to set the year when peak-temperature is reached as meta-indicator.
+
+        .. code:: python
+
+           df.set_meta_from_data(
+               name="Climate Assessment|Year of Peak Warming",
+               method="max",
+               column="value",
+               on="year",
+               variable="Climate Assessment|Surface Temperature",
+           )
+
         """
-        values = self._data[self.slice(**kwargs)]
-        if method is None and column != "value":
-            values = values.reset_index(column)[column]
-        elif method is not None:
-            if column == "value":
-                values = values.groupby(self.index.names)
-            else:
-                values = values.reset_index(column).groupby(self.index.names)[column]
-            values = values.apply(method)
+        if on is not None:
+
+            def apply_method(x):
+                return x[x[on] == x[on].apply(method)][column].iloc[0]
+
+            values = (
+                self._data[self.slice(**kwargs)]
+                .reset_index([col for col in [column, on] if col != "value"])
+                .groupby(self.index.names)
+                .apply(apply_method)
+            )
+        else:
+            values = self._data[self.slice(**kwargs)]
+            if method is None and column != "value":
+                values = values.reset_index(column)[column]
+            elif method is not None:
+                if column == "value":
+                    values = values.groupby(self.index.names)
+                else:
+                    values = values.reset_index(column).groupby(self.index.names)[
+                        column
+                    ]
+                values = values.apply(method)
         self.set_meta(values, name)
 
     def categorize(

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -990,8 +990,17 @@ class IamDataFrame:
         """
         if on is not None:
 
+            @staticmethod
             def apply_method(x):
-                return x[x[on] == x[on].apply(method)][column].iloc[0]
+                if callable(method):
+                    value = x[x[on] == method(x[on])][column].unique()
+                else:
+                    value = x[x[on] == x[on].apply(method)][column].unique()
+
+                if len(value) > 1:
+                    logger.warning(f"Non-unique result from {method} on column {on}.")
+
+                return value[0]
 
             values = (
                 self._data[self.slice(**kwargs)]

--- a/tests/test_feature_set_meta.py
+++ b/tests/test_feature_set_meta.py
@@ -167,4 +167,4 @@ def test_set_meta_from_data_method_on_other_column(test_df_year, method):
     exp = pd.Series(
         data=["Primary Energy|Coal", "Primary Energy"], index=EXP_IDX, name="foo"
     )
-    pdt.assert_series_equal(test_df_year["foo"], exp)
+    pdt.assert_series_equal(test_df_year.meta["foo"], exp)

--- a/tests/test_feature_set_meta.py
+++ b/tests/test_feature_set_meta.py
@@ -141,7 +141,7 @@ def test_set_meta_from_data_mean(test_df):
     pdt.assert_series_equal(test_df["pe_mean"], exp)
 
 
-def test_set_meta_from_data_method_other_column(test_df):
+def test_set_meta_from_data_method_non_default_column(test_df):
     if "year" in test_df.data.columns:
         col, value = "year", 2010
     else:
@@ -161,7 +161,7 @@ def test_set_meta_from_data_nonunique(test_df):
 
 
 @pytest.mark.parametrize("method", ("min", np.min))
-def test_set_meta_from_data_method_other_column(test_df_year, method):
+def test_set_meta_from_data_method_on_other_column(test_df_year, method):
     # get the variable that has the lowest data value for each scenario
     test_df_year.set_meta_from_data("foo", method=method, column="variable", on="value")
     exp = pd.Series(

--- a/tests/test_feature_set_meta.py
+++ b/tests/test_feature_set_meta.py
@@ -160,8 +160,10 @@ def test_set_meta_from_data_nonunique(test_df):
     )
 
 
-def test_set_meta_from_data_method_other_column(test_df_year):
-    test_df_year.set_meta_from_data("foo", method="min", column="variable", on="value")
+@pytest.mark.parametrize("method", ("min", np.min))
+def test_set_meta_from_data_method_other_column(test_df_year, method):
+    # get the variable that has the lowest data value for each scenario
+    test_df_year.set_meta_from_data("foo", method=method, column="variable", on="value")
     exp = pd.Series(
         data=["Primary Energy|Coal", "Primary Energy"], index=EXP_IDX, name="foo"
     )

--- a/tests/test_feature_set_meta.py
+++ b/tests/test_feature_set_meta.py
@@ -158,3 +158,11 @@ def test_set_meta_from_data_nonunique(test_df):
     pytest.raises(
         ValueError, test_df.set_meta_from_data, "fail", variable="Primary Energy"
     )
+
+
+def test_set_meta_from_data_method_other_column(test_df_year):
+    test_df_year.set_meta_from_data("foo", method="min", column="variable", on="value")
+    exp = pd.Series(
+        data=["Primary Energy|Coal", "Primary Energy"], index=EXP_IDX, name="foo"
+    )
+    pdt.assert_series_equal(test_df_year["foo"], exp)


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

This PR (finally) implements a feature that a user can check where some function applied to a timeseries in `data` holds and use the corresponding value in a different column for the meta value.

I've done this (manually) multiple times for getting the year where peak-warming (i.e., maximum of the temperature timeseries) is reached.

A few items to discuss:
- I chose "on" as argument name for the column *on* which to apply the "method", following the logic of `groupby(by)`... But I'm open to suggestions for alternative argument names
- The resulting meta-value is not necessarily unique, like when the temperature maximum is reached in two years. I (arbitrarily) use the first item and write a warning to the log.
- The implementation of `apply_method()` is very "hands-on", there may be more elegant approaches with lumpy...?
- For whatever reason, `df.groupby()[column].apply("min")` yields a different result from `df.groupby()[column].apply(np.min)` (because the latter evaluates element-wise).

# Example

To set the year where peak-temperature is reached as meta-indicator "Year of Peak Warming":

```python
df.set_meta_from_data(
    name="Year of Peak Warming",
    variable="Climate Assessment|Surface Temperature (GSAT)|Median",
    method="max",
    column="year",
    on="value",
)
```