### PR TITLE
Add an IamDataFrame.series attribute to get internal `_data`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+# Next release
+
+- [#989](https://github.com/IAMconsortium/pyam/pull/989) Add an `IamDataFrame.series` attribute to get timeseries data
+  as **pd.Series**
+
 # Release v3.3.3
 
 ## Highlights

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -433,6 +433,11 @@ class IamDataFrame:
             return pd.DataFrame([], columns=self.dimensions + ["value"])
         return self._data.reset_index()
 
+    @property
+    def series(self):
+        """Return the timeseries data as an indexed :class:`pandas.Series`"""
+        return self._data
+
     def sort_data(self, inplace=False):
         """Sort timeseries data by index and coordinates
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -436,7 +436,7 @@ class IamDataFrame:
     @property
     def series(self):
         """Return the timeseries data as an indexed :class:`pandas.Series`"""
-        return self._data
+        return self._data.copy()
 
     def sort_data(self, inplace=False):
         """Sort timeseries data by index and coordinates

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -337,7 +337,12 @@ def test_pandas_types(test_df):
     series = test_df.series
     data = test_df.data
 
+    # assert that data and series yield the same result as different types
     pdt.assert_frame_equal(series.reset_index(), data)
+
+    # check that `series` yields a copy and changes to not affect the IamDataFrame
+    series.iloc[0] = -2
+    pdt.assert_frame_equal(test_df.series.reset_index(), data)
 
 
 def test_as_pandas(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -332,6 +332,14 @@ def test_print_empty(test_df_year):
     assert obs == exp
 
 
+def test_pandas_types(test_df):
+
+    series = test_df.series
+    data = test_df.data
+
+    pdt.assert_frame_equal(series.reset_index(), data)
+
+
 def test_as_pandas(test_df):
     # test that `as_pandas()` returns the right columns
     df = test_df.copy()


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

I'm accessing the `_data` object for a lot of computations, but that yields warnings because of access to an internal attribute. So this PR adds a utility method.
