### PR TITLE
Mark `len(df)` as deprecated

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ values 'full range', 'interquartile' or 'central 90%'. The previous boolean argu
 
 ## Individual updates
 
+- [#993](https://github.com/IAMconsortium/pyam/pull/993) Mark `len(df)` as deprecated
 - [#991](https://github.com/IAMconsortium/pyam/pull/991) Support the central 90% as limits in the statistics summary
 - [#989](https://github.com/IAMconsortium/pyam/pull/989) Add an `IamDataFrame.series` attribute to get timeseries data
   as **pd.Series**

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -263,6 +263,12 @@ class IamDataFrame:
             return self.get_data_column(key)
 
     def __len__(self):
+        # TODO deprecate with release v4.0, return `len(df.index)`instead
+        deprecation_warning(
+            "Use `len(df.series)` instead. In the future, "
+            "`len(df)` will return `len(df.index)`.",
+            "The method `len()`",
+        )
         return len(self._data)
 
     def __repr__(self):
@@ -2005,7 +2011,7 @@ class IamDataFrame:
             but accepts `regexp: True` in the dictionary to use regexp directly
         """
         regexp = filters.pop("regexp", False)
-        keep = np.ones(len(self), dtype=bool)
+        keep = np.ones(len(self._data), dtype=bool)
 
         if level is not None and depth is not None:
             raise ValueError("Filter by `level` and `depth` not supported")
@@ -2059,7 +2065,7 @@ class IamDataFrame:
             elif col == "time_domain":
                 # fast-pass if `self` already has selected time-domain
                 if self.time_domain == values:
-                    keep_col = np.ones(len(self), dtype=bool)
+                    keep_col = np.ones(len(self._data), dtype=bool)
                 else:
                     levels, codes = get_index_levels_codes(self._data, self.time_col)
                     keep_col = filter_by_time_domain(values, levels, codes)
@@ -2071,14 +2077,14 @@ class IamDataFrame:
             elif col in ["month", "hour", "day"]:
                 if self.time_col != "time":
                     logger.error(f"Filter by `{col}` not supported with yearly data.")
-                    return np.zeros(len(self), dtype=bool)
+                    return np.zeros(len(self._data), dtype=bool)
 
                 keep_col = filter_by_dt_arg(col, values, self.get_data_column("time"))
 
             elif col == "time":
                 if self.time_col != "time":
                     logger.error(f"Filter by `{col}` not supported with yearly data.")
-                    return np.zeros(len(self), dtype=bool)
+                    return np.zeros(len(self._data), dtype=bool)
 
                 keep_col = datetime_match(self.get_data_column("time"), values)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -460,7 +460,7 @@ def test_filter_empty_df():
     # test for issue seen in #254
     df = IamDataFrame(data=df_empty)
     obs = df.filter(variable="foo")
-    assert len(obs) == 0
+    assert len(obs.series) == 0
 
 
 def test_filter_variable_and_measurand_raises(test_df):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -362,7 +362,7 @@ def test_barplot_stacked_net_line(plot_df):
             y,
             v,
         ]
-        df.data.loc[len(df) + i] = newdata
+        df.data.loc[len(df.series) + i] = newdata
     df.filter(
         variable="Primary Energy|*",
         model="test_model1",


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- ~Tests Addedn 
- [x] Documentation Added
- ~Name of contributors Added to AUTHORS.rst~
- [x] Description in RELEASE_NOTES.md Added

# Description of PR

To avoid confusion whether this refers to the number of scenarios or the number datapoints, `len(df)` is marked as deprecated.
