### PR TITLE
Highlight documentation for derived timeseries

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,7 @@ The following persons contributed to the development of the |pyam| package:
 - Fridolin Glatter `@glatterf42 <https://github.com/glatterf42>`_
 - Linh Ho `@linhho <https://github.com/LinhHo>`
 - Max Wolschlager `@meksor <https://github.com/meksor>`
+- `@JSap0914 <https://github.com/JSap0914>`_
 
 | The core maintenance of the |pyam| package is done by
   the *Scenario Services & Scientific Software* research theme

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# Next Release
+
+## Individual updates
+
+- [#984](https://github.com/IAMconsortium/pyam/issues/984) Highlight documentation
+  for computing derived timeseries data
+
 # Release v3.3.3
 
 ## Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Individual updates
 
-- [#984](https://github.com/IAMconsortium/pyam/issues/984) Highlight documentation
+- [#988](https://github.com/IAMconsortium/pyam/pull/988) Highlight documentation
   for computing derived timeseries data
 
 # Release v3.3.3

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -16,6 +16,15 @@ The source code is available in the folder
 .. _`docs/tutorials`:
    https://github.com/IAMconsortium/pyam/tree/main/docs/tutorials
 
+Computing derived timeseries
+----------------------------
+
+To derive new timeseries from existing data, start with the
+:doc:`algebraic operations tutorial <tutorials/algebraic_operations>`, which
+covers adding, subtracting, multiplying and dividing data. For higher-level
+indicators such as shares, quantiles, growth rates and learning rates, see the
+:doc:`derived timeseries API <api/compute>`.
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added (not applicable for this documentation-only change)
- [x] Documentation Added
- [x] Name of contributors Added to AUTHORS.rst
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

Closes #984.

This adds a prominent entry point for computing derived timeseries to the tutorials overview. It directs readers to the existing algebraic-operations tutorial for arithmetic and to the compute API for higher-level indicators such as shares, quantiles, growth rates, and learning rates.

The documentation was built with Sphinx, and both links were followed in a browser to confirm their rendered destinations.
